### PR TITLE
Update testnetwork script to use V3 for asset creation

### DIFF
--- a/scripts/testNetworkSetup.ts
+++ b/scripts/testNetworkSetup.ts
@@ -131,7 +131,7 @@ const main = async () => {
 	});
 	const xcmOriginType = rococoApi.createType('XcmOriginKind', 'Superuser');
 	const xcmDest = {
-		V1: {
+		V3: {
 			parents: 0,
 			interior: {
 				X1: {
@@ -141,11 +141,14 @@ const main = async () => {
 		},
 	};
 	const xcmMessage = {
-		V2: [
+		V3: [
 			{
 				transact: {
 					originType: xcmOriginType,
-					requireWeightAtMost: 1000000000,
+					requireWeightAtMost: {
+						refTime: 1000000000,
+						proofSize: 0,
+					},
 					call: xcmDoubleEncoded,
 				},
 			},


### PR DESCRIPTION
rel: https://github.com/paritytech/asset-transfer-api/issues/106

This doesn't fix the overall issue with the V3 Barrier Trait Error but sets the script to use V3.