### PR TITLE
Update System Parachain Id check based on chainId

### DIFF
--- a/src/AssetsTransferApi.spec.ts
+++ b/src/AssetsTransferApi.spec.ts
@@ -33,30 +33,51 @@ const moonriverAssetsApi = new AssetsTransferApi(
 describe('AssetTransferAPI', () => {
 	describe('establishDirection', () => {
 		it('Should correctly determine direction for SystemToSystem', () => {
-			const res = systemAssetsApi['establishDirection']('1000', 'statemint');
+			const res = systemAssetsApi['establishDirection'](
+				'1000',
+				'statemint',
+				true
+			);
 			expect(res).toEqual('SystemToSystem');
 		});
 		it('Should correctly determine direction for SystemToPara', () => {
-			const res = systemAssetsApi['establishDirection']('2000', 'statemint');
+			const res = systemAssetsApi['establishDirection'](
+				'2000',
+				'statemint',
+				false
+			);
 			expect(res).toEqual('SystemToPara');
 		});
 		it('Should correctly determine direction for SystemToRelay', () => {
 			const res = systemAssetsApi['establishDirection'](
 				'0',
-				'asset-hub-polkadot'
+				'asset-hub-polkadot',
+				false
 			);
 			expect(res).toEqual('SystemToRelay');
 		});
 		it('Should correctly determine direction for RelayToPara', () => {
-			const res = relayAssetsApi['establishDirection']('2000', 'polkadot');
+			const res = relayAssetsApi['establishDirection'](
+				'2000',
+				'polkadot',
+				false
+			);
 			expect(res).toEqual('RelayToPara');
 		});
 		it('Should correctly determine direction for RelayToSystem', () => {
-			const res = relayAssetsApi['establishDirection']('1000', 'polkadot');
+			const res = relayAssetsApi['establishDirection'](
+				'1000',
+				'polkadot',
+				true
+			);
 			expect(res).toEqual('RelayToSystem');
 		});
 		it('Should correctly determine direction for ParaToSystem', () => {
-			const res = moonriverAssetsApi['establishDirection']('1000', 'moonriver');
+			const res = moonriverAssetsApi['establishDirection'](
+				'1000',
+				'moonriver',
+				true
+			);
 			expect(res).toEqual('ParaToSystem');
 		});
 	});

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -10,6 +10,11 @@ export const RELAY_CHAIN_NAMES = ['kusama', 'polkadot', 'westend'];
 export const RELAY_CHAIN_IDS = ['0'];
 
 /**
+ * AssetHub chains have an ID of 1000;
+ */
+export const ASSET_HUB_CHAIN_ID = '1000';
+
+/**
  * List of all known system parachains.
  */
 export const SYSTEM_PARACHAINS_NAMES = [
@@ -30,10 +35,7 @@ export const POLKADOT_ASSET_HUB_SPEC_NAMES = [
 ];
 export const KUSAMA_ASSET_HUB_SPEC_NAMES = ['statemine', 'asset-hub-kusama'];
 export const WESTEND_ASSET_HUB_SPEC_NAMES = ['westmint', 'asset-hub-westend'];
-/**
- * List of IDs for assets and bridge hub system parachains.
- */
-export const SYSTEM_PARACHAINS_IDS = ['1000', '1001', '1002'];
+
 /**
  * The default xcm version to construct a xcm message.
  */

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -13,7 +13,6 @@ import type {
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
-import { SYSTEM_PARACHAINS_IDS } from '../consts';
 import { getChainIdBySpecName } from '../createXcmTypes/util/getChainIdBySpecName';
 import { BaseError } from '../errors';
 import type { Registry } from '../registry';
@@ -31,6 +30,7 @@ import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
 import { getChainAssetId } from './util/getChainAssetId';
 import { isRelayNativeAsset } from './util/isRelayNativeAsset';
+import { isSystemChain } from './util/isSystemChain';
 import { sortMultiAssetsAscending } from './util/sortMultiAssetsAscending';
 
 export const SystemToPara: ICreateXcmType = {
@@ -224,7 +224,7 @@ export const SystemToPara: ICreateXcmType = {
 			);
 
 			const systemChainId = getChainIdBySpecName(registry, specName);
-			if (!SYSTEM_PARACHAINS_IDS.includes(systemChainId)) {
+			if (!isSystemChain(systemChainId)) {
 				throw new BaseError(
 					`specName ${specName} did not match a valid system chain ID. Found ID ${systemChainId}`
 				);
@@ -271,7 +271,7 @@ export const createSystemToParaMultiAssets = async (
 
 	const systemChainId = getChainIdBySpecName(registry, specName);
 
-	if (!SYSTEM_PARACHAINS_IDS.includes(systemChainId)) {
+	if (!isSystemChain(systemChainId)) {
 		throw new BaseError(
 			`specName ${specName} did not match a valid system chain ID. Found ID ${systemChainId}`
 		);

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -12,7 +12,6 @@ import type {
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
-import { SYSTEM_PARACHAINS_IDS } from '../consts';
 import { getChainIdBySpecName } from '../createXcmTypes/util/getChainIdBySpecName';
 import { BaseError } from '../errors';
 import type { Registry } from '../registry';
@@ -29,6 +28,7 @@ import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
 import { getChainAssetId } from './util/getChainAssetId';
 import { isRelayNativeAsset } from './util/isRelayNativeAsset';
+import { isSystemChain } from './util/isSystemChain';
 import { sortMultiAssetsAscending } from './util/sortMultiAssetsAscending';
 
 export const SystemToSystem: ICreateXcmType = {
@@ -216,7 +216,7 @@ export const SystemToSystem: ICreateXcmType = {
 
 			const systemChainId = getChainIdBySpecName(registry, specName);
 
-			if (!SYSTEM_PARACHAINS_IDS.includes(systemChainId)) {
+			if (!isSystemChain(systemChainId)) {
 				throw new BaseError(
 					`specName ${specName} did not match a valid system chain ID. Found ID ${systemChainId}`
 				);
@@ -263,7 +263,7 @@ export const createSystemToSystemMultiAssets = async (
 	const foreignAssetsPalletId = foreignAssetsPalletInstance as string;
 	const systemChainId = getChainIdBySpecName(registry, specName);
 
-	if (!SYSTEM_PARACHAINS_IDS.includes(systemChainId)) {
+	if (!isSystemChain(systemChainId)) {
 		throw new BaseError(
 			`specName ${specName} did not match a valid system chain ID. Found ID ${systemChainId}`
 		);

--- a/src/createXcmTypes/util/isSystemChain.spec.ts
+++ b/src/createXcmTypes/util/isSystemChain.spec.ts
@@ -13,7 +13,7 @@ describe('isSystemChain', () => {
 
 		expect(result).toEqual(false);
 	});
-    it('Should correctly return false for a chainId of 0', () => {
+	it('Should correctly return false for a chainId of 0', () => {
 		const result = isSystemChain('0');
 
 		expect(result).toEqual(false);

--- a/src/createXcmTypes/util/isSystemChain.spec.ts
+++ b/src/createXcmTypes/util/isSystemChain.spec.ts
@@ -13,4 +13,9 @@ describe('isSystemChain', () => {
 
 		expect(result).toEqual(false);
 	});
+    it('Should correctly return false for a chainId of 0', () => {
+		const result = isSystemChain('0');
+
+		expect(result).toEqual(false);
+	});
 });

--- a/src/createXcmTypes/util/isSystemChain.spec.ts
+++ b/src/createXcmTypes/util/isSystemChain.spec.ts
@@ -1,0 +1,16 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { isSystemChain } from './isSystemChain';
+
+describe('isSystemChain', () => {
+	it('Should correctly return true for a chainId of 1000', () => {
+		const result = isSystemChain('1000');
+
+		expect(result).toEqual(true);
+	});
+	it('Should correctly return false for a chainId of 2000', () => {
+		const result = isSystemChain(2000);
+
+		expect(result).toEqual(false);
+	});
+});

--- a/src/createXcmTypes/util/isSystemChain.ts
+++ b/src/createXcmTypes/util/isSystemChain.ts
@@ -1,0 +1,13 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+/**
+ * Determines if a chain is a system chain based on the value of its chainId being strictly less than 2000
+ * @param chainId
+ * @returns boolean
+ */
+export const isSystemChain = (chainId: string | number): boolean => {
+	const chainIdAsNumber =
+		typeof chainId === 'string' ? parseInt(chainId) : chainId;
+
+	return chainIdAsNumber < 2000;
+};

--- a/src/createXcmTypes/util/isSystemChain.ts
+++ b/src/createXcmTypes/util/isSystemChain.ts
@@ -1,7 +1,7 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 /**
- * Determines if a chain is a system chain based on the value of its chainId being strictly less than 2000
+ * Determines if a chain is a system chain based on the value of its chainId being strictly greater than 0 and less than 2000
  * @param chainId
  * @returns boolean
  */

--- a/src/createXcmTypes/util/isSystemChain.ts
+++ b/src/createXcmTypes/util/isSystemChain.ts
@@ -9,5 +9,5 @@ export const isSystemChain = (chainId: string | number): boolean => {
 	const chainIdAsNumber =
 		typeof chainId === 'string' ? parseInt(chainId) : chainId;
 
-	return chainIdAsNumber < 2000;
+	return chainIdAsNumber  > 0 && chainIdAsNumber < 2000;
 };

--- a/src/createXcmTypes/util/isSystemChain.ts
+++ b/src/createXcmTypes/util/isSystemChain.ts
@@ -9,5 +9,5 @@ export const isSystemChain = (chainId: string | number): boolean => {
 	const chainIdAsNumber =
 		typeof chainId === 'string' ? parseInt(chainId) : chainId;
 
-	return chainIdAsNumber  > 0 && chainIdAsNumber < 2000;
+	return chainIdAsNumber > 0 && chainIdAsNumber < 2000;
 };

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -5,9 +5,9 @@ import { isHex } from '@polkadot/util';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import {
+	ASSET_HUB_CHAIN_ID,
 	MAX_ASSETS_FOR_TRANSFER,
 	RELAY_CHAIN_IDS,
-	SYSTEM_PARACHAINS_IDS,
 } from '../consts';
 import { foreignAssetMultiLocationIsInRegistry } from '../createXcmTypes/util/foreignAssetMultiLocationIsInRegistry';
 import { foreignAssetsMultiLocationExists } from '../createXcmTypes/util/foreignAssetsMultiLocationExists';
@@ -544,16 +544,16 @@ export const checkIsValidSystemChainAssetId = async (
  * @param specName
  * @param relayChainInfo
  */
-const checkParaToSystemAssetId = async (
+const checkParaToAssetHubAssetId = async (
 	api: ApiPromise,
 	assetId: string,
 	relayChainInfo: ChainInfo,
 	registry: Registry,
 	isForeignAssetsTransfer: boolean
 ) => {
-	const systemParachainId = SYSTEM_PARACHAINS_IDS[0];
-	const systemParachainInfo = relayChainInfo[systemParachainId];
-	const systemSpecName = systemParachainInfo.specName;
+	const assetHubChainId = ASSET_HUB_CHAIN_ID;
+	const assetHubChainInfo = relayChainInfo[assetHubChainId];
+	const assetHubSpecName = assetHubChainInfo.specName;
 
 	if (typeof assetId === 'string') {
 		// An assetId may be a hex value to represent a GeneralKey for erc20 tokens.
@@ -572,8 +572,8 @@ const checkParaToSystemAssetId = async (
 		await checkSystemAssets(
 			api,
 			assetId,
-			systemSpecName,
-			systemParachainInfo,
+			assetHubSpecName,
+			assetHubChainInfo,
 			registry,
 			'ParaToSystem',
 			isForeignAssetsTransfer
@@ -809,7 +809,7 @@ export const checkAssetIdInput = async (
 		}
 
 		if (xcmDirection === Direction.ParaToSystem) {
-			await checkParaToSystemAssetId(
+			await checkParaToAssetHubAssetId(
 				api,
 				assetId,
 				relayChainInfo,

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -551,8 +551,7 @@ const checkParaToAssetHubAssetId = async (
 	registry: Registry,
 	isForeignAssetsTransfer: boolean
 ) => {
-	const assetHubChainId = ASSET_HUB_CHAIN_ID;
-	const assetHubChainInfo = relayChainInfo[assetHubChainId];
+	const assetHubChainInfo = relayChainInfo[ASSET_HUB_CHAIN_ID];
 	const assetHubSpecName = assetHubChainInfo.specName;
 
 	if (typeof assetId === 'string') {


### PR DESCRIPTION
* removed SYSTEM_PARACHAINS_IDS
* checks if a chainId is a system chain based on whether its ID is strictly less than 2000 and greater than 0

closes: [#218](https://github.com/paritytech/asset-transfer-api/issues/218)