### PR TITLE
make xcm input validation direction based

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "@polkadot/api": "^10.5.1",
-    "@substrate/asset-transfer-api-registry": "0.1.0"
+    "@substrate/asset-transfer-api-registry": "0.2.0"
   }
 }

--- a/src/AssetsTransferApi.spec.ts
+++ b/src/AssetsTransferApi.spec.ts
@@ -401,7 +401,7 @@ describe('AssetTransferAPI', () => {
 				polkadot: {
 					'9876': {
 						tokens: ['TST'],
-						assetIds: [],
+						assetsInfo: {},
 						specName: 'testing',
 					},
 				},

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,15 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 /**
+ * List of all known relay chains.
+ */
+export const RELAY_CHAIN_NAMES = ['kusama', 'polkadot', 'westend'];
+/**
+ * As of now all the known relay chains have an ID of 0.
+ */
+export const RELAY_CHAIN_IDS = ['0'];
+
+/**
  * List of all known system parachains.
  */
 export const SYSTEM_PARACHAINS_NAMES = ['statemine', 'statemint', 'westmint'];

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -45,7 +45,7 @@ type Test = [
 ];
 
 describe('checkAssetIds', () => {
-	it('Should error when direction is RelayToSystem and an assetId is found that is empty or a blank space', () => {
+	it('Should error when an assetId is found that is empty or a blank space', () => {
 		const registry = parseRegistry({});
 
 		const tests: Test[] = [
@@ -57,10 +57,10 @@ describe('checkAssetIds', () => {
 				`assetId cannot be blank spaces or empty. Found empty string`,
 			],
 			[
-				'1000',
+				'0',
 				'Statemine',
-				[' ', 'DOT'],
-				Direction.RelayToSystem,
+				[' ', 'KSM'],
+				Direction.SystemToRelay,
 				`assetId cannot be blank spaces or empty. Found blank space`,
 			],
 		];
@@ -69,8 +69,6 @@ describe('checkAssetIds', () => {
 			const [destChainId, specName, testInputs, direction, errorMessage] = test;
 			const relayChainName = findRelayChain(specName, registry);
 			const currentRegistry = registry[relayChainName];
-
-			console.log('current registry', currentRegistry);
 
 			const err = () =>
 				checkAssetIdInput(

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -40,158 +40,79 @@ type Test = [
 	destChainId: string,
 	specName: string,
 	inputs: string[],
+	xcmDirection: Direction,
 	errorMessage: string
 ];
 
 describe('checkAssetIds', () => {
-	it("Should error when inputted assetId's are not valid integer numbers or valid token symbols", () => {
+	it('Should error when direction is RelayToSystem and an assetId is found that is empty or a blank space', () => {
 		const registry = parseRegistry({});
 
 		const tests: Test[] = [
 			[
 				'1000',
 				'Statemint',
-				['1', '2', '3', 'hello'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: hello`,
+				['', 'DOT'],
+				Direction.RelayToSystem,
+				`assetId cannot be blank spaces or empty. Found empty string`,
 			],
-			[
-				'2004',
-				'Moonbeam',
-				['two', 'GLMR'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: two`,
-			],
-			[
-				'2030',
-				'Bifrost_Polkadot',
-				['BNCC'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: BNCC`,
-			],
-			[
-				'2104',
-				'Manta',
-				['', 'MANTA'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: `,
-			],
-		];
-
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					Direction.SystemToPara
-				);
-			expect(err).toThrow(errorMessage);
-		}
-	});
-
-	it("Should error when assetId's includes a foreign chains asset", () => {
-		const registry = parseRegistry({});
-
-		const tests: Test[] = [
-			[
-				'2006',
-				'Astar',
-				['ASTR', 'DOT'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: DOT`,
-			],
-			[
-				'2004',
-				'Moonbeam',
-				['GLMR', 'BNC'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: BNC`,
-			],
-			[
-				'2000',
-				'Acala',
-				['ACA', 'GLMR'],
-				`'assetIds' must be either valid integer numbers or valid chain token symbols. Got: GLMR`,
-			],
-		];
-
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					Direction.SystemToPara
-				);
-			expect(err).toThrow(errorMessage);
-		}
-	});
-
-	it('Should error when the given specName does not match the destChainIds specName', () => {
-		const registry = parseRegistry({});
-
-		const tests: Test[] = [
-			[
-				'2006',
-				'Polkadot',
-				['ASTR', 'DOT'],
-				`non matching chains. Received: polkadot. Expected: astar`,
-			],
-			[
-				'2004',
-				'Bifrost_Polkadot',
-				['GLMR'],
-				`non matching chains. Received: bifrost_polkadot. Expected: moonbeam`,
-			],
-			[
-				'2000',
-				'Origintrail-Parachain',
-				['ACA'],
-				`non matching chains. Received: origintrail-parachain. Expected: acala`,
-			],
-		];
-
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					Direction.SystemToPara
-				);
-			expect(err).toThrow(errorMessage);
-		}
-	});
-	it('Should error when the given integer asset id is not found in system parachain asset ids', () => {
-		const registry = parseRegistry({});
-
-		const tests: Test[] = [
 			[
 				'1000',
 				'Statemine',
-				['11250986484', 'KSM'],
-				`assetId 11250986484 not found in Statemine`,
-			],
-			[
-				'1000',
-				'Statemint',
-				['28250986484', 'DOT'],
-				`assetId 28250986484 not found in Statemint`,
+				[' ', 'DOT'],
+				Direction.RelayToSystem,
+				`assetId cannot be blank spaces or empty. Found blank space`,
 			],
 		];
 
 		for (const test of tests) {
-			const [destChainId, specName, testInputs, errorMessage] = test;
+			const [destChainId, specName, testInputs, direction, errorMessage] = test;
+			const relayChainName = findRelayChain(specName, registry);
+			const currentRegistry = registry[relayChainName];
+
+			console.log('current registry', currentRegistry);
+
+			const err = () =>
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					direction
+				);
+			expect(err).toThrow(errorMessage);
+		}
+	});
+
+	it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', () => {
+		const registry = parseRegistry({});
+
+		const tests: Test[] = [
+			[
+				'1000',
+				'Polkadot',
+				['1', 'DOT'],
+				Direction.RelayToSystem,
+				`Relay to System: asset 1 is not polkadot's native asset. Expected DOT`,
+			],
+			[
+				'1000',
+				'Kusama',
+				['DOT', 'KSM'],
+				Direction.RelayToSystem,
+				`Relay to System: asset DOT is not kusama's native asset. Expected KSM`,
+			],
+			[
+				'1000',
+				'Westend',
+				['WND', '100000'],
+				Direction.RelayToSystem,
+				`Relay to System: asset 100000 is not westend's native asset. Expected WND`,
+			],
+		];
+
+		for (const test of tests) {
+			const [destChainId, specName, testInputs, direction, errorMessage] = test;
 			const relayChainName = findRelayChain(specName, registry);
 			const currentRegistry = registry[relayChainName];
 
@@ -201,31 +122,84 @@ describe('checkAssetIds', () => {
 					currentRegistry,
 					specName,
 					destChainId,
-					Direction.SystemToPara
+					direction
 				);
 			expect(err).toThrow(errorMessage);
 		}
 	});
-	it('Should error when integer assetId is found for non system parachain origin', () => {
+	it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', () => {
+		const registry = parseRegistry({});
+
+		const tests: Test[] = [
+			[
+				'0',
+				'Statemint',
+				['0'],
+				Direction.SystemToRelay,
+				`assetId 0 not native to polkadot`,
+			],
+			[
+				'0',
+				'Statemine',
+				['MOVR', 'KSM'],
+				Direction.SystemToRelay,
+				`assetId MOVR not native to kusama`,
+			],
+			[
+				'0',
+				'Westmint',
+				['WND', '250'],
+				Direction.SystemToRelay,
+				`assetId 250 not native to westend`,
+			],
+		];
+
+		for (const test of tests) {
+			const [destChainId, specName, testInputs, direction, errorMessage] = test;
+			const relayChainName = findRelayChain(specName, registry);
+			const currentRegistry = registry[relayChainName];
+
+			const err = () =>
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					direction
+				);
+			expect(err).toThrow(errorMessage);
+		}
+	});
+
+	it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', () => {
 		const registry = parseRegistry({});
 
 		const tests: Test[] = [
 			[
 				'2004',
-				'Moonbeam',
-				['2', 'GLMR'],
-				`integer assetId's can only be used for transfers from system parachains. Expected a valid token symbol. Got 2`,
+				'Statemint',
+				['1337', 'DOT', '3500000'],
+				Direction.SystemToPara,
+				`integer assetId 3500000 not found in Statemint`,
 			],
 			[
-				'2012',
-				'Parallel',
-				['1', 'PARA'],
-				`integer assetId's can only be used for transfers from system parachains. Expected a valid token symbol. Got 1`,
+				'2023',
+				'Statemine',
+				['KSM', '8', 'stateMineDoge'],
+				Direction.SystemToPara,
+				`assetId stateMineDoge not found for system parachain Statemine`,
+			],
+			[
+				'1002',
+				'Westmint',
+				['WND', '250'],
+				Direction.SystemToPara,
+				`integer assetId 250 not found in Westmint`,
 			],
 		];
 
 		for (const test of tests) {
-			const [destChainId, specName, testInputs, errorMessage] = test;
+			const [destChainId, specName, testInputs, direction, errorMessage] = test;
 			const relayChainName = findRelayChain(specName, registry);
 			const currentRegistry = registry[relayChainName];
 
@@ -235,9 +209,63 @@ describe('checkAssetIds', () => {
 					currentRegistry,
 					specName,
 					destChainId,
-					Direction.ParaToPara
+					direction
 				);
 			expect(err).toThrow(errorMessage);
 		}
 	});
+
+	it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', () => {
+		const registry = parseRegistry({});
+
+		const tests: Test[] = [
+			[
+				'2004',
+				'Statemint',
+				['1337', 'xcDOT'],
+				Direction.SystemToPara,
+				`assetId xcDOT not found for system parachain Statemint`,
+			],
+			[
+				'2023',
+				'Statemine',
+				['KSM', 'xcMOVR'],
+				Direction.SystemToPara,
+				`assetId xcMOVR not found for system parachain Statemine`,
+			],
+			[
+				'1002',
+				'Westmint',
+				['WND', 'Test Westend'],
+				Direction.SystemToPara,
+				`assetId Test Westend not found for system parachain Westmint`,
+			],
+		];
+
+		for (const test of tests) {
+			const [destChainId, specName, testInputs, direction, errorMessage] = test;
+			const relayChainName = findRelayChain(specName, registry);
+			const currentRegistry = registry[relayChainName];
+
+			const err = () =>
+				checkAssetIdInput(
+					testInputs,
+					currentRegistry,
+					specName,
+					destChainId,
+					direction
+				);
+			expect(err).toThrow(errorMessage);
+		}
+	});
+
+	// TODO:
+	// it('Should error when direction is ParaToRelay and the string assetId is not the relay chains native asset', () => {
+
+	// });
+
+	// TODO:
+	// it('Should error when direction is ParaToPara and the string assetId is not found in the origin chains assets', () => {
+
+	// });
 });

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -1,7 +1,29 @@
+import type { MultiLocation } from '@polkadot/types/interfaces';
+import { ChainInfoRegistry } from 'src/registry/types';
+
 import { findRelayChain } from '../registry/findRelayChain';
 import { parseRegistry } from '../registry/parseRegistry';
+import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { Direction } from '../types';
 import { checkAssetIdInput, checkXcmTxInputs } from './checkXcmTxInputs';
+
+const runTests = (tests: Test[], registry: ChainInfoRegistry) => {
+	for (const test of tests) {
+		const [destChainId, specName, testInputs, direction, errorMessage] = test;
+		const relayChainName = findRelayChain(specName, registry);
+		const currentRegistry = registry[relayChainName];
+
+		const err = () =>
+			checkAssetIdInput(
+				testInputs,
+				currentRegistry,
+				specName,
+				destChainId,
+				direction
+			);
+		expect(err).toThrow(errorMessage);
+	}
+};
 
 describe('checkXcmTxinputs', () => {
 	it("Should error when inputted assetId's dont match amounts length", () => {
@@ -39,7 +61,7 @@ describe('checkXcmTxinputs', () => {
 type Test = [
 	destChainId: string,
 	specName: string,
-	inputs: string[],
+	inputs: (string | MultiLocation)[],
 	xcmDirection: Direction,
 	errorMessage: string
 ];
@@ -65,21 +87,7 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					direction
-				);
-			expect(err).toThrow(errorMessage);
-		}
+		runTests(tests, registry);
 	});
 
 	it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', () => {
@@ -109,22 +117,52 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					direction
-				);
-			expect(err).toThrow(errorMessage);
-		}
+		runTests(tests, registry);
 	});
+
+	it('Should error when direction is RelayToSystem or RelayToPara for a MultiLocation assetId with a non 1 parents field or non Here interior', () => {
+		const registry = parseRegistry({});
+
+		const nonOneParentMultiLocation = mockRelayApi.registry.createType(
+			'MultiLocation',
+			{
+				parents: 0,
+				interior: {
+					Here: '',
+				},
+			}
+		);
+
+		const nonHereInteriorMultiLocation = mockRelayApi.registry.createType(
+			'MultiLocation',
+			{
+				parents: 0,
+				interior: {
+					X1: { Parachain: 1000 },
+				},
+			}
+		);
+
+		const tests: Test[] = [
+			[
+				'1000',
+				'Polkadot',
+				[nonOneParentMultiLocation, 'DOT'],
+				Direction.RelayToSystem,
+				`Relay to System: asset ${nonOneParentMultiLocation.toString()} is not polkadot's native asset. Expected DOT or relaychain MultiLocation with parents of 1 and Here interior`,
+			],
+			[
+				'2006',
+				'Polkadot',
+				[nonHereInteriorMultiLocation, 'DOT'],
+				Direction.RelayToPara,
+				`Relay to System: asset ${nonHereInteriorMultiLocation.toString()} is not polkadot's native asset. Expected DOT or relaychain MultiLocation with parents of 1 and Here interior`,
+			],
+		];
+
+		runTests(tests, registry);
+	});
+
 	it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', () => {
 		const registry = parseRegistry({});
 
@@ -152,110 +190,122 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					direction
-				);
-			expect(err).toThrow(errorMessage);
-		}
+		runTests(tests, registry);
 	});
 
