### PR TITLE
check integer asset ids are valid system

### DIFF
--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -239,5 +239,5 @@ describe('checkAssetIds', () => {
 				);
 			expect(err).toThrow(errorMessage);
 		}
-	})
+	});
 });

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -7,7 +7,7 @@ describe('checkXcmTxinputs', () => {
 	it("Should error when inputted assetId's dont match amounts length", () => {
 		const err = () =>
 			checkXcmTxInputs(
-				['1000'],
+				['1'],
 				['10', '10'],
 				IDirection.SystemToPara,
 				'0',
@@ -49,21 +49,21 @@ describe('checkAssetIds', () => {
 
 		const tests: Test[] = [
 			[
-				'0',
-				'Polkadot',
-				['DOT', 'hello', '2', 'DOT'],
+				'1000',
+				'Statemint',
+				['1', '2', '3', 'hello'],
 				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: hello`,
 			],
 			[
 				'2004',
 				'Moonbeam',
-				['1', 'two', 'GLMR'],
+				['two', 'GLMR'],
 				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: two`,
 			],
 			[
 				'2030',
 				'Bifrost_Polkadot',
-				['BNCC', '1', '2', '3', '4'],
+				['BNCC'],
 				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: BNCC`,
 			],
 			[
@@ -80,7 +80,13 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry[relayChainName];
 
 			const err = () =>
-				checkAssetIdInput(testInputs, currentRegistry, specName, destChainId);
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					IDirection.SystemToPara
+				);
 			expect(err).toThrow(errorMessage);
 		}
 	});
@@ -92,13 +98,13 @@ describe('checkAssetIds', () => {
 			[
 				'2006',
 				'Astar',
-				['1', '2', '3', 'ASTR', 'DOT'],
+				['ASTR', 'DOT'],
 				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: DOT`,
 			],
 			[
 				'2004',
 				'Moonbeam',
-				['1', '2', '3', 'GLMR', 'BNC'],
+				['GLMR', 'BNC'],
 				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: BNC`,
 			],
 			[
@@ -115,7 +121,13 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry[relayChainName];
 
 			const err = () =>
-				checkAssetIdInput(testInputs, currentRegistry, specName, destChainId);
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					IDirection.SystemToPara
+				);
 			expect(err).toThrow(errorMessage);
 		}
 	});
@@ -127,13 +139,13 @@ describe('checkAssetIds', () => {
 			[
 				'2006',
 				'Polkadot',
-				['1', '2', '3', 'ASTR', 'DOT'],
+				['ASTR', 'DOT'],
 				`non matching chains. Received: polkadot. Expected: astar`,
 			],
 			[
 				'2004',
 				'Bifrost_Polkadot',
-				['1', '2', '3', 'GLMR'],
+				['GLMR'],
 				`non matching chains. Received: bifrost_polkadot. Expected: moonbeam`,
 			],
 			[
@@ -150,8 +162,82 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry[relayChainName];
 
 			const err = () =>
-				checkAssetIdInput(testInputs, currentRegistry, specName, destChainId);
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					IDirection.SystemToPara
+				);
 			expect(err).toThrow(errorMessage);
 		}
 	});
+	it('Should error when the given integer asset id is not found in system parachain asset ids', () => {
+		const registry = parseRegistry({});
+
+		const tests: Test[] = [
+			[
+				'1000',
+				'Statemine',
+				['11250986484', 'KSM'],
+				`assetId 11250986484 not found in Statemine`,
+			],
+			[
+				'1000',
+				'Statemint',
+				['28250986484', 'DOT'],
+				`assetId 28250986484 not found in Statemint`,
+			],
+		];
+
+		for (const test of tests) {
+			const [destChainId, specName, testInputs, errorMessage] = test;
+			const relayChainName = findRelayChain(specName, registry);
+			const currentRegistry = registry[relayChainName];
+
+			const err = () =>
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					IDirection.SystemToPara
+				);
+			expect(err).toThrow(errorMessage);
+		}
+	});
+	it('Should error when integer assetId is found for non system parachain origin', () => {
+		const registry = parseRegistry({});
+
+		const tests: Test[] = [
+			[
+				'2004',
+				'Moonbeam',
+				['2', 'GLMR'],
+				`integer assetId's can only be used for transfers from system parachains. Expected a valid token symbol. Got 2`,
+			],
+			[
+				'2012',
+				'Parallel',
+				['1', 'PARA'],
+				`integer assetId's can only be used for transfers from system parachains. Expected a valid token symbol. Got 1`,
+			],
+		];
+
+		for (const test of tests) {
+			const [destChainId, specName, testInputs, errorMessage] = test;
+			const relayChainName = findRelayChain(specName, registry);
+			const currentRegistry = registry[relayChainName];
+
+			const err = () =>
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					IDirection.ParaToPara
+				);
+			expect(err).toThrow(errorMessage);
+		}
+	})
 });

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -16,14 +16,40 @@ export const checkAssetIdInput = (
 	assetIds: string[],
 	relayChainInfo: ChainInfo,
 	specName: string,
-	destChainId: string
+	destChainId: string,
+	xcmDirection: IDirection
 ) => {
 	for (let i = 0; i < assetIds.length; i++) {
 		const assetId = assetIds[i];
 		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const notValidNumber = Number.isNaN(parsedAssetIdAsNumber);
+		const invalidNumber = Number.isNaN(parsedAssetIdAsNumber);
 
-		if (notValidNumber) {
+		// check that the specific assetId exists for the destChain
+		if (!invalidNumber) {
+			if (xcmDirection.toLowerCase().startsWith('system')) {
+				const systemParachainId = 1000;
+				const chainInfo = relayChainInfo[systemParachainId];
+				let isValidAssetId = false;
+
+				for (const id of chainInfo.assetIds) {
+					if (id === parsedAssetIdAsNumber) {
+						isValidAssetId = true;
+						break;
+					}
+				}
+
+				if (!isValidAssetId) {
+					throw new BaseError(`assetId ${assetId} not found in ${specName}`);
+				}
+			} else {
+				// if the asset id is a valid number and the chain isn't a system parachain throw an error
+				throw new BaseError(
+					`integer assetId's can only be used for transfers from system parachains. Expected a valid token symbol. Got ${parsedAssetIdAsNumber}`
+				);
+			}
+		}
+
+		if (invalidNumber) {
 			let isValidTokenSymbol = false;
 			const chainInfo = relayChainInfo[destChainId];
 
@@ -82,7 +108,13 @@ export const checkXcmTxInputs = (
 	/**
 	 * Checks to ensure that assetId's are either valid integer numbers or native asset token symbols
 	 */
-	checkAssetIdInput(assetIds, relayChainInfo, specName, destChainId);
+	checkAssetIdInput(
+		assetIds,
+		relayChainInfo,
+		specName,
+		destChainId,
+		xcmDirection
+	);
 
 	const isRelayDirection = xcmDirection.toLowerCase().includes('relay');
 	/**

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -1,8 +1,8 @@
+import { SYSTEM_PARACHAINS_IDS } from '../consts';
 import { findRelayChain } from '../registry/findRelayChain';
 import type { ChainInfo, ChainInfoRegistry } from '../registry/types';
 import type { IDirection } from '../types';
 import { BaseError } from './BaseError';
-import { SYSTEM_PARACHAINS_IDS } from '../consts'
 
 /**
  * This will check the given assetIds and ensure they are either valid integers as strings

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -2,6 +2,7 @@ import { findRelayChain } from '../registry/findRelayChain';
 import type { ChainInfo, ChainInfoRegistry } from '../registry/types';
 import type { IDirection } from '../types';
 import { BaseError } from './BaseError';
+import { SYSTEM_PARACHAINS_IDS } from '../consts'
 
 /**
  * This will check the given assetIds and ensure they are either valid integers as strings
@@ -27,7 +28,7 @@ export const checkAssetIdInput = (
 		// check that the specific assetId exists for the destChain
 		if (!invalidNumber) {
 			if (xcmDirection.toLowerCase().startsWith('system')) {
-				const systemParachainId = 1000;
+				const systemParachainId = SYSTEM_PARACHAINS_IDS[0];
 				const chainInfo = relayChainInfo[systemParachainId];
 				let isValidAssetId = false;
 


### PR DESCRIPTION
* adds check to ensure integer asset id inputs exist on each respective system parachain
* adds  test for system to para
* adds test for para to para

closes [#128](https://github.com/paritytech/asset-transfer-api/issues/128)