### PR TITLE
[WIP] feat: add poolAssets support

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -107,6 +107,7 @@ export class AssetsTransferApi {
 			weightLimit,
 			xcmVersion,
 			keepAlive,
+			transferLiquidToken,
 		} = opts;
 		/**
 		 * Ensure all the inputs are the corrects primitive and or object types.
@@ -256,7 +257,7 @@ export class AssetsTransferApi {
 					declaredXcmVersion,
 					_specName,
 					this.registry,
-					{ paysWithFeeDest, weightLimit }
+					{ paysWithFeeDest, weightLimit, transferLiquidToken }
 				);
 			} else {
 				txMethod = 'reserveTransferAssets';
@@ -270,7 +271,7 @@ export class AssetsTransferApi {
 					declaredXcmVersion,
 					_specName,
 					this.registry,
-					{ paysWithFeeDest }
+					{ paysWithFeeDest, transferLiquidToken }
 				);
 			}
 		} else {

--- a/src/createXcmCalls/limitedReserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/limitedReserveTransferAssets.spec.ts
@@ -38,7 +38,7 @@ describe('limitedReserveTransferAssets', () => {
 				2,
 				'statemine',
 				registry,
-				'1000000000'
+				{ weightLimit: '1000000000' }
 			);
 
 			expect(ext.toHex()).toBe(

--- a/src/createXcmCalls/limitedReserveTransferAssets.ts
+++ b/src/createXcmCalls/limitedReserveTransferAssets.ts
@@ -36,7 +36,7 @@ export const limitedReserveTransferAssets = (
 	registry: Registry,
 	opts: CreateXcmCallOpts = {}
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
-	const { paysWithFeeDest, weightLimit } = opts;
+	const { paysWithFeeDest, transferLiquidToken, weightLimit } = opts;
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].limitedReserveTransferAssets;
 	const typeCreator = createXcmTypes[direction];
@@ -48,7 +48,7 @@ export const limitedReserveTransferAssets = (
 		xcmVersion,
 		specName,
 		assetIds,
-		{ registry }
+		{ registry, transferLiquidToken }
 	);
 	const weightLimitType = typeCreator.createWeightLimit(api, weightLimit);
 
@@ -60,6 +60,7 @@ export const limitedReserveTransferAssets = (
 				assetIds,
 				amounts,
 				xcmVersion,
+				transferLiquidToken,
 		  })
 		: api.registry.createType('u32', 0);
 

--- a/src/createXcmCalls/limitedReserveTransferAssets.ts
+++ b/src/createXcmCalls/limitedReserveTransferAssets.ts
@@ -9,6 +9,7 @@ import { createXcmTypes } from '../createXcmTypes';
 import type { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import type { CreateXcmCallOpts } from './types';
 import { establishXcmPallet } from './util/establishXcmPallet';
 
 /**
@@ -33,9 +34,9 @@ export const limitedReserveTransferAssets = (
 	xcmVersion: number,
 	specName: string,
 	registry: Registry,
-	weightLimit?: string,
-	paysWithFeeDest?: string
+	opts: CreateXcmCallOpts = {}
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
+	const { paysWithFeeDest, weightLimit } = opts;
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].limitedReserveTransferAssets;
 	const typeCreator = createXcmTypes[direction];

--- a/src/createXcmCalls/limitedTeleportAssets.ts
+++ b/src/createXcmCalls/limitedTeleportAssets.ts
@@ -8,6 +8,7 @@ import { createXcmTypes } from '../createXcmTypes';
 import type { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import type { CreateXcmCallOpts } from './types';
 import { establishXcmPallet } from './util/establishXcmPallet';
 
 /**
@@ -31,9 +32,9 @@ export const limitedTeleportAssets = (
 	xcmVersion: number,
 	specName: string,
 	registry: Registry,
-	weightLimit?: string,
-	paysWithFeeDest?: string
+	opts: CreateXcmCallOpts = {}
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
+	const { paysWithFeeDest, weightLimit } = opts;
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].limitedTeleportAssets;
 	const typeCreator = createXcmTypes[direction];

--- a/src/createXcmCalls/reserveTransferAssets.ts
+++ b/src/createXcmCalls/reserveTransferAssets.ts
@@ -8,6 +8,7 @@ import { createXcmTypes } from '../createXcmTypes';
 import type { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import type { CreateXcmCallOpts } from './types';
 import { establishXcmPallet } from './util/establishXcmPallet';
 
 /**
@@ -31,8 +32,9 @@ export const reserveTransferAssets = (
 	xcmVersion: number,
 	specName: string,
 	registry: Registry,
-	paysWithFeeDest?: string
+	opts: CreateXcmCallOpts = {}
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
+	const { paysWithFeeDest } = opts;
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].reserveTransferAssets;
 	const typeCreator = createXcmTypes[direction];

--- a/src/createXcmCalls/reserveTransferAssets.ts
+++ b/src/createXcmCalls/reserveTransferAssets.ts
@@ -34,7 +34,7 @@ export const reserveTransferAssets = (
 	registry: Registry,
 	opts: CreateXcmCallOpts = {}
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
-	const { paysWithFeeDest } = opts;
+	const { paysWithFeeDest, transferLiquidToken } = opts;
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].reserveTransferAssets;
 	const typeCreator = createXcmTypes[direction];
@@ -46,7 +46,7 @@ export const reserveTransferAssets = (
 		xcmVersion,
 		specName,
 		assetIds,
-		{ registry }
+		{ registry, transferLiquidToken }
 	);
 
 	const feeAssetItem = paysWithFeeDest
@@ -57,6 +57,7 @@ export const reserveTransferAssets = (
 				assetIds,
 				amounts,
 				xcmVersion,
+				transferLiquidToken,
 		  })
 		: api.registry.createType('u32', 0);
 

--- a/src/createXcmCalls/teleportAssets.ts
+++ b/src/createXcmCalls/teleportAssets.ts
@@ -8,6 +8,7 @@ import { createXcmTypes } from '../createXcmTypes';
 import { Registry } from '../registry';
 import { Direction } from '../types';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import type { CreateXcmCallOpts } from './types';
 import { establishXcmPallet } from './util/establishXcmPallet';
 
 /**
@@ -31,8 +32,9 @@ export const teleportAssets = (
 	xcmVersion: number,
 	specName: string,
 	registry: Registry,
-	paysWithFeeDest?: string
+	opts: CreateXcmCallOpts = {}
 ): SubmittableExtrinsic<'promise', ISubmittableResult> => {
+	const { paysWithFeeDest } = opts;
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].teleportAssets;
 	const typeCreator = createXcmTypes[direction];

--- a/src/createXcmCalls/types.ts
+++ b/src/createXcmCalls/types.ts
@@ -1,0 +1,7 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+export interface CreateXcmCallOpts {
+	weightLimit?: string;
+	paysWithFeeDest?: string;
+	transferLiquidToken?: boolean;
+}

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -290,7 +290,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				amounts,
 				specName,
 				assets,
-				registry
+				registry,
+				false
 			);
 
 			expect(result).toEqual(expected);

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -126,12 +126,15 @@ export const SystemToPara: ICreateXcmType = {
 		assets: string[],
 		opts: CreateAssetsOpts
 	): VersionedMultiAssets => {
+		const { registry, transferLiquidToken } = opts;
+		const isLiquidToken = transferLiquidToken === true;
 		const sortedAndDedupedMultiAssets = createSystemToParaMultiAssets(
 			api,
 			amounts,
 			specName,
 			assets,
-			opts.registry
+			registry,
+			isLiquidToken
 		);
 
 		if (xcmVersion === 2) {
@@ -189,21 +192,23 @@ export const SystemToPara: ICreateXcmType = {
 			assetIds,
 			amounts,
 			xcmVersion,
+			transferLiquidToken,
 		} = opts;
 		if (
-			xcmVersion &&
 			xcmVersion === 3 &&
 			specName &&
 			amounts &&
 			assetIds &&
 			paysWithFeeDest
 		) {
+			const isLiquidToken = transferLiquidToken === true;
 			const multiAssets = createSystemToParaMultiAssets(
 				api,
 				normalizeArrToStr(amounts),
 				specName,
 				assetIds,
-				registry
+				registry,
+				isLiquidToken
 			);
 
 			const systemChainId = getChainIdBySpecName(registry, specName);
@@ -239,9 +244,10 @@ export const createSystemToParaMultiAssets = (
 	amounts: string[],
 	specName: string,
 	assets: string[],
-	registry: Registry
+	registry: Registry,
+	isLiquidToken: boolean
 ): MultiAsset[] => {
-	const palletId = fetchPalletInstanceId(api);
+	const palletId = fetchPalletInstanceId(api, isLiquidToken);
 	let multiAssets = [];
 
 	const systemChainId = getChainIdBySpecName(registry, specName);

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -266,7 +266,8 @@ export const createSystemToSystemMultiAssets = (
 			? { Here: '' }
 			: {
 					X2: [
-						{ PalletInstance: fetchPalletInstanceId(api) },
+						// TODO: Should SystemToSystem support liquid tokens.
+						{ PalletInstance: fetchPalletInstanceId(api, false) },
 						{ GeneralIndex: assetId },
 					],
 			  };

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -13,6 +13,7 @@ import type { RequireOnlyOne } from '../types';
 
 export interface CreateAssetsOpts {
 	registry: Registry;
+	transferLiquidToken?: boolean;
 }
 
 export interface CreateFeeAssetItemOpts {
@@ -22,6 +23,7 @@ export interface CreateFeeAssetItemOpts {
 	assetIds?: string[];
 	amounts?: string[];
 	xcmVersion?: number;
+	transferLiquidToken?: boolean;
 }
 
 export interface ICreateXcmType {

--- a/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
@@ -7,7 +7,7 @@ import { fetchPalletInstanceId } from './fetchPalletInstanceId';
 
 describe('fetchPalletInstandId', () => {
 	it('Should return the correct string when the api has the assets pallet', () => {
-		const res = fetchPalletInstanceId(mockSystemApi);
+		const res = fetchPalletInstanceId(mockSystemApi, false);
 
 		expect(res).toEqual('50');
 	});
@@ -19,7 +19,7 @@ describe('fetchPalletInstandId', () => {
 				},
 			},
 		} as unknown as ApiPromise;
-		const res = () => fetchPalletInstanceId(mockApi);
+		const res = () => fetchPalletInstanceId(mockApi, false);
 
 		expect(res).toThrowError(
 			"No assets pallet available, can't find a valid PalletInstance."

--- a/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
@@ -5,7 +5,7 @@ import type { ApiPromise } from '@polkadot/api';
 import { mockSystemApi } from '../../testHelpers/mockSystemApi';
 import { fetchPalletInstanceId } from './fetchPalletInstanceId';
 
-describe('fetchPalletInstandId', () => {
+describe('fetchPalletInstanceId', () => {
 	it('Should return the correct string when the api has the assets pallet', () => {
 		const res = fetchPalletInstanceId(mockSystemApi, false);
 
@@ -22,7 +22,7 @@ describe('fetchPalletInstandId', () => {
 		const res = () => fetchPalletInstanceId(mockApi, false);
 
 		expect(res).toThrowError(
-			"No assets pallet available, can't find a valid PalletInstance."
+			"No Assets pallet available, can't find a valid PalletInstance."
 		);
 	});
 });

--- a/src/createXcmTypes/util/fetchPalletInstanceId.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.ts
@@ -18,7 +18,7 @@ export const fetchPalletInstanceId = (
 
 	if (pallet.length === 0) {
 		throw Error(
-			"No assets pallet available, can't find a valid PalletInstance."
+			`No ${palletName} pallet available, can't find a valid PalletInstance.`
 		);
 	}
 

--- a/src/createXcmTypes/util/fetchPalletInstanceId.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.ts
@@ -7,16 +7,20 @@ import type { ApiPromise } from '@polkadot/api';
  *
  * @param api ApiPromise
  */
