### PR TITLE
Re-implement AssetHub ForeignAsset queries

### DIFF
--- a/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
+++ b/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
@@ -1,0 +1,67 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { AssetsTransferApi } from '../../AssetsTransferApi';
+import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
+import { foreignAssetsMultiLocationExists } from './foreignAssetsMultiLocationExists';
+
+describe('foreignMultiAssetMultiLocationExists', () => {
+	const systemAssetsApi = new AssetsTransferApi(
+		adjustedMockSystemApi,
+		'statemine',
+		2
+	);
+
+	it('Should return true for an existing foreign asset multilocation', async () => {
+		const expected = true;
+		const multiLocation =
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}';
+
+		const isValid = await foreignAssetsMultiLocationExists(
+			systemAssetsApi._api,
+			multiLocation
+		);
+
+		expect(isValid).toEqual(expected);
+	});
+
+	it('Should return false for a non existing foreign asset multilocation', async () => {
+		const expected = false;
+		const multiLocation =
+			'{"parents":"1","interior":{"X1": {"Parachain":"21252525"}}}';
+
+		const isValid = await foreignAssetsMultiLocationExists(
+			systemAssetsApi._api,
+			multiLocation
+		);
+
+		expect(isValid).toEqual(expected);
+	});
+
+	it('Should throw an invalid character error when an invalid character is found in a multilocation keys value', async () => {
+		const expectedError =
+			'Error creating MultiLocation type: Enum(Parachain) Invalid character';
+		const multiLocation =
+			'{"parents":"1","interior":{"X1": {"Parachain":"g2125"}}}';
+
+		await expect(async () => {
+			await foreignAssetsMultiLocationExists(
+				systemAssetsApi._api,
+				multiLocation
+			);
+		}).rejects.toThrowError(expectedError);
+	});
+
+	it('Should throw an error when an comma is found in a multilocation keys value', async () => {
+		const expectedError =
+			'Error creating MultiLocation type: Enum(Parachain) String should not contain decimal points or scientific notation';
+		const multiLocation =
+			'{"parents":"2","interior":{"X1": {"Parachain":"2,125"}}}';
+
+		await expect(async () => {
+			await foreignAssetsMultiLocationExists(
+				systemAssetsApi._api,
+				multiLocation
+			);
+		}).rejects.toThrowError(expectedError);
+	});
+});

--- a/src/createXcmTypes/util/foreignAssetsMultiLocationExists.ts
+++ b/src/createXcmTypes/util/foreignAssetsMultiLocationExists.ts
@@ -1,0 +1,41 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { ApiPromise } from '@polkadot/api';
+
+import { BaseError } from '../../errors';
+
+export const foreignAssetsMultiLocationExists = async (
+	assetHubApi: ApiPromise,
+	multilocationStr: string
+): Promise<boolean> => {
+	try {
+		const multiLocation = assetHubApi.registry.createType(
+			'MultiLocation',
+			JSON.parse(multilocationStr)
+		);
+
+		const foreignAsset = await assetHubApi.query.foreignAssets.asset(
+			multiLocation
+		);
+
+		// check if foreign asset exists
+		if (foreignAsset.toString().length > 0) {
+			return true;
+		}
+
+		return false;
+	} catch (error) {
+		if ((error as Error).message.includes('::')) {
+			const errorInfo = (error as Error).message.split('::');
+			const errorDetails = errorInfo[errorInfo.length - 2].concat(
+				errorInfo[errorInfo.length - 1]
+			);
+
+			throw new BaseError(`Error creating MultiLocation type:${errorDetails}`);
+		} else {
+			throw new BaseError(
+				`Error creating multilocation type: ${(error as Error).message}`
+			);
+		}
+	}
+};

--- a/src/createXcmTypes/util/getAssetHubAssetId.spec.ts
+++ b/src/createXcmTypes/util/getAssetHubAssetId.spec.ts
@@ -64,4 +64,18 @@ describe('getAssetHubAssetId', () => {
 
 		expect(result).toEqual(expected);
 	});
+
+	it('Should correctly error when a foreign asset multilocation is given that is not present in the registry or chain state', async () => {
+		const multiLocation =
+			'{"parents":"1","interior":{"X1":{"Parachain":"212500000"}}}';
+
+		await expect(async () => {
+			await getAssetHubAssetId(
+				systemAssetsApi._api,
+				multiLocation,
+				'statemine',
+				true
+			);
+		}).rejects.toThrowError(`MultiLocation ${multiLocation} not found`);
+	});
 });

