### PR TITLE
Add additional xcmDirection validation checks, fix SystemToRelay AssetType

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -378,7 +378,7 @@ export class AssetsTransferApi {
 		assets: string[],
 		xcmDirection: Direction
 	): AssetType {
-		if (xcmDirection === 'RelayToSystem') {
+		if (xcmDirection === 'RelayToSystem' || xcmDirection === 'SystemToRelay') {
 			return AssetType.Native;
 		}
 		const relayChainName = findRelayChain(specName, this._registry);

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -139,7 +139,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 	});
 	describe('Assets', () => {
 		it('Should work for V2', () => {
-			const assets = RelayToPara.createAssets(mockRelayApi, ['100'], 2, '');
+			const assets = RelayToPara.createAssets(mockRelayApi, ['100'], 2, '', []);
 
 			const expectedRes = {
 				v2: [
@@ -162,7 +162,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 			expect(assets.toJSON()).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const assets = RelayToPara.createAssets(mockRelayApi, ['100'], 3, '');
+			const assets = RelayToPara.createAssets(mockRelayApi, ['100'], 3, '', []);
 
 			const expectedRes = {
 				v3: [

--- a/src/createXcmTypes/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/RelayToSystem.spec.ts
@@ -91,7 +91,13 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 	});
 	describe('Assets', () => {
 		it('Should work for V2', () => {
-			const assets = RelayToSystem.createAssets(mockRelayApi, ['100'], 2, '');
+			const assets = RelayToSystem.createAssets(
+				mockRelayApi,
+				['100'],
+				2,
+				'',
+				[]
+			);
 
 			const expectedRes = {
 				v2: [
@@ -114,7 +120,13 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 			expect(assets.toJSON()).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const assets = RelayToSystem.createAssets(mockRelayApi, ['100'], 3, '');
+			const assets = RelayToSystem.createAssets(
+				mockRelayApi,
+				['100'],
+				3,
+				'',
+				[]
+			);
 
 			const expectedRes = {
 				v3: [

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -107,14 +107,8 @@ export const SystemToPara: ICreateXcmType = {
 		amounts: string[],
 		xcmVersion: number,
 		specName: string,
-		assets?: string[]
+		assets: string[]
 	): VersionedMultiAssets => {
-		// TODO: We should consider a centralized place where these errors are check for.
-		if (!assets) {
-			throw Error(
-				'Assets are required for constructing a MultiAsset from SystemToPara'
-			);
-		}
 		const palletId = fetchPalletInstanceId(api);
 		const multiAssets = [];
 		const registry = parseRegistry({});

--- a/src/createXcmTypes/SystemToRelay.spec.ts
+++ b/src/createXcmTypes/SystemToRelay.spec.ts
@@ -86,7 +86,13 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 	});
 	describe('Assets', () => {
 		it('Should work for V2', () => {
-			const assets = SystemToRelay.createAssets(mockSystemApi, ['100'], 2, '');
+			const assets = SystemToRelay.createAssets(
+				mockSystemApi,
+				['100'],
+				2,
+				'',
+				[]
+			);
 
 			const expectedRes = {
 				v2: [
@@ -109,7 +115,13 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 			expect(assets.toJSON()).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const assets = SystemToRelay.createAssets(mockSystemApi, ['100'], 3, '');
+			const assets = SystemToRelay.createAssets(
+				mockSystemApi,
+				['100'],
+				3,
+				'',
+				[]
+			);
 
 			const expectedRes = {
 				v3: [

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -32,7 +32,7 @@ export interface ICreateXcmType {
 		amounts: string[],
 		xcmVersion: number,
 		specName: string,
-		assets?: string[]
+		assets: string[]
 	) => VersionedMultiAssets;
 	createWeightLimit: (api: ApiPromise, weightLimit?: string) => WeightLimitV2;
 }

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -51,7 +51,7 @@ describe('checkXcmTxinputs', () => {
 			);
 
 		expect(err).toThrow(
-			"`assetIds` should be empty when sending tx's from the relay chain."
+			"`assetIds` should be empty when sending tx's to or from the relay chain."
 		);
 	});
 });

--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -409,7 +409,7 @@ describe('AssetTransferApi Integration Tests', () => {
 				return await systemAssetsApi.createTransferTransaction(
 					'0', // `0` indicating the dest chain is a relay chain.
 					'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-					['DOT'],
+					[],
 					['100'],
 					{
 						format,


### PR DESCRIPTION
Ensure `SystemToRelay` is a teleport.

Reorganize xcmDirection validation checks.