-	it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', () => {
+	it('Should error when xcm direction is SystemToRelay for a MultiLocation assetId with a "parents" value that is not 0', () => {
 		const registry = parseRegistry({});
+
+		const nonZeroParentsMultiLocation = mockRelayApi.createType(
+			'MultiLocation',
+			{
+				parents: 1,
+				interior: {
+					Here: '',
+				},
+			}
+		);
 
 		const tests: Test[] = [
 			[
-				'2004',
-				'Statemint',
-				['1337', 'DOT', '3500000'],
-				Direction.SystemToPara,
-				`integer assetId 3500000 not found in Statemint`,
-			],
-			[
-				'2023',
-				'Statemine',
-				['KSM', '8', 'stateMineDoge'],
-				Direction.SystemToPara,
-				`assetId stateMineDoge not found for system parachain Statemine`,
-			],
-			[
-				'1002',
-				'Westmint',
-				['WND', '250'],
-				Direction.SystemToPara,
-				`integer assetId 250 not found in Westmint`,
+				'1000',
+				'Polkadot',
+				[nonZeroParentsMultiLocation, 'DOT'],
+				Direction.SystemToRelay,
+				`assetId ${nonZeroParentsMultiLocation.toString()} not native to polkadot. Expected DOT or relaychain MultiLocation with parents of 0 and Here interior`,
 			],
 		];
 
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
-
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					direction
-				);
-			expect(err).toThrow(errorMessage);
-		}
+		runTests(tests, registry);
 	});
 