--- a/src/errors/checkLocalTxInputs.ts
+++ b/src/errors/checkLocalTxInputs.ts
@@ -3,6 +3,7 @@
 import { ApiPromise } from '@polkadot/api';
 
 import { foreignAssetMultiLocationIsInRegistry } from '../createXcmTypes/util/foreignAssetMultiLocationIsInRegistry';
+import { foreignAssetsMultiLocationExists } from '../createXcmTypes/util/foreignAssetsMultiLocationExists';
 import { getAssetHubAssetId } from '../createXcmTypes/util/getAssetHubAssetId';
 import { getChainIdBySpecName } from '../createXcmTypes/util/getChainIdBySpecName';
 import { checkLiquidTokenValidity } from '../errors/checkXcmTxInputs';
@@ -56,8 +57,15 @@ export const checkLocalTxInput = async (
 		if (foreignAssetIsInRegistry) {
 			return LocalTxType.ForeignAssets;
 		} else {
-			// TODO: create AssetHub ApiPromise to query chain state for foreign assets
-			throw new BaseError(`MultiLocation ${multiLocationStr} not found`);
+			const isValidForeignAsset = await foreignAssetsMultiLocationExists(
+				api,
+				multiLocationStr
+			);
+			if (isValidForeignAsset) {
+				return LocalTxType.ForeignAssets;
+			} else {
+				throw new BaseError(`MultiLocation ${multiLocationStr} not found`);
+			}
 		}
 	} else if (isLiquidTokenTransfer) {
 		const relayChainInfo = registry.currentRelayRegistry;

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -776,8 +776,7 @@ describe('checkParaAssets', () => {
 				assetId,
 				specName,
 				registry,
-				Direction.ParaToSystem,
-				false
+				Direction.ParaToSystem
 			);
 		} catch (err) {
 			didNotError = false;
@@ -797,8 +796,7 @@ describe('checkParaAssets', () => {
 				assetId,
 				specName,
 				registry,
-				Direction.ParaToSystem,
-				false
+				Direction.ParaToSystem
 			);
 		} catch (err) {
 			didNotError = false;
@@ -817,8 +815,7 @@ describe('checkParaAssets', () => {
 				assetId,
 				specName,
 				registry,
-				Direction.ParaToSystem,
-				false
+				Direction.ParaToSystem
 			);
 		}).rejects.toThrowError(
 			'ParaToSystem: symbol assetId xcUSDfake not found for parachain moonriver'
@@ -835,8 +832,7 @@ describe('checkParaAssets', () => {
 				assetId,
 				specName,
 				registry,
-				Direction.ParaToSystem,
-				false
+				Direction.ParaToSystem
 			);
 		}).rejects.toThrowError(
 			'ParaToSystem: integer assetId 2096586909097964981698161 not found in moonriver'
@@ -914,8 +910,7 @@ describe('checkParaAssets', () => {
 				assetId,
 				specName,
 				registry,
-				Direction.ParaToSystem,
-				false
+				Direction.ParaToSystem
 			);
 		}).rejects.toThrowError(
 			'unable to identify xcAsset with ID 311091173110107856861649819128533077277'

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -8,6 +8,7 @@ import { MAX_ASSETS_FOR_TRANSFER, RELAY_CHAIN_IDS } from '../consts';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
 import { CheckXcmTxInputsOpts } from '../createXcmTypes/types';
 import { foreignAssetMultiLocationIsInRegistry } from '../createXcmTypes/util/foreignAssetMultiLocationIsInRegistry';
+import { foreignAssetsMultiLocationExists } from '../createXcmTypes/util/foreignAssetsMultiLocationExists';
 import { getChainIdBySpecName } from '../createXcmTypes/util/getChainIdBySpecName';
 import { multiLocationAssetIsParachainsNativeAsset } from '../createXcmTypes/util/multiLocationAssetIsParachainsNativeAsset';
 import { Registry } from '../registry';
@@ -397,7 +398,14 @@ const checkSystemAssets = async (
 		);
 
 		if (!multiLocationIsInRegistry) {
-			// TODO: create AssetHub ApiPromise to query chain state for foreign assets
+			const isValidForeignAsset = await foreignAssetsMultiLocationExists(
+				api,
+				assetId
+			);
+
+			if (!isValidForeignAsset) {
+				throw new BaseError(`MultiLocation ${assetId} not found`);
+			}
 		}
 	} else if (isLiquidTokenTransfer) {
 		await checkLiquidTokenValidity(api, systemParachainInfo, assetId);
@@ -504,7 +512,7 @@ export const checkParaAssets = async (
 		);
 
 		if (!multiLocationIsInRegistry) {
-			// TODO: create AssetHub ApiPromise to query chain state for foreign assets
+			// TODO: remove foreignAssets check from ParaToSystem
 		}
 	} else {
 		// check if assetId is a number

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -981,17 +981,6 @@ export const checkXcmTxInputs = async (
 		isLiquidTokenTransfer
 	);
 
-	await checkAssetIdInput(
-		api,
-		assetIds,
-		relayChainInfo,
-		specName,
-		xcmDirection,
-		registry,
-		isForeignAssetsTransfer,
-		isLiquidTokenTransfer
-	);
-
 	if (xcmDirection === Direction.RelayToSystem) {
 		checkRelayAssetIdLength(assetIds);
 		checkRelayAmountsLength(amounts);

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -497,99 +497,85 @@ export const checkParaAssets = async (
 	assetId: string,
 	specName: string,
 	registry: Registry,
-	xcmDirection: string,
-	isForeignAssetsTransfer: boolean
+	xcmDirection: string
 ) => {
 	const { xcAssets } = registry;
 	const currentRelayChainSpecName = registry.relayChain;
 
-	if (isForeignAssetsTransfer) {
-		// check that the asset id is a valid multilocation
-		const multiLocationIsInRegistry = foreignAssetMultiLocationIsInRegistry(
-			api,
-			assetId,
-			registry
-		);
+	// check if assetId is a number
+	const parsedAssetIdAsNumber = Number.parseInt(assetId);
+	const invalidNumber = Number.isNaN(parsedAssetIdAsNumber);
 
-		if (!multiLocationIsInRegistry) {
-			// TODO: remove foreignAssets check from ParaToSystem
+	if (!invalidNumber) {
+		// query the parachains assets pallet to see if it has a value matching the assetId
+		const asset = await api.query.assets.asset(assetId);
+
+		if (asset.isNone) {
+			throw new BaseError(
+				`${xcmDirection}: integer assetId ${assetId} not found in ${specName}`
+			);
+		}
+
+		// check that xcAsset exists in the xcAsset registry
+		let relayChainXcAssetInfoKeys: XCMChainInfoKeys[] = [];
+		if (currentRelayChainSpecName.toLowerCase() === 'kusama') {
+			relayChainXcAssetInfoKeys = xcAssets.kusama;
+		}
+		if (currentRelayChainSpecName.toLowerCase() === 'polkadot') {
+			relayChainXcAssetInfoKeys = xcAssets.polkadot;
+		}
+
+		if (relayChainXcAssetInfoKeys.length === 0) {
+			throw new BaseError(
+				`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`
+			);
+		}
+
+		let xcAsset: XCMChainInfoDataKeys | string = '';
+		for (let i = 0; i < relayChainXcAssetInfoKeys.length; i++) {
+			const chainInfo = relayChainXcAssetInfoKeys[i];
+
+			for (let j = 0; j < chainInfo.data.length; j++) {
+				const xcAssetData = chainInfo.data[j];
+				if (
+					typeof xcAssetData.asset === 'string' &&
+					xcAssetData.asset === assetId
+				) {
+					xcAsset = xcAssetData;
+					break;
+				}
+			}
+		}
+
+		if (typeof xcAsset === 'string') {
+			throw new BaseError(`unable to identify xcAsset with ID ${assetId}`);
 		}
 	} else {
-		// check if assetId is a number
-		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const invalidNumber = Number.isNaN(parsedAssetIdAsNumber);
+		// not a valid number
+		// check if id is a valid token symbol of the system parachain chain
+		let isValidTokenSymbol = false;
 
-		if (!invalidNumber) {
-			// query the parachains assets pallet to see if it has a value matching the assetId
-			const asset = await api.query.assets.asset(assetId);
+		const parachainAssets = await api.query.assets.asset.entries();
 
-			if (asset.isNone) {
-				throw new BaseError(
-					`${xcmDirection}: integer assetId ${assetId} not found in ${specName}`
-				);
+		for (let i = 0; i < parachainAssets.length; i++) {
+			const parachainAsset = parachainAssets[i];
+			const id = parachainAsset[0].args[0];
+
+			const metadata = await api.query.assets.metadata(id);
+
+			if (
+				metadata.symbol.toHuman()?.toString().toLowerCase() ===
+				assetId.toLowerCase()
+			) {
+				isValidTokenSymbol = true;
 			}
+		}
 
-			// check that xcAsset exists in the xcAsset registry
-			let relayChainXcAssetInfoKeys: XCMChainInfoKeys[] = [];
-			if (currentRelayChainSpecName.toLowerCase() === 'kusama') {
-				relayChainXcAssetInfoKeys = xcAssets.kusama;
-			}
-			if (currentRelayChainSpecName.toLowerCase() === 'polkadot') {
-				relayChainXcAssetInfoKeys = xcAssets.polkadot;
-			}
-
-			if (relayChainXcAssetInfoKeys.length === 0) {
-				throw new BaseError(
-					`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`
-				);
-			}
-
-			let xcAsset: XCMChainInfoDataKeys | string = '';
-			for (let i = 0; i < relayChainXcAssetInfoKeys.length; i++) {
-				const chainInfo = relayChainXcAssetInfoKeys[i];
-
-				for (let j = 0; j < chainInfo.data.length; j++) {
-					const xcAssetData = chainInfo.data[j];
-					if (
-						typeof xcAssetData.asset === 'string' &&
-						xcAssetData.asset === assetId
-					) {
-						xcAsset = xcAssetData;
-						break;
-					}
-				}
-			}
-
-			if (typeof xcAsset === 'string') {
-				throw new BaseError(`unable to identify xcAsset with ID ${assetId}`);
-			}
-		} else {
-			// not a valid number
-			// check if id is a valid token symbol of the system parachain chain
-			let isValidTokenSymbol = false;
-
-			const parachainAssets = await api.query.assets.asset.entries();
-
-			for (let i = 0; i < parachainAssets.length; i++) {
-				const parachainAsset = parachainAssets[i];
-				const id = parachainAsset[0].args[0];
-
-				const metadata = await api.query.assets.metadata(id);
-
-				if (
-					metadata.symbol.toHuman()?.toString().toLowerCase() ===
-					assetId.toLowerCase()
-				) {
-					isValidTokenSymbol = true;
-				}
-			}
-
-			// if no native token for the parachain was matched, throw an error
-			if (!isValidTokenSymbol) {
-				throw new BaseError(
-					`${xcmDirection}: symbol assetId ${assetId} not found for parachain ${specName}`
-				);
-			}
+		// if no native token for the parachain was matched, throw an error
+		if (!isValidTokenSymbol) {
+			throw new BaseError(
+				`${xcmDirection}: symbol assetId ${assetId} not found for parachain ${specName}`
+			);
 		}
 	}
 };
@@ -663,8 +649,7 @@ const checkParaToAssetHubAssetId = async (
 	api: ApiPromise,
 	assetId: string,
 	specName: string,
-	registry: Registry,
-	isForeignAssetsTransfer: boolean
+	registry: Registry
 ) => {
 	if (typeof assetId === 'string') {
 		// An assetId may be a hex value to represent a GeneralKey for erc20 tokens.
@@ -680,14 +665,7 @@ const checkParaToAssetHubAssetId = async (
 			return;
 		}
 
-		await checkParaAssets(
-			api,
-			assetId,
-			specName,
-			registry,
-			'ParaToSystem',
-			isForeignAssetsTransfer
-		);
+		await checkParaAssets(api, assetId, specName, registry, 'ParaToSystem');
 	}
 };
 
@@ -926,13 +904,7 @@ export const checkAssetIdInput = async (
 		}
 
 		if (xcmDirection === Direction.ParaToSystem) {
-			await checkParaToAssetHubAssetId(
-				api,
-				assetId,
-				specName,
-				registry,
-				isForeignAssetsTransfer
-			);
+			await checkParaToAssetHubAssetId(api, assetId, specName, registry);
 		}
 	}
 };


### PR DESCRIPTION
* re-adds `foreignAssetsMultiLocationExists` for checking AssetHub chain state if a foreign asset isn't found in the registry