### PR TITLE
Update all examples with decoding and colors

### DIFF
--- a/examples/colors.ts
+++ b/examples/colors.ts
@@ -1,0 +1,4 @@
+export const GREEN = '\u001b[32m';
+export const CYAN = '\u001b[36m';
+export const PURPLE = '\u001b[35m';
+export const RESET = '\u001b[0m';

--- a/examples/relayToPara.ts
+++ b/examples/relayToPara.ts
@@ -4,6 +4,8 @@
  * import { AssetsTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetsTransferApi, constructApiPromise } from '../src';
+import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 KSM from a Kusama (Relay Chain) account
@@ -17,9 +19,9 @@ const main = async () => {
 		'wss://kusama-rpc.polkadot.io'
 	);
 	const assetApi = new AssetsTransferApi(api, specName, safeXcmVersion);
-
+	let callInfo: TxResult<'call'>;
 	try {
-		const callInfo = await assetApi.createTransferTransaction(
+		callInfo = await assetApi.createTransferTransaction(
 			'2023',
 			'0xF977814e90dA44bFA03b6295A0616a897441aceC',
 			['KSM'],
@@ -31,10 +33,26 @@ const main = async () => {
 			}
 		);
 
-		console.log(callInfo);
+		console.log(
+			`${PURPLE}The following call data that is returned:\n${GREEN}${JSON.stringify(
+				callInfo,
+				null,
+				4
+			)}`
+		);
 	} catch (e) {
 		console.error(e);
+		throw Error(e as string);
 	}
+
+	const decoded = assetApi.decodeExtrinsic(callInfo.tx, 'call');
+	console.log(
+		`\n${PURPLE}The following decoded tx:\n${GREEN} ${JSON.stringify(
+			JSON.parse(decoded),
+			null,
+			4
+		)}${RESET}`
+	);
 };
 
 main().finally(() => process.exit());

--- a/examples/relayToSystem.ts
+++ b/examples/relayToSystem.ts
@@ -4,6 +4,8 @@
  * import { AssetsTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetsTransferApi, constructApiPromise } from '../src';
+import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 WND from a Westend (Relay Chain) account
@@ -17,9 +19,9 @@ const main = async () => {
 		'wss://westend-rpc.polkadot.io'
 	);
 	const assetApi = new AssetsTransferApi(api, specName, safeXcmVersion);
-
+	let callInfo: TxResult<'call'>;
 	try {
-		const callInfo = await assetApi.createTransferTransaction(
+		callInfo = await assetApi.createTransferTransaction(
 			'1000',
 			'5EWNeodpcQ6iYibJ3jmWVe85nsok1EDG8Kk3aFg8ZzpfY1qX',
 			['WND'],
@@ -31,10 +33,26 @@ const main = async () => {
 			}
 		);
 
-		console.log(callInfo);
+		console.log(
+			`${PURPLE}The following call data that is returned:\n${GREEN}${JSON.stringify(
+				callInfo,
+				null,
+				4
+			)}`
+		);
 	} catch (e) {
 		console.error(e);
+		throw Error(e as string);
 	}
+
+	const decoded = assetApi.decodeExtrinsic(callInfo.tx, 'call');
+	console.log(
+		`\n${PURPLE}The following decoded tx:\n${GREEN} ${JSON.stringify(
+			JSON.parse(decoded),
+			null,
+			4
+		)}${RESET}`
+	);
 };
 
 main().finally(() => process.exit());

--- a/examples/submittable.ts
+++ b/examples/submittable.ts
@@ -8,6 +8,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { AssetsTransferApi, constructApiPromise } from '../src';
 import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example, we are creating a `SubmittableExtrinsic` and showing how one may sign and send it over
@@ -36,7 +37,13 @@ const main = async () => {
 			}
 		);
 
-		console.log(callInfo);
+		console.log(
+			`${PURPLE}The following call data that is returned:\n${GREEN}${JSON.stringify(
+				callInfo,
+				null,
+				4
+			)}${RESET}`
+		);
 	} catch (e) {
 		console.error(e);
 		throw Error(e as string);

--- a/examples/systemToPara.ts
+++ b/examples/systemToPara.ts
@@ -4,6 +4,8 @@
  * import { AssetsTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetsTransferApi, constructApiPromise } from '../src';
+import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 0.1 USDt from a Statemine (System Parachain) account
@@ -18,8 +20,9 @@ const main = async () => {
 	);
 	const assetApi = new AssetsTransferApi(api, specName, safeXcmVersion);
 
+	let callInfo: TxResult<'call'>;
 	try {
-		const callInfo = await assetApi.createTransferTransaction(
+		callInfo = await assetApi.createTransferTransaction(
 			'2023',
 			'0xF977814e90dA44bFA03b6295A0616a897441aceC',
 			['1984'],
@@ -31,10 +34,26 @@ const main = async () => {
 			}
 		);
 
-		console.log(callInfo);
+		console.log(
+			`${PURPLE}The following call data that is returned:\n${GREEN}${JSON.stringify(
+				callInfo,
+				null,
+				4
+			)}`
+		);
 	} catch (e) {
 		console.error(e);
+		throw Error(e as string);
 	}
+
+	const decoded = assetApi.decodeExtrinsic(callInfo.tx, 'call');
+	console.log(
+		`\n${PURPLE}The following decoded tx:\n${GREEN} ${JSON.stringify(
+			JSON.parse(decoded),
+			null,
+			4
+		)}${RESET}`
+	);
 };
 
 main().finally(() => process.exit());

--- a/examples/systemToRelay.ts
+++ b/examples/systemToRelay.ts
@@ -4,6 +4,8 @@
  * import { AssetsTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetsTransferApi, constructApiPromise } from '../src';
+import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 WND from a Westmint (System Parachain) account
@@ -18,8 +20,9 @@ const main = async () => {
 	);
 	const assetApi = new AssetsTransferApi(api, specName, safeXcmVersion);
 
+	let callInfo: TxResult<'call'>;
 	try {
-		const callInfo = await assetApi.createTransferTransaction(
+		callInfo = await assetApi.createTransferTransaction(
 			'0', // NOTE: The destination id is `0` noting that we are sending to the relay chain.
 			'5EWNeodpcQ6iYibJ3jmWVe85nsok1EDG8Kk3aFg8ZzpfY1qX',
 			['WND'],
@@ -34,7 +37,17 @@ const main = async () => {
 		console.log(callInfo);
 	} catch (e) {
 		console.error(e);
+		throw Error(e as string);
 	}
+
+	const decoded = assetApi.decodeExtrinsic(callInfo.tx, 'call');
+	console.log(
+		`\n${PURPLE}The following decoded tx:\n${GREEN} ${JSON.stringify(
+			JSON.parse(decoded),
+			null,
+			4
+		)}${RESET}`
+	);
 };
 
 main().finally(() => process.exit());


### PR DESCRIPTION
rel: https://github.com/paritytech/asset-transfer-api/issues/165

This adds coloring, and decoding examples to all xcmDirections and the submittable example