-	it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', () => {
-		const registry = parseRegistry({});
+	// it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', () => {
+	// 	const registry = parseRegistry({});
 
-		const tests: Test[] = [
-			[
-				'2004',
-				'Statemint',
-				['1337', 'xcDOT'],
-				Direction.SystemToPara,
-				`assetId xcDOT not found for system parachain Statemint`,
-			],
-			[
-				'2023',
-				'Statemine',
-				['KSM', 'xcMOVR'],
-				Direction.SystemToPara,
-				`assetId xcMOVR not found for system parachain Statemine`,
-			],
-			[
-				'1002',
-				'Westmint',
-				['WND', 'Test Westend'],
-				Direction.SystemToPara,
-				`assetId Test Westend not found for system parachain Westmint`,
-			],
-		];
+	// 	const tests: Test[] = [
+	// 		[
+	// 			'2004',
+	// 			'Statemint',
+	// 			['1337', 'DOT', '3500000'],
+	// 			Direction.SystemToPara,
+	// 			`integer assetId 3500000 not found in Statemint`,
+	// 		],
+	// 		[
+	// 			'2023',
+	// 			'Statemine',
+	// 			['KSM', '8', 'stateMineDoge'],
+	// 			Direction.SystemToPara,
+	// 			`assetId stateMineDoge not found for system parachain Statemine`,
+	// 		],
+	// 		[
+	// 			'1002',
+	// 			'Westmint',
+	// 			['WND', '250'],
+	// 			Direction.SystemToPara,
+	// 			`integer assetId 250 not found in Westmint`,
+	// 		],
+	// 	];
 
