### PR TITLE
Add support for AccountKey20

### DIFF
--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -30,6 +30,31 @@ describe('RelayToPara XcmVersioned Generation', () => {
 
 			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
 		});
+		it('Should work for V2 Ethereum address', () => {
+			const beneficiary = RelayToPara.createBeneficiary(
+				mockRelayApi,
+				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
+				2
+			);
+
+			const expectedRes = {
+				v2: {
+					parents: 0,
+					interior: {
+						x1: {
+							accountKey20: {
+								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
+								network: {
+									any: null,
+								},
+							},
+						},
+					},
+				},
+			};
+
+			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+		})
 		it('Should work for V3', () => {
 			const beneficiary = RelayToPara.createBeneficiary(
 				mockRelayApi,
@@ -53,6 +78,29 @@ describe('RelayToPara XcmVersioned Generation', () => {
 
 			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
 		});
+		it('Should work for V3 Ethereum address', () => {
+			const beneficiary = RelayToPara.createBeneficiary(
+				mockRelayApi,
+				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
+				3
+			);
+
+			const expectedRes = {
+				v3: {
+					parents: 0,
+					interior: {
+						x1: {
+							accountKey20: {
+								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
+								network: null
+							},
+						},
+					},
+				},
+			};
+
+			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+		})
 	});
 
 	describe('Destination', () => {

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -54,7 +54,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 			};
 
 			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
-		})
+		});
 		it('Should work for V3', () => {
 			const beneficiary = RelayToPara.createBeneficiary(
 				mockRelayApi,
@@ -92,7 +92,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 						x1: {
 							accountKey20: {
 								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
-								network: null
+								network: null,
 							},
 						},
 					},
@@ -100,7 +100,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 			};
 
 			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
-		})
+		});
 	});
 
 	describe('Destination', () => {

--- a/src/createXcmTypes/RelayToPara.ts
+++ b/src/createXcmTypes/RelayToPara.ts
@@ -8,6 +8,7 @@ import type {
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
+import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import { ICreateXcmType, IWeightLimit } from './types';
 
@@ -28,30 +29,28 @@ export const RelayToPara: ICreateXcmType = {
 		xcmVersion?: number
 	): VersionedMultiLocation => {
 		if (xcmVersion === 2) {
+			const X1 = isEthereumAddress(accountId)
+				? { AccountKey20: { network: 'Any', key: accountId } }
+				: { AccountId32: { network: 'Any', id: accountId } };
 			return api.registry.createType('XcmVersionedMultiLocation', {
 				V2: {
 					parents: 0,
 					interior: {
-						X1: {
-							AccountId32: {
-								network: 'Any',
-								id: accountId,
-							},
-						},
+						X1,
 					},
 				},
 			});
 		}
 
+		const X1 = isEthereumAddress(accountId)
+			? { AccountKey20: { key: accountId } }
+			: { AccountId32: { id: accountId } };
+
 		return api.registry.createType('XcmVersionedMultiLocation', {
 			V3: {
 				parents: 0,
 				interior: {
-					X1: {
-						AccountId32: {
-							id: accountId,
-						},
-					},
+					X1,
 				},
 			},
 		});

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -30,6 +30,31 @@ describe('SystemToPara XcmVersioned Generation', () => {
 
 			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
 		});
+		it('Should work for V2 for an Ethereum Address', () => {
+			const beneficiary = SystemToPara.createBeneficiary(
+				mockSystemApi,
+				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
+				2
+			);
+
+			const expectedRes = {
+				v2: {
+					parents: 0,
+					interior: {
+						x1: {
+							accountKey20: {
+								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
+								network: {
+									any: null,
+								},
+							},
+						},
+					},
+				},
+			};
+
+			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+		});
 		it('Should work for V3', () => {
 			const beneficiary = SystemToPara.createBeneficiary(
 				mockSystemApi,
@@ -45,6 +70,29 @@ describe('SystemToPara XcmVersioned Generation', () => {
 							accountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 								network: null,
+							},
+						},
+					},
+				},
+			};
+
+			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+		});
+		it('Should work for V3 for an Ethereum Address', () => {
+			const beneficiary = SystemToPara.createBeneficiary(
+				mockSystemApi,
+				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
+				3
+			);
+
+			const expectedRes = {
+				v3: {
+					parents: 0,
+					interior: {
+						x1: {
+							accountKey20: {
+								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
+								network: null
 							},
 						},
 					},

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -92,7 +92,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 						x1: {
 							accountKey20: {
 								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
-								network: null
+								network: null,
 							},
 						},
 					},

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -8,6 +8,7 @@ import type {
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
+import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import { findRelayChain, parseRegistry } from '../registry';
 import { ICreateXcmType, IWeightLimit } from './types';
@@ -27,30 +28,29 @@ export const SystemToPara: ICreateXcmType = {
 		xcmVersion?: number
 	): VersionedMultiLocation => {
 		if (xcmVersion == 2) {
+			const X1 = isEthereumAddress(accountId)
+				? { AccountKey20: { network: 'Any', key: accountId } }
+				: { AccountId32: { network: 'Any', id: accountId } };
+
 			return api.registry.createType('XcmVersionedMultiLocation', {
 				V2: {
 					parents: 0,
 					interior: {
-						X1: {
-							AccountId32: {
-								network: 'Any',
-								id: accountId,
-							},
-						},
+						X1,
 					},
 				},
 			});
 		}
 
+		const X1 = isEthereumAddress(accountId)
+			? { AccountKey20: { key: accountId } }
+			: { AccountId32: { id: accountId } };
+
 		return api.registry.createType('XcmVersionedMultiLocation', {
 			V3: {
 				parents: 0,
 				interior: {
-					X1: {
-						AccountId32: {
-							id: accountId,
-						},
-					},
+					X1,
 				},
 			},
 		});

--- a/src/validate/validateAddress.spec.ts
+++ b/src/validate/validateAddress.spec.ts
@@ -15,6 +15,11 @@ describe('validateAddress', () => {
 			)
 		).toEqual([true, undefined]);
 	});
+	it('Should not error with a valid ethereum address', () => {
+		expect(
+			validateAddress('0x96Bd611EbE3Af39544104e26764F4939924F6Ece')
+		).toEqual([true, undefined]);
+	});
 	it('Should error with a nonsense address', () => {
 		expect(validateAddress('hello')).toEqual([
 			false,

--- a/src/validate/validateAddress.ts
+++ b/src/validate/validateAddress.ts
@@ -5,6 +5,7 @@ import {
 	base58Decode,
 	checkAddressChecksum,
 	encodeAddress,
+	isEthereumAddress,
 } from '@polkadot/util-crypto';
 import { defaults } from '@polkadot/util-crypto/address/defaults';
 
@@ -20,6 +21,11 @@ export const validateAddress = (
 	address: string
 ): [boolean, string | undefined] => {
 	let u8Address;
+
+	if (isEthereumAddress(address)) {
+		return [true, undefined];
+	}
+
 	if (isHex(address)) {
 		u8Address = base58Decode(encodeAddress(hexToU8a(address)));
 	} else {


### PR DESCRIPTION
closes: https://github.com/paritytech/asset-transfer-api/issues/43

This adds support for ethereum addresses. It only really matters for `SystemToPara`, and `RelayToPara` so we added it to those directions. 