### PR TITLE
Check base types for createTransferTransaction inputs

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -26,7 +26,12 @@ import {
 	teleportAssets,
 } from './createXcmCalls';
 import { establishXcmPallet } from './createXcmCalls/util/establishXcmPallet';
-import { checkLocalTxInput, checkXcmTxInputs, checkXcmVersion } from './errors';
+import {
+	checkBaseInputTypes,
+	checkLocalTxInput,
+	checkXcmTxInputs,
+	checkXcmVersion,
+} from './errors';
 import { findRelayChain } from './registry/findRelayChain';
 import { parseRegistry } from './registry/parseRegistry';
 import type { ChainInfoRegistry } from './registry/types';
@@ -86,6 +91,12 @@ export class AssetsTransferApi {
 		amounts: string[],
 		opts?: TransferArgsOpts<T>
 	): Promise<TxResult<T>> {
+		/**
+		 * Ensure all the inputs are the corrects primitive and or object types.
+		 * It will throw an error if any are incorrect.
+		 */
+		checkBaseInputTypes(destChainId, destAddr, assetIds, amounts);
+
 		const { _api, _info, _safeXcmVersion, _registry } = this;
 		const { specName } = await _info;
 		const safeXcmVersion = await _safeXcmVersion;

--- a/src/errors/checkBaseInputTypes.spec.ts
+++ b/src/errors/checkBaseInputTypes.spec.ts
@@ -1,0 +1,74 @@
+import { checkBaseInputTypes } from './checkBaseInputTypes';
+
+describe('checkBaseInputTypes', () => {
+	it('Should error when destChainId is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				1000 as unknown as string,
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				['TST'],
+				['10000000000']
+			);
+
+		expect(err).toThrow(`'destChainId' must be a string. Received: number`);
+	});
+	it('Should error when destAddr is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				10000000 as unknown as string,
+				['TST'],
+				['10000000000']
+			);
+
+		expect(err).toThrow(`'destAddr' must be a string. Received: number`);
+	});
+	it('Should error when assetIds is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				'TST' as unknown as string[],
+				['10000000000']
+			);
+
+		expect(err).toThrow(`'assetIds' must be a array. Received: string`);
+	});
+	it('Should error when assetIds has the wrong types in the array', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				[1] as unknown as string[],
+				['10000000000']
+			);
+
+		expect(err).toThrow(
+			`All inputs in the 'assetIds' array must be strings: Received: a number at index 0`
+		);
+	});
+	it('Should error when amounts is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				['TST'],
+				10000000000 as unknown as string[]
+			);
+
+		expect(err).toThrow(`'amounts' must be a array. Received: number`);
+	});
+	it('Should error when amounts has the wrong types in the array', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				['TST'],
+				[10000000000] as unknown as string[]
+			);
+
+		expect(err).toThrow(
+			`All inputs in the 'amounts' array must be strings: Received: a number at index 0`
+		);
+	});
+});

--- a/src/errors/checkBaseInputTypes.ts
+++ b/src/errors/checkBaseInputTypes.ts
@@ -2,6 +2,14 @@
 
 import { BaseError } from './BaseError';
 
+/**
+ * Check the base types for the inputs for createTransferTransaction
+ *
+ * @param destChainId
+ * @param destAddr
+ * @param assetIds
+ * @param amounts
+ */
 export const checkBaseInputTypes = (
 	destChainId: string,
 	destAddr: string,
@@ -25,7 +33,7 @@ export const checkBaseInputTypes = (
 			`'assetIds' must be a array. Received: ${typeof assetIds}`
 		);
 	} else {
-		for (let i = 0; i < assetIds.length - 1; i++) {
+		for (let i = 0; i < assetIds.length; i++) {
 			if (typeof assetIds[i] !== 'string') {
 				throw new BaseError(
 					`All inputs in the 'assetIds' array must be strings: Received: a ${typeof assetIds[
@@ -38,10 +46,10 @@ export const checkBaseInputTypes = (
 
 	if (!Array.isArray(amounts)) {
 		throw new BaseError(
-			`'amounts' must be a array. Received: ${typeof assetIds}`
+			`'amounts' must be a array. Received: ${typeof amounts}`
 		);
 	} else {
-		for (let i = 0; i < amounts.length - 1; i++) {
+		for (let i = 0; i < amounts.length; i++) {
 			if (typeof amounts[i] !== 'string') {
 				throw new BaseError(
 					`All inputs in the 'amounts' array must be strings: Received: a ${typeof amounts[

--- a/src/errors/checkBaseInputTypes.ts
+++ b/src/errors/checkBaseInputTypes.ts
@@ -1,0 +1,54 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { BaseError } from './BaseError';
+
+export const checkBaseInputTypes = (
+	destChainId: string,
+	destAddr: string,
+	assetIds: string[],
+	amounts: string[]
+) => {
+	if (typeof destChainId !== 'string') {
+		throw new BaseError(
+			`'destChainId' must be a string. Received: ${typeof destChainId}`
+		);
+	}
+
+	if (typeof destAddr !== 'string') {
+		throw new BaseError(
+			`'destAddr' must be a string. Received: ${typeof destAddr}`
+		);
+	}
+
+	if (!Array.isArray(assetIds)) {
+		throw new BaseError(
+			`'assetIds' must be a array. Received: ${typeof assetIds}`
+		);
+	} else {
+		for (let i = 0; i < assetIds.length - 1; i++) {
+			if (typeof assetIds[i] !== 'string') {
+				throw new BaseError(
+					`All inputs in the 'assetIds' array must be strings: Received: a ${typeof assetIds[
+						i
+					]} at index ${i}`
+				);
+			}
+		}
+	}
+
+	if (!Array.isArray(amounts)) {
+		throw new BaseError(
+			`'amounts' must be a array. Received: ${typeof assetIds}`
+		);
+	} else {
+		for (let i = 0; i < amounts.length - 1; i++) {
+			if (typeof amounts[i] !== 'string') {
+				throw new BaseError(
+					`All inputs in the 'amounts' array must be strings: Received: a ${typeof amounts[
+						i
+					]} at index ${i}`
+				);
+			}
+		}
+	}
+};

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 export { BaseError } from './BaseError';
+export { checkBaseInputTypes } from './checkBaseInputTypes';
 export { checkLocalTxInput } from './checkLocalTxInputs';
 export { checkXcmTxInputs } from './checkXcmTxInputs';
 export { checkXcmVersion } from './checkXcmVersion';


### PR DESCRIPTION
If the library is used in plain JS, we wont have the same type verification for inputs, therefore we need to enforce the types but adding our own base checks.