-		for (const test of tests) {
-			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
+	// 	for (const test of tests) {
+	// 		const [destChainId, specName, testInputs, direction, errorMessage] = test;
+	// 		const relayChainName = findRelayChain(specName, registry);
+	// 		const currentRegistry = registry[relayChainName];
 
-			const err = () =>
-				checkAssetIdInput(
-					testInputs,
-					currentRegistry,
-					specName,
-					destChainId,
-					direction
-				);
-			expect(err).toThrow(errorMessage);
-		}
-	});
+	// 		const err = () =>
+	// 			checkAssetIdInput(
+	// 				testInputs,
+	// 				currentRegistry,
+	// 				specName,
+	// 				destChainId,
+	// 				direction
+	// 			);
+	// 		expect(err).toThrow(errorMessage);
+	// 	}
+	// });
+
+	// it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', () => {
+	// 	const registry = parseRegistry({});
+
+	// 	const tests: Test[] = [
+	// 		[
+	// 			'2004',
+	// 			'Statemint',
+	// 			['1337', 'xcDOT'],
+	// 			Direction.SystemToPara,
+	// 			`assetId xcDOT not found for system parachain Statemint`,
+	// 		],
+	// 		[
+	// 			'2023',
+	// 			'Statemine',
+	// 			['KSM', 'xcMOVR'],
+	// 			Direction.SystemToPara,
+	// 			`assetId xcMOVR not found for system parachain Statemine`,
+	// 		],
+	// 		[
+	// 			'1002',
+	// 			'Westmint',
+	// 			['WND', 'Test Westend'],
+	// 			Direction.SystemToPara,
+	// 			`assetId Test Westend not found for system parachain Westmint`,
+	// 		],
+	// 	];
+
+	// 	for (const test of tests) {
+	// 		const [destChainId, specName, testInputs, direction, errorMessage] = test;
+	// 		const relayChainName = findRelayChain(specName, registry);
+	// 		const currentRegistry = registry[relayChainName];
+
+	// 		const err = () =>
+	// 			checkAssetIdInput(
+	// 				testInputs,
+	// 				currentRegistry,
+	// 				specName,
+	// 				destChainId,
+	// 				direction
+	// 			);
+	// 		expect(err).toThrow(errorMessage);
+	// 	}
+	// });
 
 	// TODO:
 	// it('Should error when direction is ParaToRelay and the string assetId is not the relay chains native asset', () => {

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -118,6 +118,29 @@ describe('checkAssetIds', () => {
 		runTests(tests, registry);
 	});
 
