### PR TITLE
Fix parents for native vs non-native tokens when construct xcm types for assets

### DIFF
--- a/src/AssetsTransferApi.spec.ts
+++ b/src/AssetsTransferApi.spec.ts
@@ -277,7 +277,7 @@ describe('AssetTransferAPI', () => {
 						direction: 'SystemToPara',
 						format: 'call',
 						method: 'teleportAssets',
-						tx: '0x1f010100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01010100411f010400000000910100000000',
+						tx: '0x1f010100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01010100411f010400010000910100000000',
 						xcmVersion: 2,
 					});
 				});

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -126,14 +126,16 @@ export const SystemToPara: ICreateXcmType = {
 			const assetId = assets[i];
 			const amount = amounts[i];
 
-			const interior = tokens.includes(assetId)
+			const isNative = tokens.includes(assetId);
+			const interior = isNative
 				? { Here: '' }
 				: { X2: [{ PalletInstance: palletId }, { GeneralIndex: assetId }] };
+			const parents = isNative ? 1 : 0;
 
 			const multiAsset = {
 				id: {
 					Concrete: {
-						parents: 0,
+						parents,
 						interior,
 					},
 				},


### PR DESCRIPTION
This ensures when we create xcm types for assets for `SystemToPara` we correctly input the right `parents` value depending on the token.