-export const fetchPalletInstanceId = (api: ApiPromise): string => {
-	const assetsPallet = api.registry.metadata.pallets.filter(
-		(pallet) => pallet.name.toString() === 'Assets'
+export const fetchPalletInstanceId = (
+	api: ApiPromise,
+	isLiquidToken: boolean
+): string => {
+	const palletName = isLiquidToken ? 'PoolAssets' : 'Assets';
+	const pallet = api.registry.metadata.pallets.filter(
+		(pallet) => pallet.name.toString() === palletName
 	);
 
-	if (assetsPallet.length === 0) {
+	if (pallet.length === 0) {
 		throw Error(
 			"No assets pallet available, can't find a valid PalletInstance."
 		);
 	}
 
-	return assetsPallet[0].index.toString();
+	return pallet[0].index.toString();
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,6 +184,11 @@ export interface TransferArgsOpts<T extends Format> {
 	 * to a `transfer`.
 	 */
 	keepAlive?: boolean;
+	/**
+	 * Boolean to declare if this will transfer liquidity tokens.
+	 * Default is false.
+	 */
+	transferLiquidToken?: boolean;
 }
 
 export interface ChainInfo {


### PR DESCRIPTION
closes: https://github.com/paritytech/asset-transfer-api/issues/219

Todo:

- [X] Create and refactor options for downstream threading
- [X] SystemToPara support
    - [ ] Tests
- [ ] SystemToSystem support
    - [ ] Tests
- [x]  Tests for fetchPalletInstanceId
    - NOTE: It is not doable at the moment for testing `PoolAssets` because there is no metadata that includes it yet. 
- [ ] `getFeeAssetItemIndex` support for liquid token
- [ ] error validation layer.
- [ ] Docs