+	it('Should error when direction is RelayToPara and assetId does not match relay chains native token', () => {
+		const registry = parseRegistry({});
+
+		const tests: Test[] = [
+			[
+				'2004',
+				'Polkadot',
+				['1', 'DOT'],
+				Direction.RelayToPara,
+				`Relay to Para: asset 1 is not polkadot's native asset. Expected DOT`,
+			],
+			[
+				'2001',
+				'Kusama',
+				['DOT', 'KSM'],
+				Direction.RelayToPara,
+				`Relay to Para: asset DOT is not kusama's native asset. Expected KSM`,
+			],
+		];
+
+		runTests(tests, registry);
+	});
+
 	it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', () => {
 		const registry = parseRegistry({});
 
@@ -127,21 +150,21 @@ describe('checkAssetIds', () => {
 				'Statemint',
 				['0'],
 				Direction.SystemToRelay,
-				`assetId 0 not native to polkadot`,
+				`System to Relay: assetId 0 not native to polkadot`,
 			],
 			[
 				'0',
 				'Statemine',
 				['MOVR', 'KSM'],
 				Direction.SystemToRelay,
-				`assetId MOVR not native to kusama`,
+				`System to Relay: assetId MOVR not native to kusama`,
 			],
 			[
 				'0',
 				'Westmint',
 				['WND', '250'],
 				Direction.SystemToRelay,
-				`assetId 250 not native to westend`,
+				`System to Relay: assetId 250 not native to westend`,
 			],
 		];
 
@@ -157,21 +180,21 @@ describe('checkAssetIds', () => {
 				'Statemint',
 				['1337', 'DOT', '3500000'],
 				Direction.SystemToPara,
-				`integer assetId 3500000 not found in Statemint`,
+				`System to Para: integer assetId 3500000 not found in Statemint`,
 			],
 			[
 				'2023',
 				'Statemine',
 				['KSM', '8', 'stateMineDoge'],
 				Direction.SystemToPara,
-				`assetId stateMineDoge not found for system parachain Statemine`,
+				`System to Para: assetId stateMineDoge not found for system parachain Statemine`,
 			],
 			[
 				'1002',
 				'Westmint',
 				['WND', '250'],
 				Direction.SystemToPara,
-				`integer assetId 250 not found in Westmint`,
+				`System to Para: integer assetId 250 not found in Westmint`,
 			],
 		];
 
