### PR TITLE
Rework the Registry to be a public class

### DIFF
--- a/src/AssetsTransferApi.spec.ts
+++ b/src/AssetsTransferApi.spec.ts
@@ -90,7 +90,6 @@ describe('AssetTransferAPI', () => {
 		describe('SystemToRelay', () => {
 			it('Should corectly return Native', () => {
 				const assetType = systemAssetsApi['fetchAssetType'](
-					'statemint',
 					'0',
 					['DOT'],
 					Direction.SystemToRelay
@@ -102,7 +101,6 @@ describe('AssetTransferAPI', () => {
 		describe('RelayToSystem', () => {
 			it('Should correctly return Native', () => {
 				const assetType = systemAssetsApi['fetchAssetType'](
-					'polkadot',
 					'1000',
 					['DOT'],
 					Direction.RelayToSystem
@@ -114,7 +112,6 @@ describe('AssetTransferAPI', () => {
 		describe('SystemToPara', () => {
 			it('Should correctly return Foreign', () => {
 				const assetType = systemAssetsApi['fetchAssetType'](
-					'statemint',
 					'2000',
 					['1'],
 					Direction.SystemToPara

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -8,14 +8,7 @@ import type {
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 
-type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
-	T,
-	Exclude<keyof T, Keys>
-> &
-	{
-		[K in Keys]-?: Required<Pick<T, K>> &
-			Partial<Record<Exclude<Keys, K>, undefined>>;
-	}[Keys];
+import type { RequireOnlyOne } from '../types';
 
 export interface ICreateXcmType {
 	createBeneficiary: (

--- a/src/errors/checkLocalTxInputs.spec.ts
+++ b/src/errors/checkLocalTxInputs.spec.ts
@@ -1,47 +1,43 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
-import { parseRegistry } from '../registry/parseRegistry';
+import { Registry } from '../registry';
 import { checkLocalTxInput } from './checkLocalTxInputs';
 
 describe('checkLocalTxInput', () => {
-	const registry = parseRegistry({});
+	const registry = new Registry('statemine', {});
 
 	it('Should correctly return Balances with an empty assetIds', () => {
-		const res = checkLocalTxInput([], ['10000'], 'statemine', registry);
+		const res = checkLocalTxInput([], ['10000'], registry);
 		expect(res).toEqual('Balances');
 	});
 	it('Should correctly return Balances with a native token', () => {
-		const res = checkLocalTxInput(['KSM'], ['10000'], 'statemine', registry);
+		const res = checkLocalTxInput(['KSM'], ['10000'], registry);
 		expect(res).toEqual('Balances');
 	});
 	it('Should correctly return Assets with a valid assetId', () => {
-		const res = checkLocalTxInput(['1984'], ['10000'], 'statemine', registry);
+		const res = checkLocalTxInput(['1984'], ['10000'], registry);
 		expect(res).toEqual('Assets');
 	});
 	it('Should correctly throw an error for incorrect length on `assetIds`', () => {
-		const err = () =>
-			checkLocalTxInput(['1', '2'], ['10000'], 'statemine', registry);
+		const err = () => checkLocalTxInput(['1', '2'], ['10000'], registry);
 		expect(err).toThrowError(
 			'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1'
 		);
 	});
 	it('Should correctly throw an error for incorrect length on `amounts`', () => {
-		const err = () =>
-			checkLocalTxInput(['1'], ['10000', '20000'], 'statemine', registry);
+		const err = () => checkLocalTxInput(['1'], ['10000', '20000'], registry);
 		expect(err).toThrowError(
 			'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1'
 		);
 	});
 	it('Should correctly throw an error with an incorrect assetId', () => {
-		const err = () =>
-			checkLocalTxInput(['TST'], ['10000'], 'statemine', registry);
+		const err = () => checkLocalTxInput(['TST'], ['10000'], registry);
 		expect(err).toThrowError(
 			'The assetId passed in is not a valid number: TST'
 		);
 	});
 	it("Should correctly throw an error when the assetId doesn't exist", () => {
-		const err = () =>
-			checkLocalTxInput(['9876111'], ['10000'], 'statemine', registry);
+		const err = () => checkLocalTxInput(['9876111'], ['10000'], registry);
 		expect(err).toThrowError(
 			'The assetId 9876111 does not exist in the registry.'
 		);

--- a/src/errors/checkLocalTxInputs.ts
+++ b/src/errors/checkLocalTxInputs.ts
@@ -1,8 +1,7 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { SYSTEM_PARACHAINS_IDS } from '../consts';
-import { findRelayChain } from '../registry/findRelayChain';
-import type { ChainInfoRegistry } from '../registry/types';
+import { Registry } from '../registry';
 import { BaseError } from './BaseError';
 
 enum LocalTxType {
@@ -20,11 +19,9 @@ enum LocalTxType {
 export const checkLocalTxInput = (
 	assetIds: string[],
 	amounts: string[],
-	specName: string,
-	registry: ChainInfoRegistry
+	registry: Registry
 ): LocalTxType => {
-	const relayChain = findRelayChain(specName, registry);
-	const relayChainInfo = registry[relayChain];
+	const relayChainInfo = registry.currentRelayRegistry;
 	const systemParachainInfo = relayChainInfo[SYSTEM_PARACHAINS_IDS[0]];
 
 	// Ensure the lengths in assetIds and amounts is correct

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -1,7 +1,6 @@
-import { ChainInfoRegistry } from 'src/registry/types';
+// Copyright 2023 Parity Technologies (UK) Ltd.
 
-import { findRelayChain } from '../registry/findRelayChain';
-import { parseRegistry } from '../registry/parseRegistry';
+import { Registry } from '../registry';
 import { Direction } from '../types';
 import {
 	checkAssetIdInput,
@@ -10,11 +9,11 @@ import {
 	checkRelayAssetIdLength,
 } from './checkXcmTxInputs';
 
-const runTests = (tests: Test[], registry: ChainInfoRegistry) => {
+const runTests = (tests: Test[]) => {
 	for (const test of tests) {
 		const [destChainId, specName, testInputs, direction, errorMessage] = test;
-		const relayChainName = findRelayChain(specName, registry);
-		const currentRegistry = registry[relayChainName];
+		const registry = new Registry(specName, {});
+		const currentRegistry = registry.currentRelayRegistry;
 
 		const err = () =>
 			checkAssetIdInput(
@@ -67,8 +66,6 @@ type Test = [
 
 describe('checkAssetIds', () => {
 	it('Should error when an assetId is found that is empty or a blank space', () => {
-		const registry = parseRegistry({});
-
 		const tests: Test[] = [
 			[
 				'1000',
@@ -86,12 +83,10 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		runTests(tests, registry);
+		runTests(tests);
 	});
 
 	it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', () => {
-		const registry = parseRegistry({});
-
 		const tests: Test[] = [
 			[
 				'1000',
@@ -116,12 +111,10 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		runTests(tests, registry);
+		runTests(tests);
 	});
 
 	it('Should error when direction is RelayToPara and assetId does not match relay chains native token', () => {
-		const registry = parseRegistry({});
-
 		const tests: Test[] = [
 			[
 				'2004',
@@ -139,12 +132,10 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		runTests(tests, registry);
+		runTests(tests);
 	});
 
 	it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', () => {
-		const registry = parseRegistry({});
-
 		const tests: Test[] = [
 			[
 				'0',
@@ -169,12 +160,10 @@ describe('checkAssetIds', () => {
 			],
 		];
 
-		runTests(tests, registry);
+		runTests(tests);
 	});
 
 	it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', () => {
-		const registry = parseRegistry({});
-
 		const tests: Test[] = [
 			[
 				'2004',
@@ -201,8 +190,8 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
 			const err = () =>
 				checkAssetIdInput(
@@ -217,8 +206,6 @@ describe('checkAssetIds', () => {
 	});
 
 	it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', () => {
-		const registry = parseRegistry({});
-
 		const tests: Test[] = [
 			[
 				'2004',
@@ -245,8 +232,8 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [destChainId, specName, testInputs, direction, errorMessage] = test;
-			const relayChainName = findRelayChain(specName, registry);
-			const currentRegistry = registry[relayChainName];
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
 			const err = () =>
 				checkAssetIdInput(

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -1,6 +1,6 @@
 import { RELAY_CHAIN_IDS, SYSTEM_PARACHAINS_IDS } from '../consts';
-import { findRelayChain } from '../registry/findRelayChain';
-import type { ChainInfo, ChainInfoRegistry } from '../registry/types';
+import { Registry } from '../registry';
+import type { ChainInfo } from '../registry/types';
 import { Direction } from '../types';
 import { BaseError } from './BaseError';
 
@@ -277,10 +277,9 @@ export const checkXcmTxInputs = (
 	xcmDirection: Direction,
 	destChainId: string,
 	specName: string,
-	registry: ChainInfoRegistry
+	registry: Registry
 ) => {
-	const relayChainName = findRelayChain(specName, registry);
-	const relayChainInfo: ChainInfo = registry[relayChainName];
+	const relayChainInfo = registry.currentRelayRegistry;
 	/**
 	 * Checks to ensure that assetId's are either valid integer numbers or native asset token symbols
 	 */

--- a/src/registry/Registry.spec.ts
+++ b/src/registry/Registry.spec.ts
@@ -68,12 +68,14 @@ describe('Registry', () => {
 	describe('lookupParachainInfo', () => {
 		it('Should return the correct result', () => {
 			const res = registry.lookupParachainInfo('2000');
-			const expected = [{
-				tokens: ['ACA', 'AUSD', 'DOT', 'LDOT'],
-				assetsInfo: {},
-				specName: 'acala',
-                chainId: '2000'
-			}];
+			const expected = [
+				{
+					tokens: ['ACA', 'AUSD', 'DOT', 'LDOT'],
+					assetsInfo: {},
+					specName: 'acala',
+					chainId: '2000',
+				},
+			];
 			expect(res).toEqual(expected);
 		});
 	});

--- a/src/registry/Registry.spec.ts
+++ b/src/registry/Registry.spec.ts
@@ -1,0 +1,80 @@
+import { Registry } from './Registry';
+
+describe('Registry', () => {
+	const registry = new Registry('polkadot', {});
+	describe('lookupTokenSymbol', () => {
+		it('Should return the correct result', () => {
+			const res = registry.lookupTokenSymbol('GLMR');
+			const expected = [
+				{
+					tokens: ['GLMR'],
+					assetsInfo: {},
+					specName: 'moonbeam',
+					chainId: '2004',
+				},
+			];
+			expect(res).toEqual(expected);
+		});
+	});
+	describe('lookupAssetId', () => {
+		it('Should return the correct result', () => {
+			const res = registry.lookupAssetId('1984');
+			const expected = [
+				{
+					tokens: ['DOT'],
+					assetsInfo: {
+						'1': 'no1',
+						'2': 'BTC',
+						'3': 'DOT',
+						'4': 'EFI',
+						'5': 'PLX',
+						'6': 'LPHP',
+						'7': 'lucky7',
+						'8': 'JOE',
+						'9': 'PINT',
+						'10': 'BEAST',
+						'11': 'web3',
+						'21': 'WBTC',
+						'77': 'TRQ',
+						'100': 'WETH',
+						'101': 'DOTMA',
+						'123': '123',
+						'666': 'DANGER',
+						'777': '777',
+						'999': 'gold',
+						'1000': 'BRZ',
+						'1337': 'USDC',
+						'1984': 'USDt',
+						'862812': 'CUBO',
+						'868367': 'VSC',
+						'20090103': 'BTC',
+					},
+					specName: 'statemint',
+					chainId: '1000',
+				},
+			];
+			expect(res).toEqual(expected);
+		});
+	});
+	describe('lookupParachainId', () => {
+		it('Should return the correct result', () => {
+			const res1 = registry.lookupParachainId('1000');
+			const res2 = registry.lookupParachainId('999999');
+
+			expect(res1).toEqual(true);
+			expect(res2).toEqual(false);
+		});
+	});
+	describe('lookupParachainInfo', () => {
+		it('Should return the correct result', () => {
+			const res = registry.lookupParachainInfo('2000');
+			const expected = [{
+				tokens: ['ACA', 'AUSD', 'DOT', 'LDOT'],
+				assetsInfo: {},
+				specName: 'acala',
+                chainId: '2000'
+			}];
+			expect(res).toEqual(expected);
+		});
+	});
+});

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -1,0 +1,79 @@
+import type { AssetsTransferApiOpts } from '../types';
+import { findRelayChain, parseRegistry } from './';
+import type {
+	ChainInfo,
+	ChainInfoRegistry,
+	ExpandedChainInfoKeys,
+	RelayChains,
+} from './types';
+
+export class Registry {
+	readonly specName: string;
+	readonly registry: ChainInfoRegistry;
+	readonly relayChain: RelayChains;
+	readonly currentRelayRegistry: ChainInfo;
+
+	constructor(specName: string, opts: AssetsTransferApiOpts) {
+		this.specName = specName;
+		this.registry = parseRegistry(opts);
+		this.relayChain = findRelayChain(this.specName, this.registry);
+		this.currentRelayRegistry = this.registry[this.relayChain];
+	}
+
+	public get getRegistry() {
+		return this.registry;
+	}
+
+	public get getRelayChain() {
+		return this.relayChain;
+	}
+
+	public get getRelaysRegistry() {
+		return this.currentRelayRegistry;
+	}
+
+	public lookupTokenSymbol(symbol: string): ExpandedChainInfoKeys[] {
+		const chainIds = Object.keys(this.currentRelayRegistry);
+		const result = [];
+
+		for (let i = 0; i < chainIds.length; i++) {
+			const chainInfo = this.currentRelayRegistry[chainIds[i]];
+			if (chainInfo.tokens.includes(symbol)) {
+				result.push(Object.assign({}, chainInfo, { chainId: chainIds[i] }));
+			}
+		}
+
+		return result;
+	}
+
+	public lookupAssetId(id: string) {
+		const chainIds = Object.keys(this.currentRelayRegistry);
+		const result = [];
+
+		for (let i = 0; i < chainIds.length; i++) {
+			const chainInfo = this.currentRelayRegistry[chainIds[i]];
+			if (Object.keys(chainInfo.assetsInfo).includes(id)) {
+				result.push(Object.assign({}, chainInfo, { chainId: chainIds[i] }));
+			}
+		}
+
+		return result;
+	}
+
+	public lookupParachainId(id: string): boolean {
+		const chainIds = Object.keys(this.currentRelayRegistry);
+		if (chainIds.includes(id)) return true;
+
+		return false;
+	}
+
+	public lookupParachainInfo(id: string): ExpandedChainInfoKeys[] {
+		const chainIds = Object.keys(this.currentRelayRegistry);
+		if (chainIds.includes(id)) {
+			return [
+				Object.assign({}, this.currentRelayRegistry[id], { chainId: id }),
+			];
+		}
+		return [];
+	}
+}

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -20,18 +20,34 @@ export class Registry {
 		this.currentRelayRegistry = this.registry[this.relayChain];
 	}
 
+	/**
+	 * Getter for the complete registry.
+	 */
 	public get getRegistry() {
 		return this.registry;
 	}
 
+	/**
+	 * Getter for the name of the relay chain for this network.
+	 */
 	public get getRelayChain() {
 		return this.relayChain;
 	}
 
+	/**
+	 * Getter for the registry associated with this networks relay chain.
+	 */
 	public get getRelaysRegistry() {
 		return this.currentRelayRegistry;
 	}
 
+	/**
+	 * Lookup all chains that have the following token symbol. It will return an array
+	 * with all the chains that have the following token symbols. Note this will only
+	 * be searched in the respective relay chains registry.
+	 *
+	 * @param symbol Token symbol to lookup
+	 */
 	public lookupTokenSymbol(symbol: string): ExpandedChainInfoKeys[] {
 		const chainIds = Object.keys(this.currentRelayRegistry);
 		const result = [];
@@ -46,6 +62,13 @@ export class Registry {
 		return result;
 	}
 
+	/**
+	 * Lookup all chains that have the following assetId. It will return an array
+	 * with all the chains that have the following AssetId. Note this will only
+	 * be searched in the respective relay chains registry.
+	 *
+	 * @param id AssetId to lookup
+	 */
 	public lookupAssetId(id: string) {
 		const chainIds = Object.keys(this.currentRelayRegistry);
 		const result = [];
@@ -60,6 +83,11 @@ export class Registry {
 		return result;
 	}
 
+	/**
+	 * Check whether a parachain id exists within the relay chains registry.
+	 *
+	 * @param id Id of the parachain
+	 */
 	public lookupParachainId(id: string): boolean {
 		const chainIds = Object.keys(this.currentRelayRegistry);
 		if (chainIds.includes(id)) return true;
@@ -67,6 +95,11 @@ export class Registry {
 		return false;
 	}
 
+	/**
+	 * Return the info for a parachain within a relay chains registry.
+	 *
+	 * @param id
+	 */
 	public lookupParachainInfo(id: string): ExpandedChainInfoKeys[] {
 		const chainIds = Object.keys(this.currentRelayRegistry);
 		if (chainIds.includes(id)) {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,2 +1,3 @@
 export { findRelayChain } from './findRelayChain';
 export { parseRegistry } from './parseRegistry';
+export { Registry } from './Registry';

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,15 +1,19 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
-interface AssetsInfo {
+export interface AssetsInfo {
 	[key: string]: string;
 }
 
+export interface ChainInfoKeys {
+	specName: string;
+	tokens: string[];
+	assetsInfo: AssetsInfo;
+}
+
+export type ExpandedChainInfoKeys = { chainId: string } & ChainInfoKeys;
+
 export type ChainInfo = {
-	[x: string]: {
-		specName: string;
-		tokens: string[];
-		assetsInfo: AssetsInfo;
-	};
+	[x: string]: ChainInfoKeys;
 };
 
 export type ChainInfoRegistry = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,15 @@ import type { ISubmittableResult } from '@polkadot/types/types';
 
 import type { ChainInfoRegistry } from './registry/types';
 
+export type RequireOnlyOne<T, Keys extends keyof T = keyof T> = Pick<
+	T,
+	Exclude<keyof T, Keys>
+> &
+	{
+		[K in Keys]-?: Required<Pick<T, K>> &
+			Partial<Record<Exclude<Keys, K>, undefined>>;
+	}[Keys];
+
 export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
 	T,
 	Exclude<keyof T, Keys>


### PR DESCRIPTION
## Summary

I reworked the registry to save on performance, and memory while also exposing a bunch of public functions to the user. 

### Exposed functions from the registry

```typescript
// Getter for the complete registry
public get getRegistry

// Getter for the name of the relay chain for this network
public get getRelayChain

// Getter for the registry associated with this networks relay chain
public get getRelaysRegistry

// Lookup all chains that have the following token symbol. It will return an array
// with all the chains that have the following token symbols. Note this will only
// be searched in the respective relay chains registry.
public lookupTokenSymbol(symbol: string)

// Lookup all chains that have the following assetId. It will return an array
// with all the chains that have the following AssetId. Note this will only
// be searched in the respective relay chains registry.
public lookupAssetId(id: string)

// Check whether a parachain id exists within the relay chains registry.
public lookupParachainId(id: string)

// Return the info for a parachain within a relay chains registry.
public lookupParachainInfo(id: string)
```