### PR TITLE
Ensure a user can input a native token or have an empty array for tx's to or from relay

### DIFF
--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -3,7 +3,12 @@ import { ChainInfoRegistry } from 'src/registry/types';
 import { findRelayChain } from '../registry/findRelayChain';
 import { parseRegistry } from '../registry/parseRegistry';
 import { Direction } from '../types';
-import { checkAssetIdInput, checkXcmTxInputs } from './checkXcmTxInputs';
+import {
+	checkAssetIdInput,
+	checkAssetsAmountMatch,
+	checkRelayAmountsLength,
+	checkRelayAssetIdLength,
+} from './checkXcmTxInputs';
 
 const runTests = (tests: Test[], registry: ChainInfoRegistry) => {
 	for (const test of tests) {
@@ -23,35 +28,31 @@ const runTests = (tests: Test[], registry: ChainInfoRegistry) => {
 	}
 };
 
-describe('checkXcmTxinputs', () => {
+describe('checkRelayAssetIdLength', () => {
+	it('Should error with an incorrect assetId length for inputs to or from relay chains', () => {
+		const err = () => checkRelayAssetIdLength(['dot', 'usdt']);
+
+		expect(err).toThrow(
+			"`assetIds` should be empty or length 1 when sending tx's to or from the relay chain."
+		);
+	});
+});
+
+describe('checkRelayAmountsLength', () => {
+	it('Should error with an incorrect amounts length', () => {
+		const err = () => checkRelayAmountsLength(['1000000000', '10000000000']);
+		expect(err).toThrow(
+			'`amounts` should be of length 1 when sending to or from a relay chain'
+		);
+	});
+});
+
+describe('checkAssetsAmountMatch', () => {
 	it("Should error when inputted assetId's dont match amounts length", () => {
-		const err = () =>
-			checkXcmTxInputs(
-				['1'],
-				['10', '10'],
-				Direction.SystemToPara,
-				'0',
-				'Statemint',
-				parseRegistry({})
-			);
+		const err = () => checkAssetsAmountMatch(['1'], ['10', '10']);
 
 		expect(err).toThrow(
 			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.'
-		);
-	});
-	it('Should error when inputting assetIds when a transactions origin is the relay chain', () => {
-		const err = () =>
-			checkXcmTxInputs(
-				['DOT'],
-				['1000'],
-				Direction.RelayToSystem,
-				'1000',
-				'Polkadot',
-				parseRegistry({})
-			);
-
-		expect(err).toThrow(
-			"`assetIds` should be empty when sending tx's to or from the relay chain."
 		);
 	});
 });

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -6,14 +6,14 @@ import { BaseError } from './BaseError';
 
 /**
  * Ensure when sending tx's to or from the relay chain that the length of the assetIds array
- * is zero
+ * is zero or 1, and contains the correct token.
  *
  * @param assetIds
  */
-const checkRelayAssetIdLength = (assetIds: string[]) => {
-	if (assetIds.length > 0) {
+export const checkRelayAssetIdLength = (assetIds: string[]) => {
+	if (assetIds.length > 1) {
 		throw new BaseError(
-			"`assetIds` should be empty when sending tx's to or from the relay chain."
+			"`assetIds` should be empty or length 1 when sending tx's to or from the relay chain."
 		);
 	}
 };
@@ -24,7 +24,7 @@ const checkRelayAssetIdLength = (assetIds: string[]) => {
  *
  * @param amounts
  */
-const checkRelayAmountsLength = (amounts: string[]) => {
+export const checkRelayAmountsLength = (amounts: string[]) => {
 	if (amounts.length !== 1) {
 		throw new BaseError(
 			'`amounts` should be of length 1 when sending to or from a relay chain'
@@ -38,7 +38,10 @@ const checkRelayAmountsLength = (amounts: string[]) => {
  * @param assetIds
  * @param amounts
  */
-const checkAssetsAmountMatch = (assetIds: string[], amounts: string[]) => {
+export const checkAssetsAmountMatch = (
+	assetIds: string[],
+	amounts: string[]
+) => {
 	if (assetIds.length !== amounts.length) {
 		throw new BaseError(
 			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.'


### PR DESCRIPTION
closes: https://github.com/paritytech/asset-transfer-api/issues/168