### PR TITLE
fix: replace all unsafe instances of parseInt

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -219,9 +219,7 @@ export class AssetsTransferApi {
 			if (isLocalSystemTx) {
 				let tx: SubmittableExtrinsic<'promise', ISubmittableResult>;
 				let palletMethod: LocalTransferTypes;
-				/**
-				 *
-				 */
+
 				if (localAssetType === 'Balances') {
 					tx =
 						method === 'transferKeepAlive'

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -50,3 +50,8 @@ export const SUPPORTED_XCM_VERSIONS: [number, number] = [2, 3];
  * https://github.com/paritytech/polkadot/blob/e0ed7e862c8c8b6c75eda1731c449543642176ef/xcm/pallet-xcm/src/lib.rs#L1131
  */
 export const MAX_ASSETS_FOR_TRANSFER = 2;
+
+/**
+ * This is the max length for a number before we need to use BigInt.
+ */
+export const MAX_NUM_LENGTH = Number.MAX_SAFE_INTEGER.toString().length;

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -24,6 +24,7 @@ import {
 } from '../types';
 import { getFeeAssetItemIndex } from '../util/getFeeAssetItemIndex';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import { validateNumber } from '../validate';
 import type {
 	CreateAssetsOpts,
 	CreateFeeAssetItemOpts,
@@ -289,12 +290,11 @@ export const ParaToSystem: ICreateXcmType = {
 		const { registry } = opts;
 		const { xcAssets } = registry;
 		const { tokens: relayTokens } = registry.currentRelayRegistry['0'];
-		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(relayTokens, assetId);
 		const currentRelayChainSpecName = registry.relayChain;
 
-		if (!isRelayNative && isNotANumber) {
+		if (!isRelayNative && !isValidInt) {
 			assetId = await getAssetId(api, registry, assetId, specName);
 		}
 
@@ -407,10 +407,9 @@ const createXTokensMultiAssets = async (
 		const amount = amounts[i];
 		let assetId = assets[i];
 
-		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+		const isValidInt = validateNumber(assetId);
 
-		if (isNotANumber) {
+		if (!isValidInt) {
 			assetId = await getAssetId(api, registry, assetId, specName);
 		}
 
@@ -516,10 +515,9 @@ const createParaToSystemMultiAssets = async (
 		const amount = amounts[i];
 		let assetId = assets[i];
 
-		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+		const isValidInt = validateNumber(assetId);
 
-		if (isNotANumber) {
+		if (!isValidInt) {
 			assetId = await getAssetId(
 				api,
 				registry,

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -19,6 +19,7 @@ import type { Registry } from '../registry';
 import { MultiAsset } from '../types';
 import { getFeeAssetItemIndex } from '../util/getFeeAssetItemIndex';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import { validateNumber } from '../validate';
 import {
 	CreateAssetsOpts,
 	CreateFeeAssetItemOpts,
@@ -297,11 +298,10 @@ export const createSystemToParaMultiAssets = async (
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
-		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(tokens, assetId);
 
-		if (!isRelayNative && isNotANumber) {
+		if (!isRelayNative && !isValidInt) {
 			assetId = await getAssetId(
 				api,
 				registry,

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -18,6 +18,7 @@ import { BaseError, BaseErrorsEnum } from '../errors';
 import type { Registry } from '../registry';
 import { getFeeAssetItemIndex } from '../util/getFeeAssetItemIndex';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
+import { validateNumber } from '../validate';
 import { MultiAsset } from './../types';
 import {
 	CreateAssetsOpts,
@@ -289,20 +290,17 @@ export const createSystemToSystemMultiAssets = async (
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
-		const parsedAssetIdAsNumber = Number.parseInt(assetId);
-		const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(tokens, assetId);
 
-		if (!isRelayNative) {
-			if (isNotANumber) {
-				assetId = await getAssetId(
-					api,
-					registry,
-					assetId,
-					specName,
-					isForeignAssetsTransfer
-				);
-			}
+		if (!isRelayNative && !isValidInt) {
+			assetId = await getAssetId(
+				api,
+				registry,
+				assetId,
+				specName,
+				isForeignAssetsTransfer
+			);
 		}
 
 		let concretMultiLocation: MultiLocation;

--- a/src/createXcmTypes/util/getAssetId.ts
+++ b/src/createXcmTypes/util/getAssetId.ts
@@ -5,6 +5,7 @@ import { ApiPromise } from '@polkadot/api';
 import { ASSET_HUB_CHAIN_ID } from '../../consts';
 import { BaseError, BaseErrorsEnum } from '../../errors';
 import { Registry } from '../../registry';
+import { validateNumber } from '../../validate';
 import { foreignAssetMultiLocationIsInCacheOrRegistry } from './foreignAssetMultiLocationIsInCacheOrRegistry';
 import { foreignAssetsMultiLocationExists } from './foreignAssetsMultiLocationExists';
 import { getChainIdBySpecName } from './getChainIdBySpecName';
@@ -29,8 +30,7 @@ export const getAssetId = async (
 	isForeignAssetsTransfer?: boolean
 ): Promise<string> => {
 	const currentChainId = getChainIdBySpecName(registry, specName);
-	const parsedAssetAsNumber = Number.parseInt(asset);
-	const assetIsNumber = !Number.isNaN(parsedAssetAsNumber);
+	const assetIsValidInt = validateNumber(asset);
 	const isParachain = parseInt(currentChainId) >= 2000;
 
 	// if assets pallet, check the cache and return the cached assetId if found
@@ -56,7 +56,7 @@ export const getAssetId = async (
 		}
 	}
 	// check number assetId in registry
-	if (assetIsNumber) {
+	if (assetIsValidInt) {
 		// if assetId index is valid, return the assetId
 		if (assetsInfo[asset] && assetsInfo[asset].length > 0) {
 			return asset;
@@ -105,7 +105,7 @@ export const getAssetId = async (
 			const { tokens } = registry.currentRelayRegistry[ASSET_HUB_CHAIN_ID];
 
 			assetId = tokens[0];
-		} else if (assetIsNumber) {
+		} else if (assetIsValidInt) {
 			const maybeAsset = await _api.query.assets.asset(asset);
 
 			if (maybeAsset.isSome) {
@@ -130,7 +130,7 @@ export const getAssetId = async (
 			);
 		}
 	} else if (isParachain) {
-		if (!assetIsNumber) {
+		if (!assetIsValidInt) {
 			// if not assetHub and assetId isnt a number, query the parachain chain for the asset symbol
 			const parachainAssets = await _api.query.assets.asset.entries();
 

--- a/src/createXcmTypes/util/sortMultiAssetsAscending.ts
+++ b/src/createXcmTypes/util/sortMultiAssetsAscending.ts
@@ -2,8 +2,10 @@
 
 import { JunctionV1 } from '@polkadot/types/interfaces';
 import { ITuple } from '@polkadot/types-codec/types';
+import { BN } from 'bn.js';
 
 import { MultiAsset, XcmMultiAsset } from '../../types';
+import { validateNumber } from '../../validate';
 
 /**
  * This sorts a list of multiassets in ascending order based on their id.
@@ -192,22 +194,17 @@ const getSortOrderForX2ThroughX8 = (
 		// if the junctions are the same type but not equal
 		// we compare the inner values in order to determine sort order
 		if (junctionA.type === junctionB.type && !junctionA.eq(junctionB)) {
-			const junctionAValueAsNumber = Number.parseInt(
-				junctionA.value.toString()
-			);
-			const junctionAIsNotANumber = Number.isNaN(junctionAValueAsNumber);
-
-			const junctionBValueAsNumber = Number.parseInt(
-				junctionB.value.toString()
-			);
-			const junctionBIsNotANumber = Number.isNaN(junctionBValueAsNumber);
+			const junctionAIsValidInt = validateNumber(junctionA.value.toString());
+			const junctionBIsValidInt = validateNumber(junctionB.value.toString());
 
 			// compare number values if both junction values are valid integers
 			// otherwise compare the lexicographical values
-			if (!junctionAIsNotANumber && !junctionBIsNotANumber) {
-				if (junctionAValueAsNumber < junctionBValueAsNumber) {
+			if (junctionAIsValidInt && junctionBIsValidInt) {
+				const junctionAValueAsBN = new BN(junctionA.value.toString());
+				const junctionBValueAsBN = new BN(junctionB.value.toString());
+				if (junctionAValueAsBN.lt(junctionBValueAsBN)) {
 					return -1;
-				} else if (junctionAValueAsNumber > junctionBValueAsNumber) {
+				} else if (junctionAValueAsBN.gt(junctionBValueAsBN)) {
 					return 1;
 				}
 			} else {

--- a/src/testHelpers/adjustedMockSystemApi.ts
+++ b/src/testHelpers/adjustedMockSystemApi.ts
@@ -11,6 +11,7 @@ import type {
 } from '@polkadot/types/lookup';
 import { ITuple } from '@polkadot/types-codec/types';
 import { getSpecTypes } from '@polkadot/types-known';
+import BN from 'bn.js';
 
 import { assetHubWestendV9435 } from './metadata/assetHubWestendV9435';
 import { mockSystemApi } from './mockSystemApi';
@@ -104,7 +105,9 @@ const multiLocationAssetInfo = {
 	status: mockSystemApi.registry.createType('PalletAssetsAssetStatus', 'live'),
 };
 
-const asset = (assetId: number): Promise<Option<PalletAssetsAssetDetails>> =>
+const asset = (
+	assetId: number | string | BN
+): Promise<Option<PalletAssetsAssetDetails>> =>
 	Promise.resolve().then(() => {
 		const assets: Map<number, PalletAssetsAssetDetails> = new Map();
 
@@ -149,7 +152,12 @@ const asset = (assetId: number): Promise<Option<PalletAssetsAssetDetails>> =>
 		);
 		assets.set(1984, sufficientAsset);
 
-		const maybeAsset = assets.has(assetId) ? assets.get(assetId) : undefined;
+		const adjAsset = BN.isBN(assetId)
+			? assetId.toNumber()
+			: typeof assetId === 'string'
+			? Number.parseInt(assetId)
+			: assetId;
+		const maybeAsset = assets.has(adjAsset) ? assets.get(adjAsset) : undefined;
 
 		if (maybeAsset) {
 			return new Option(
@@ -165,7 +173,9 @@ const asset = (assetId: number): Promise<Option<PalletAssetsAssetDetails>> =>
 		);
 	});
 
-const assetsMetadata = (assetId: number): Promise<PalletAssetsAssetMetadata> =>
+const assetsMetadata = (
+	assetId: number | string | BN
+): Promise<PalletAssetsAssetMetadata> =>
 	Promise.resolve().then(() => {
 		const metadata: Map<number, PalletAssetsAssetMetadata> = new Map();
 
@@ -187,8 +197,13 @@ const assetsMetadata = (assetId: number): Promise<PalletAssetsAssetMetadata> =>
 		);
 		metadata.set(1984, usdtMetadata);
 
-		const maybeMetadata = metadata.has(assetId)
-			? metadata.get(assetId)
+		const adjAsset = BN.isBN(assetId)
+			? assetId.toNumber()
+			: typeof assetId === 'string'
+			? Number.parseInt(assetId)
+			: assetId;
+		const maybeMetadata = metadata.has(adjAsset)
+			? metadata.get(adjAsset)
 			: undefined;
 
 		if (maybeMetadata) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import {
 	MultiLocation,
 } from '@polkadot/types/interfaces';
 import type { ISubmittableResult } from '@polkadot/types/types';
+import BN from 'bn.js';
 
 import type { ChainInfoRegistry } from './registry/types';
 
@@ -315,7 +316,7 @@ export interface UnsignedTransaction extends SignerPayloadJSON {
 	 *
 	 * @default 0
 	 */
-	assetId?: number;
+	assetId: BN;
 }
 
 export interface LocalDest {

--- a/src/validate/index.ts
+++ b/src/validate/index.ts
@@ -1,3 +1,4 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 export { validateAddress } from './validateAddress';
+export { validateNumber } from './validateNumber';

--- a/src/validate/validateNumber.spec.ts
+++ b/src/validate/validateNumber.spec.ts
@@ -1,7 +1,7 @@
 import { validateNumber } from './validateNumber';
 
 describe('validateNumber', () => {
-	it('Should correctly validate an number as a string with a length less than 16', () => {
+	it('Should correctly validate a number as a string with a length less than 16', () => {
 		const res = validateNumber('123456789000000');
 
 		expect(res).toEqual(true);
@@ -11,12 +11,12 @@ describe('validateNumber', () => {
 
 		expect(res).toEqual(false);
 	});
-	it('Should correctly validate an number as a string with a length greater than 16', () => {
+	it('Should correctly validate a number as a string with a length greater than 16', () => {
 		const res = validateNumber('123456789000000123456789');
 
 		expect(res).toEqual(true);
 	});
-	it('Should return false on an invalid number as a string with a length less than 16', () => {
+	it('Should return false on an invalid number as a string with a length greater than 16', () => {
 		const res = validateNumber('thisisatestthissisatestthisisatest');
 
 		expect(res).toEqual(false);

--- a/src/validate/validateNumber.spec.ts
+++ b/src/validate/validateNumber.spec.ts
@@ -1,0 +1,24 @@
+import { validateNumber } from './validateNumber';
+
+describe('validateNumber', () => {
+	it('Should correctly validate an number as a string with a length less than 16', () => {
+		const res = validateNumber('123456789000000');
+
+		expect(res).toEqual(true);
+	});
+	it('Should return false on an invalid number as a string with a length less than 16', () => {
+		const res = validateNumber('test');
+
+		expect(res).toEqual(false);
+	});
+	it('Should correctly validate an number as a string with a length greater than 16', () => {
+		const res = validateNumber('123456789000000123456789');
+
+		expect(res).toEqual(true);
+	});
+	it('Should return false on an invalid number as a string with a length less than 16', () => {
+		const res = validateNumber('thisisatestthissisatestthisisatest');
+
+		expect(res).toEqual(false);
+	});
+});

--- a/src/validate/validateNumber.ts
+++ b/src/validate/validateNumber.ts
@@ -1,0 +1,17 @@
+import { MAX_NUM_LENGTH } from '../consts';
+
+export const validateNumber = (val: string): boolean => {
+	if (val.length < MAX_NUM_LENGTH) {
+		const isNum = Number.parseInt(val);
+
+		return !Number.isNaN(isNum);
+	}
+
+	try {
+		BigInt(val);
+	} catch {
+		return false;
+	}
+
+	return true;
+};


### PR DESCRIPTION
closes: https://github.com/paritytech/asset-transfer-api/issues/263

This replaces all instances where a MAX_INTEGER_OVERFLOW can happen. 