@@ -201,21 +224,21 @@ describe('checkAssetIds', () => {
 				'Statemint',
 				['1337', 'xcDOT'],
 				Direction.SystemToPara,
-				`assetId xcDOT not found for system parachain Statemint`,
+				`System to Para: assetId xcDOT not found for system parachain Statemint`,
 			],
 			[
 				'2023',
 				'Statemine',
 				['KSM', 'xcMOVR'],
 				Direction.SystemToPara,
-				`assetId xcMOVR not found for system parachain Statemine`,
+				`System to Para: assetId xcMOVR not found for system parachain Statemine`,
 			],
 			[
 				'1002',
 				'Westmint',
 				['WND', 'Test Westend'],
 				Direction.SystemToPara,
-				`assetId Test Westend not found for system parachain Westmint`,
+				`System to Para: assetId Test Westend not found for system parachain Westmint`,
 			],
 		];
 

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -195,7 +195,7 @@ export const checkAssetIdInput = (
 ) => {
 	for (let i = 0; i < assetIds.length; i++) {
 		const assetId = assetIds[i];
-		// check if assetId is empty string or blank space
+		
 		checkIfAssetIdIsEmptyOrBlankSpace(assetId);
 
 		if (xcmDirection === Direction.RelayToSystem) {

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -195,7 +195,7 @@ export const checkAssetIdInput = (
 ) => {
 	for (let i = 0; i < assetIds.length; i++) {
 		const assetId = assetIds[i];
-		
+
 		checkIfAssetIdIsEmptyOrBlankSpace(assetId);
 
 		if (xcmDirection === Direction.RelayToSystem) {

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -13,7 +13,7 @@ import { BaseError } from './BaseError';
 const checkIfAssetIdIsEmptyOrBlankSpace = (assetId: string) => {
 	// check if empty or space
 	// if assetId is an empty space or space error
-	if (assetId === '' || assetId === ' ') {
+	if (assetId === '' || assetId.trim() === '') {
 		const assetIdLength = assetId.length;
 		const errorMessageDetails =
 			assetIdLength > 0 ? 'Found blank space' : 'Found empty string';

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -1,5 +1,3 @@
-import type { MultiLocation } from '@polkadot/types/interfaces';
-
 import { RELAY_CHAIN_IDS, SYSTEM_PARACHAINS_IDS } from '../consts';
 import { findRelayChain } from '../registry/findRelayChain';
 import type { ChainInfo, ChainInfoRegistry } from '../registry/types';
@@ -12,7 +10,7 @@ import { BaseError } from './BaseError';
  *
  * @param assetId
  */
-const checkIfAssetIdIsEmptyOrBlankSpace = (assetId: string | MultiLocation) => {
+const checkIfAssetIdIsEmptyOrBlankSpace = (assetId: string) => {
 	// check if empty or space
 	// if assetId is an empty space or space error
 	if (assetId === '' || assetId === ' ') {
@@ -32,7 +30,7 @@ const checkIfAssetIdIsEmptyOrBlankSpace = (assetId: string | MultiLocation) => {
  * @param relayChainInfo
  */
 const checkRelayToSystemAssetId = (
-	assetId: string | MultiLocation,
+	assetId: string,
 	relayChainInfo: ChainInfo
 ) => {
 	const relayChainId = RELAY_CHAIN_IDS[0];
@@ -43,26 +41,13 @@ const checkRelayToSystemAssetId = (
 	// ensure the asset being sent is the native asset of the relay chain
 	// no need to check if id is a number, if it is, it fails the check by default
 	let assetIsRelayChainNativeAsset = false;
-	if (typeof assetId === 'string') {
-		if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
-			assetIsRelayChainNativeAsset = true;
-		}
-	} else {
-		// parents value for dest chain (system chain) should be 1
-		// Here to reference relay chain interior
-		if (assetId.parents.toNumber() === 1 && assetId.interior.isHere) {
-			assetIsRelayChainNativeAsset = true;
-		}
-		// TODO:
-		// use multilocation based on destchain origin to check if the dest chain
-		// contains the given multilocations asset id
+	if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
+		assetIsRelayChainNativeAsset = true;
 	}
 
 	if (!assetIsRelayChainNativeAsset) {
 		throw new BaseError(
-			`Relay to System: asset ${assetId.toString()} is not ${
-				relayChain.specName
-			}'s native asset. Expected ${relayChainNativeAsset} or relaychain MultiLocation with parents of 1 and Here interior`
+			`Relay to System: asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`
 		);
 	}
 };
@@ -75,7 +60,7 @@ const checkRelayToSystemAssetId = (
  * @param relayChainInfo
  */
 const checkRelayToParaAssetId = (
-	assetId: string | MultiLocation,
+	assetId: string,
 	relayChainInfo: ChainInfo
 ) => {
 	const relayChainId = RELAY_CHAIN_IDS[0];
@@ -90,24 +75,11 @@ const checkRelayToParaAssetId = (
 		if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
 			assetIsRelayChainNativeAsset = true;
 		}
-	} else {
-		// handle multilocation case
-		// parents value for dest chain (parachain) should be 1
-		// Here to reference relay chain interior
-		if (assetId.parents.toNumber() === 1 && assetId.interior.isHere) {
-			assetIsRelayChainNativeAsset = true;
-		}
-
-		// TODO:
-		// use multilocation based on destchain origin to check if the dest chain
-		// contains the given multilocations asset id
 	}
 
 	if (!assetIsRelayChainNativeAsset) {
 		throw new BaseError(
-			`Relay to System: asset ${assetId.toString()} is not ${
-				relayChain.specName
-			}'s native asset. Expected ${relayChainNativeAsset} or relaychain MultiLocation with parents of 1 and Here interior`
+			`Relay to System: asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`
 		);
 	}
 };
@@ -119,7 +91,7 @@ const checkRelayToParaAssetId = (
  * @param relayChainInfo
  */
 const checkSystemToRelayAssetId = (
-	assetId: string | MultiLocation,
+	assetId: string,
 	relayChainInfo: ChainInfo
 ) => {
 	const relayChainId = RELAY_CHAIN_IDS[0];
@@ -133,20 +105,11 @@ const checkSystemToRelayAssetId = (
 		if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
 			matchedRelayChainNativeToken = true;
 		}
-	} else {
-		// handle multilocation case
-		// multilocation parents value from relay chain perspective is 0
-		// Here interior for relay chain
-		if (assetId.parents.toNumber() === 0 && assetId.interior.isHere) {
-			matchedRelayChainNativeToken = true;
-		}
 	}
 
 	if (!matchedRelayChainNativeToken) {
 		throw new BaseError(
-			`assetId ${assetId.toString()} not native to ${
-				relayChain.specName
-			}. Expected ${relayChainNativeAsset} or relaychain MultiLocation with parents of 0 and Here interior`
+			`assetId ${assetId} not native to ${relayChain.specName}. Expected ${relayChainNativeAsset}`
 		);
 	}
 };
@@ -158,7 +121,7 @@ const checkSystemToRelayAssetId = (
  * @param relayChainInfo
  */
 const checkSystemToParaAssetId = (
-	assetId: string | MultiLocation,
+	assetId: string,
 	specName: string,
 	relayChainInfo: ChainInfo
 ) => {
@@ -211,10 +174,6 @@ const checkSystemToParaAssetId = (
 				);
 			}
 		}
-		// TODO:
-		// check if destination chain has the asset?
-	} else {
-		// handle multilocation case
 	}
 };
 
@@ -228,7 +187,7 @@ const checkSystemToParaAssetId = (
  * @param destChainId
  */
 export const checkAssetIdInput = (
-	assetIds: (string | MultiLocation)[],
+	assetIds: string[],
 	relayChainInfo: ChainInfo,
 	specName: string,
 	_destChainId: string,
@@ -254,22 +213,6 @@ export const checkAssetIdInput = (
 		if (xcmDirection === Direction.SystemToPara) {
 			checkSystemToParaAssetId(assetId, specName, relayChainInfo);
 		}
-
-		// TODO:
-		// if (xcmDirection === Direction.ParaToPara) {
-		// 	// handle para to para checks
-
-		// check that asset is valid in tokens or assetsInfo
-
-		// check if asset exists on destination chain
-		// by hashing the multilocation of the asset from the perspective of the destination
-		// and taking the first 16 bytes to get the id
-		// }
-
-		// TODO:
-		// if (xcmDirection === Direction.ParaToRelay) {
-		// 	// handle para to relay checks
-		// }
 	}
 };
 
@@ -284,7 +227,7 @@ export const checkAssetIdInput = (
  * @param xcmDirection
  */
 export const checkXcmTxInputs = (
-	assetIds: (string | MultiLocation)[],
+	assetIds: string[],
 	amounts: string[],
 	xcmDirection: Direction,
 	destChainId: string,

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -79,7 +79,7 @@ const checkRelayToParaAssetId = (
 
 	if (!assetIsRelayChainNativeAsset) {
 		throw new BaseError(
-			`Relay to System: asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`
+			`Relay to Para: asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`
 		);
 	}
 };
@@ -109,7 +109,7 @@ const checkSystemToRelayAssetId = (
 
 	if (!matchedRelayChainNativeToken) {
 		throw new BaseError(
-			`assetId ${assetId} not native to ${relayChain.specName}. Expected ${relayChainNativeAsset}`
+			`System to Relay: assetId ${assetId} not native to ${relayChain.specName}. Expected ${relayChainNativeAsset}`
 		);
 	}
 };
@@ -141,7 +141,7 @@ const checkSystemToParaAssetId = (
 
 			if (assetSymbol === undefined) {
 				throw new BaseError(
-					`integer assetId ${assetId} not found in ${specName}`
+					`System to Para: integer assetId ${assetId} not found in ${specName}`
 				);
 			}
 		} else {
@@ -170,7 +170,7 @@ const checkSystemToParaAssetId = (
 			// if no native token for the system parachain was matched, throw an error
 			if (!isValidTokenSymbol) {
 				throw new BaseError(
-					`assetId ${assetId} not found for system parachain ${specName}`
+					`System to Para: assetId ${assetId} not found for system parachain ${specName}`
 				);
 			}
 		}

--- a/src/registry/parseRegistry.spec.ts
+++ b/src/registry/parseRegistry.spec.ts
@@ -12,13 +12,13 @@ describe('parseRegistry', () => {
 	});
 
 	it('Should correctly inject an injectedRegsitry', () => {
-		const assetIds: number[] = [];
+		const assetsInfo = {};
 		const opts = {
 			injectedRegistry: {
 				polkadot: {
 					'9876': {
 						tokens: ['TST'],
-						assetIds,
+						assetsInfo,
 						specName: 'testing',
 					},
 				},
@@ -28,7 +28,7 @@ describe('parseRegistry', () => {
 
 		expect(registry.polkadot['9876']).toStrictEqual({
 			tokens: ['TST'],
-			assetIds: [],
+			assetsInfo: {},
 			specName: 'testing',
 		});
 		// Ensure nothing was overwritten

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,10 +1,14 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+interface AssetsInfo {
+	[key: string]: string;
+}
+
 export type ChainInfo = {
 	[x: string]: {
 		specName: string;
 		tokens: string[];
-		assetIds: number[];
+		assetsInfo: AssetsInfo;
 	};
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,10 +1294,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/asset-transfer-api-registry@npm:0.1.0":
-  version: 0.1.0
-  resolution: "@substrate/asset-transfer-api-registry@npm:0.1.0"
-  checksum: 76397a18ae0bee507aebb3ce80897c711ba3044cd66d06d74f0c26a76783ab73bbbf091f212ed27f91cd75098e74ff8b874fe66e1ba6f7dba311fa35708f6068
+"@substrate/asset-transfer-api-registry@npm:0.2.0":
+  version: 0.2.0
+  resolution: "@substrate/asset-transfer-api-registry@npm:0.2.0"
+  checksum: 1ba9843b9d6b25980aefba656a735dd8395aa87a7a3955a44fe260f0591647973df1e237f9c544b91b9e4eb2dfe8ff54ac1ce1af56f6dd8f89bf632dd67d1a49
   languageName: node
   linkType: hard
 
@@ -1306,7 +1306,7 @@ __metadata:
   resolution: "@substrate/asset-transfer-api@workspace:."
   dependencies:
     "@polkadot/api": ^10.5.1
-    "@substrate/asset-transfer-api-registry": 0.1.0
+    "@substrate/asset-transfer-api-registry": 0.2.0
     "@substrate/dev": ^0.6.7
     chalk: 4.1.2
     typedoc: ^0.23.26


### PR DESCRIPTION
* changes input validation logic to be based on xcm direction for RelayToSystem, RelayToPara, SystemToRelay and SystemToPara directions
* closes [#138](https://github.com/paritytech/asset-transfer-api/issues/138)