### PR TITLE
fix: added unpaidExecution for testnet XCM message

### DIFF
--- a/scripts/testNetworkSetup.ts
+++ b/scripts/testNetworkSetup.ts
@@ -143,12 +143,12 @@ const main = async () => {
 	const xcmMessage = {
 		V3: [
 			{
-				unpaidExecution: { 
-					weightLimit: { Unlimited: '' }, 
+				unpaidExecution: {
+					weightLimit: { Unlimited: '' },
 					checkOrigin: {
 						parents: 1,
 						interior: { Here: '' },
-				 	} 
+					},
 				},
 			},
 			{

--- a/scripts/testNetworkSetup.ts
+++ b/scripts/testNetworkSetup.ts
@@ -143,11 +143,20 @@ const main = async () => {
 	const xcmMessage = {
 		V3: [
 			{
+				unpaidExecution: { 
+					weightLimit: { Unlimited: '' }, 
+					checkOrigin: {
+						parents: 1,
+						interior: { Here: '' },
+				 	} 
+				},
+			},
+			{
 				transact: {
-					originType: xcmOriginType,
+					originKind: xcmOriginType,
 					requireWeightAtMost: {
 						refTime: 1000000000,
-						proofSize: 0,
+						proofSize: 900000,
 					},
 					call: xcmDoubleEncoded,
 				},


### PR DESCRIPTION
I modified the XCM Message to start with `unpaidExecution` so that it passes the barrier specified by `xcm_config.rs` on Polkadot and Kusama. Solves issue #106 .