### PR TITLE
Explicit return of Foriegn for RelayToPara

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -381,6 +381,11 @@ export class AssetsTransferApi {
 		if (xcmDirection === 'RelayToSystem' || xcmDirection === 'SystemToRelay') {
 			return AssetType.Native;
 		}
+
+		if (xcmDirection === 'RelayToPara') {
+			return AssetType.Foreign;
+		}
+
 		const relayChainName = findRelayChain(specName, this._registry);
 		const relayChainInfo = this._registry[relayChainName];
 


### PR DESCRIPTION
So currently there is no bug, but this ensures that we are explicit that when the direction is `RelayToPara` that we explicitly say this is a foreign assetType and we need to use `reserveAssetTransfer`.

Currently it already works but it uses an undefined comparison.