### PR TITLE
Fix: remove incorrect reference to '0' for Native Relay Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const call = assetsApi.createTransferTransaction(
  *
  * @param destChainId ID of the destination (para) chain (‘0’ for Relaychain)
  * @param destAddr Address of destination account
- * @param assetIds Array of assetId's to be transferred (‘0’ for Native Relay Token)
+ * @param assetIds Array of assetId's to be transferred
  * @param amounts Array of the amounts of each token to transfer
  * @param opts Options
  */


### PR DESCRIPTION
closes: [#245](https://github.com/paritytech/asset-transfer-api/issues/245)