### PR TITLE
Initial `checkXcmTxInputs` implementation

### DIFF
--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -1,0 +1,13 @@
+import { IDirection } from '../types';
+import { checkXcmTxInputs } from './checkXcmTxInputs';
+
+describe('checkXcmTxinputs', () => {
+	it("Should error when inputted assetId's dont match amounts length", () => {
+		const err = () =>
+			checkXcmTxInputs(['1000'], ['10', '10'], IDirection.SystemToPara);
+
+		expect(err).toThrow(
+			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.'
+		);
+	});
+});

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -1,0 +1,28 @@
+import type { IDirection } from '../types';
+import { BaseError } from './BaseError';
+
+/**
+ * This will check the given inputs and ensure there is no issues when constructing
+ * the xcm transaction.
+ *
+ * TODO: This should be expanded upon and inputs may be added. This is just a base implementation.
+ *
+ * @param assetIds
+ * @param amounts
+ * @param xcmDirection
+ */
+export const checkXcmTxInputs = (
+	assetIds: string[],
+	amounts: string[],
+	xcmDirection: IDirection
+) => {
+	const isRelayDirection = xcmDirection.toLowerCase().includes('relay');
+	/**
+	 * Lengths should match, and indicies between both the amounts and assetIds should match.
+	 */
+	if (assetIds.length !== amounts.length && !isRelayDirection) {
+		throw new BaseError(
+			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.'
+		);
+	}
+};

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -2,4 +2,5 @@
 
 export { BaseError } from './BaseError';
 export { checkLocalTxInput } from './checkLocalTxInputs';
+export { checkXcmTxInputs } from './checkXcmTxInputs';
 export { checkXcmVersion } from './checkXcmVersion';


### PR DESCRIPTION
This is the initial implementation of the `checkXcmTxInputs` function that parses the inputs and checks for any errors. All layers of the errors should be in here. 