### PR TITLE
fix empty string assetId Balances bug for local tx

### DIFF
--- a/src/errors/checkLocalTxInputs.spec.ts
+++ b/src/errors/checkLocalTxInputs.spec.ts
@@ -39,6 +39,18 @@ describe('checkLocalTxInput', () => {
 		);
 		expect(res).toEqual('Balances');
 	});
+	it('Should correctly return Balances with an empty string assetId', async () => {
+		const res = await checkLocalTxInput(
+			systemAssetsApi._api,
+			[''],
+			['10000'],
+			specName,
+			registry,
+			false,
+			false
+		);
+		expect(res).toEqual('Balances');
+	});
 	it('Should correctly return Assets with a valid assetId', async () => {
 		const res = await checkLocalTxInput(
 			systemAssetsApi._api,

--- a/src/errors/checkLocalTxInputs.ts
+++ b/src/errors/checkLocalTxInputs.ts
@@ -95,6 +95,11 @@ export const checkLocalTxInput = async (
 
 		let assetId = assetIds[0];
 
+		// in the case the asset is an empty string, we consider it the relay asset
+		if (assetId === '') {
+			return LocalTxType.Balances;
+		}
+
 		const isNativeToken = systemParachainInfo.tokens.find(
 			(token) => token.toLowerCase() === assetId.toLowerCase()
 		);


### PR DESCRIPTION
* fixes an issue where an empty string assetId returns the `Assets` tx type for local txs instead of `Balances`