### PR TITLE
Rethread Registry down to createAssets, and createFeeAssetItem as an option

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -200,6 +200,7 @@ export class AssetsTransferApi {
 					destChainId,
 					xcmVersion,
 					_specName,
+					this.registry,
 					opts?.weightLimit,
 					opts?.paysWithFeeDest
 				);
@@ -214,6 +215,7 @@ export class AssetsTransferApi {
 					destChainId,
 					xcmVersion,
 					_specName,
+					this.registry,
 					opts?.paysWithFeeDest
 				);
 			}
@@ -229,6 +231,7 @@ export class AssetsTransferApi {
 					destChainId,
 					xcmVersion,
 					_specName,
+					this.registry,
 					opts?.weightLimit
 				);
 			} else {
@@ -241,7 +244,8 @@ export class AssetsTransferApi {
 					amounts,
 					destChainId,
 					xcmVersion,
-					_specName
+					_specName,
+					this.registry
 				);
 			}
 		}

--- a/src/createXcmCalls/limitedReserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/limitedReserveTransferAssets.spec.ts
@@ -2,11 +2,13 @@
 
 import type { ApiPromise } from '@polkadot/api';
 
+import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { Direction } from '../types';
 import { limitedReserveTransferAssets } from './limitedReserveTransferAssets';
 
 describe('limitedReserveTransferAssets', () => {
+	const registry = new Registry('statemine', {});
 	describe('SystemToPara', () => {
 		it('Should correctly construct a tx for a system parachain with V2', () => {
 			const ext = limitedReserveTransferAssets(
@@ -17,7 +19,8 @@ describe('limitedReserveTransferAssets', () => {
 				['100'],
 				'1000',
 				2,
-				'statemint'
+				'statemint',
+				registry
 			);
 
 			expect(ext.toHex()).toBe(
@@ -34,6 +37,7 @@ describe('limitedReserveTransferAssets', () => {
 				'1000',
 				2,
 				'statemint',
+				registry,
 				'1000000000'
 			);
 
@@ -52,7 +56,8 @@ describe('limitedReserveTransferAssets', () => {
 					['100'],
 					'1000',
 					2,
-					'statemint'
+					'statemint',
+					registry
 				);
 
 			expect(err).toThrowError(

--- a/src/createXcmCalls/limitedReserveTransferAssets.ts
+++ b/src/createXcmCalls/limitedReserveTransferAssets.ts
@@ -6,6 +6,7 @@ import { u32 } from '@polkadot/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { createXcmTypes } from '../createXcmTypes';
+import type { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { establishXcmPallet } from './util/establishXcmPallet';
@@ -31,6 +32,7 @@ export const limitedReserveTransferAssets = (
 	destChainId: string,
 	xcmVersion: number,
 	specName: string,
+	registry: Registry,
 	weightLimit?: string,
 	paysWithFeeDest?: string
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
@@ -44,19 +46,20 @@ export const limitedReserveTransferAssets = (
 		normalizeArrToStr(amounts),
 		xcmVersion,
 		specName,
-		assetIds
+		assetIds,
+		{ registry }
 	);
 	const weightLimitType = typeCreator.createWeightLimit(api, weightLimit);
 
 	const feeAssetItem: u32 = paysWithFeeDest
-		? typeCreator.createFeeAssetItem(
-				api,
+		? typeCreator.createFeeAssetItem(api, {
+				registry,
 				paysWithFeeDest,
 				specName,
 				assetIds,
 				amounts,
-				xcmVersion
-		  )
+				xcmVersion,
+		  })
 		: api.registry.createType('u32', 0);
 
 	return ext(dest, beneficiary, assets, feeAssetItem, weightLimitType);

--- a/src/createXcmCalls/limitedTeleportAssets.spec.ts
+++ b/src/createXcmCalls/limitedTeleportAssets.spec.ts
@@ -1,10 +1,12 @@
 import type { ApiPromise } from '@polkadot/api';
 
+import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { Direction } from '../types';
 import { limitedTeleportAssets } from './limitedTeleportAssets';
 
 describe('limitedTeleportAssets', () => {
+	const registry = new Registry('statemine', {});
 	describe('SystemToPara', () => {
 		it('Should correctly construct a tx for a system parachain with V2', () => {
 			const ext = limitedTeleportAssets(
@@ -15,7 +17,8 @@ describe('limitedTeleportAssets', () => {
 				['100'],
 				'1000',
 				2,
-				'statemint'
+				'statemint',
+				registry
 			);
 
 			expect(ext.toHex()).toBe(
@@ -33,7 +36,8 @@ describe('limitedTeleportAssets', () => {
 					['100'],
 					'1000',
 					2,
-					'statemint'
+					'statemint',
+					registry
 				);
 
 			expect(err).toThrowError(

--- a/src/createXcmCalls/limitedTeleportAssets.ts
+++ b/src/createXcmCalls/limitedTeleportAssets.ts
@@ -5,6 +5,7 @@ import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { createXcmTypes } from '../createXcmTypes';
+import type { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { establishXcmPallet } from './util/establishXcmPallet';
@@ -29,6 +30,7 @@ export const limitedTeleportAssets = (
 	destChainId: string,
 	xcmVersion: number,
 	specName: string,
+	registry: Registry,
 	weightLimit?: string,
 	paysWithFeeDest?: string
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
@@ -42,12 +44,13 @@ export const limitedTeleportAssets = (
 		normalizeArrToStr(amounts),
 		xcmVersion,
 		specName,
-		assetIds
+		assetIds,
+		{ registry }
 	);
 	const weightLimitType = typeCreator.createWeightLimit(api, weightLimit);
 
 	const feeAssetItem = paysWithFeeDest
-		? typeCreator.createFeeAssetItem(api)
+		? typeCreator.createFeeAssetItem(api, { registry })
 		: api.registry.createType('u32', 0);
 
 	return ext(dest, beneficiary, assets, feeAssetItem, weightLimitType);

--- a/src/createXcmCalls/reserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/reserveTransferAssets.spec.ts
@@ -2,11 +2,13 @@
 
 import type { ApiPromise } from '@polkadot/api';
 
+import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { Direction } from '../types';
 import { reserveTransferAssets } from './reserveTransferAssets';
 
 describe('reserveTransferAssets', () => {
+	const registry = new Registry('statemine', {});
 	describe('SystemToPara', () => {
 		it('Should correctly construct a tx for a system parachain with V2', () => {
 			const ext = reserveTransferAssets(
@@ -17,7 +19,8 @@ describe('reserveTransferAssets', () => {
 				['100'],
 				'1000',
 				2,
-				'statemint'
+				'statemint',
+				registry
 			);
 
 			expect(ext.toHex()).toBe(
@@ -35,7 +38,8 @@ describe('reserveTransferAssets', () => {
 					['100'],
 					'1000',
 					2,
-					'statemint'
+					'statemint',
+					registry
 				);
 
 			expect(err).toThrowError(

--- a/src/createXcmCalls/reserveTransferAssets.ts
+++ b/src/createXcmCalls/reserveTransferAssets.ts
@@ -5,6 +5,7 @@ import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { createXcmTypes } from '../createXcmTypes';
+import type { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { establishXcmPallet } from './util/establishXcmPallet';
@@ -29,6 +30,7 @@ export const reserveTransferAssets = (
 	destChainId: string,
 	xcmVersion: number,
 	specName: string,
+	registry: Registry,
 	paysWithFeeDest?: string
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
 	const pallet = establishXcmPallet(api);
@@ -41,18 +43,19 @@ export const reserveTransferAssets = (
 		normalizeArrToStr(amounts),
 		xcmVersion,
 		specName,
-		assetIds
+		assetIds,
+		{ registry }
 	);
 
 	const feeAssetItem = paysWithFeeDest
-		? typeCreator.createFeeAssetItem(
-				api,
+		? typeCreator.createFeeAssetItem(api, {
+				registry,
 				paysWithFeeDest,
 				specName,
 				assetIds,
 				amounts,
-				xcmVersion
-		  )
+				xcmVersion,
+		  })
 		: api.registry.createType('u32', 0);
 
 	return ext(dest, beneficiary, assets, feeAssetItem);

--- a/src/createXcmCalls/teleportAssets.spec.ts
+++ b/src/createXcmCalls/teleportAssets.spec.ts
@@ -1,10 +1,12 @@
 import type { ApiPromise } from '@polkadot/api';
 
+import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { Direction } from '../types';
 import { teleportAssets } from './teleportAssets';
 
 describe('teleportAssets', () => {
+	const registry = new Registry('statemine', {});
 	describe('SystemToPara', () => {
 		it('Should correctly construct a tx for a system parachain with V2', () => {
 			const ext = teleportAssets(
@@ -15,7 +17,8 @@ describe('teleportAssets', () => {
 				['100'],
 				'1000',
 				2,
-				'statemint'
+				'statemint',
+				registry
 			);
 
 			expect(ext.toHex()).toBe(
@@ -33,7 +36,8 @@ describe('teleportAssets', () => {
 					['100'],
 					'1000',
 					2,
-					'statemint'
+					'statemint',
+					registry
 				);
 
 			expect(err).toThrowError(

--- a/src/createXcmCalls/teleportAssets.ts
+++ b/src/createXcmCalls/teleportAssets.ts
@@ -5,6 +5,7 @@ import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { createXcmTypes } from '../createXcmTypes';
+import { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { establishXcmPallet } from './util/establishXcmPallet';
@@ -29,6 +30,7 @@ export const teleportAssets = (
 	destChainId: string,
 	xcmVersion: number,
 	specName: string,
+	registry: Registry,
 	paysWithFeeDest?: string
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
 	const pallet = establishXcmPallet(api);
@@ -41,11 +43,12 @@ export const teleportAssets = (
 		normalizeArrToStr(amounts),
 		xcmVersion,
 		specName,
-		assetIds
+		assetIds,
+		{ registry }
 	);
 
 	const feeAssetItem = paysWithFeeDest
-		? typeCreator.createFeeAssetItem(api)
+		? typeCreator.createFeeAssetItem(api, { registry })
 		: api.registry.createType('u32', 0);
 
 	return ext(dest, beneficiary, assets, feeAssetItem);

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -1,9 +1,11 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { Registry } from '../registry';
 import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { RelayToPara } from './RelayToPara';
 
 describe('RelayToPara XcmVersioned Generation', () => {
+	const registry = new Registry('kusama', {});
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = RelayToPara.createBeneficiary(
@@ -139,7 +141,14 @@ describe('RelayToPara XcmVersioned Generation', () => {
 	});
 	describe('Assets', () => {
 		it('Should work for V2', () => {
-			const assets = RelayToPara.createAssets(mockRelayApi, ['100'], 2, '', []);
+			const assets = RelayToPara.createAssets(
+				mockRelayApi,
+				['100'],
+				2,
+				'',
+				[],
+				{ registry }
+			);
 
 			const expectedRes = {
 				v2: [
@@ -162,7 +171,14 @@ describe('RelayToPara XcmVersioned Generation', () => {
 			expect(assets.toJSON()).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const assets = RelayToPara.createAssets(mockRelayApi, ['100'], 3, '', []);
+			const assets = RelayToPara.createAssets(
+				mockRelayApi,
+				['100'],
+				3,
+				'',
+				[],
+				{ registry }
+			);
 
 			const expectedRes = {
 				v3: [

--- a/src/createXcmTypes/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/RelayToSystem.spec.ts
@@ -1,9 +1,11 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { Registry } from '../registry';
 import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { RelayToSystem } from './RelayToSystem';
 
 describe('RelayToSystem XcmVersioned Generation', () => {
+	const registry = new Registry('kusama', {});
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = RelayToSystem.createBeneficiary(
@@ -96,7 +98,8 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 				['100'],
 				2,
 				'',
-				[]
+				[],
+				{ registry }
 			);
 
 			const expectedRes = {
@@ -125,7 +128,8 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 				['100'],
 				3,
 				'',
-				[]
+				[],
+				{ registry }
 			);
 
 			const expectedRes = {

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -1,11 +1,13 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { MultiAsset } from '../types';
 import { SystemToPara } from './SystemToPara';
 import { createSystemToParaMultiAssets } from './SystemToPara';
 
 describe('SystemToPara XcmVersioned Generation', () => {
+	const registry = new Registry('statemine', {});
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = SystemToPara.createBeneficiary(
@@ -147,7 +149,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				['100', '100'],
 				2,
 				'statemint',
-				['1', '2']
+				['1', '2'],
+				{ registry }
 			);
 
 			const expectedRes = {
@@ -189,7 +192,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				['100', '100'],
 				3,
 				'statemint',
-				['1', '2']
+				['1', '2'],
+				{ registry }
 			);
 
 			const expectedRes = {
@@ -285,7 +289,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				mockSystemApi,
 				amounts,
 				specName,
-				assets
+				assets,
+				registry
 			);
 
 			expect(result).toEqual(expected);

--- a/src/createXcmTypes/SystemToRelay.spec.ts
+++ b/src/createXcmTypes/SystemToRelay.spec.ts
@@ -1,9 +1,12 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToRelay } from './SystemToRelay';
 
 describe('SystemToRelay XcmVersioned Generation', () => {
+	const registry = new Registry('statemine', {});
+
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = SystemToRelay.createBeneficiary(
@@ -91,7 +94,8 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 				['100'],
 				2,
 				'',
-				[]
+				[],
+				{ registry }
 			);
 
 			const expectedRes = {
@@ -120,7 +124,8 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 				['100'],
 				3,
 				'',
-				[]
+				[],
+				{ registry }
 			);
 
 			const expectedRes = {

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -8,7 +8,21 @@ import type {
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 
+import type { Registry } from '../registry';
 import type { RequireOnlyOne } from '../types';
+
+export interface CreateAssetsOpts {
+	registry: Registry;
+}
+
+export interface CreateFeeAssetItemOpts {
+	registry: Registry;
+	paysWithFeeDest?: string;
+	specName?: string;
+	assetIds?: string[];
+	amounts?: string[];
+	xcmVersion?: number;
+}
 
 export interface ICreateXcmType {
 	createBeneficiary: (
@@ -26,17 +40,11 @@ export interface ICreateXcmType {
 		amounts: string[],
 		xcmVersion: number,
 		specName: string,
-		assets: string[]
+		assets: string[],
+		opts: CreateAssetsOpts
 	) => VersionedMultiAssets;
 	createWeightLimit: (api: ApiPromise, weightLimit?: string) => WeightLimitV2;
-	createFeeAssetItem: (
-		api: ApiPromise,
-		paysWithFeeDest?: string,
-		specName?: string,
-		assetIds?: string[],
-		amounts?: string[],
-		xcmVersion?: number
-	) => u32;
+	createFeeAssetItem: (api: ApiPromise, opts: CreateFeeAssetItemOpts) => u32;
 }
 
 interface IWeightLimitBase {


### PR DESCRIPTION
This rethreads the `registry` as an `opt` down to `SystemToPara` in order to avoid calling `parseRegistry`.

The layers of threading are:

`AssetTransferApi` -> `extrinsic call` -> `createXcmTypes`