### PR TITLE
fix: adjust `fetchPalletInstanceId` to handle `ForeignAssets` pallet

### DIFF
--- a/examples/systemToParaLpToken.ts
+++ b/examples/systemToParaLpToken.ts
@@ -25,8 +25,6 @@ const main = async () => {
 				assetsInfo: {},
 				foreignAssetsInfo: {},
 				specName: 'testing',
-				assetsPalletInstance: '100',
-				foreignAssetsPalletInstance: '1000',
 				poolPairsInfo: {},
 			},
 		},

--- a/src/AssetsTransferApi.spec.ts
+++ b/src/AssetsTransferApi.spec.ts
@@ -368,8 +368,6 @@ describe('AssetTransferAPI', () => {
 						assetsInfo: {},
 						foreignAssetsInfo: {},
 						specName: 'testing',
-						assetsPalletInstance: '100',
-						foreignAssetsPalletInstance: '1000',
 						poolPairsInfo: {},
 					},
 				},

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -11,7 +11,6 @@ import type {
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
-import { ASSET_HUB_CHAIN_ID } from '../consts';
 import { BaseError, BaseErrorsEnum } from '../errors';
 import type { Registry } from '../registry';
 import { XCMChainInfoDataKeys, XCMChainInfoKeys } from '../registry/types';
@@ -34,6 +33,7 @@ import type {
 } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
+import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
 import { getAssetId } from './util/getAssetId';
 import { isRelayNativeAsset } from './util/isRelayNativeAsset';
 import { sortMultiAssetsAscending } from './util/sortMultiAssetsAscending';
@@ -504,11 +504,7 @@ const createParaToSystemMultiAssets = async (
 ): Promise<MultiAsset[]> => {
 	const { xcAssets } = registry;
 	const currentRelayChainSpecName = registry.relayChain;
-	const { foreignAssetsPalletInstance } =
-		registry.currentRelayRegistry[ASSET_HUB_CHAIN_ID];
-	// This will always result in a value and will never be null because the AssetHub will always
-	// have the foreign assets pallet present, so we type cast here to work around the type compiler.
-	const foreignAssetsPalletId = foreignAssetsPalletInstance as string;
+	const palletId = fetchPalletInstanceId(api, false, isForeignAssetsTransfer);
 	let multiAssets: MultiAsset[] = [];
 
 	for (let i = 0; i < assets.length; i++) {
@@ -560,7 +556,7 @@ const createParaToSystemMultiAssets = async (
 			concretMultiLocation = constructForeignAssetMultiLocationFromAssetId(
 				api,
 				assetId,
-				foreignAssetsPalletId
+				palletId
 			);
 		} else {
 			concretMultiLocation = api.registry.createType(

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -276,13 +276,12 @@ export const createSystemToParaMultiAssets = async (
 	isForeignAssetsTransfer: boolean,
 	isLiquidTokenTransfer: boolean
 ): Promise<MultiAsset[]> => {
-	const assetHubChainId = '1000';
-	const { foreignAssetsPalletInstance } =
-		registry.currentRelayRegistry[assetHubChainId];
-	const foreignAssetsPalletId = foreignAssetsPalletInstance as string;
-	const palletId = fetchPalletInstanceId(api, isLiquidTokenTransfer);
 	let multiAssets: MultiAsset[] = [];
-
+	const palletId = fetchPalletInstanceId(
+		api,
+		isLiquidTokenTransfer,
+		isForeignAssetsTransfer
+	);
 	const systemChainId = getChainIdBySpecName(registry, specName);
 
 	if (!isSystemChain(systemChainId)) {
@@ -317,7 +316,7 @@ export const createSystemToParaMultiAssets = async (
 			concretMultiLocation = constructForeignAssetMultiLocationFromAssetId(
 				api,
 				assetId,
-				foreignAssetsPalletId
+				palletId
 			);
 		} else {
 			const parents = isRelayNative ? 1 : 0;

--- a/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
@@ -7,7 +7,7 @@ import { fetchPalletInstanceId } from './fetchPalletInstanceId';
 
 describe('fetchPalletInstanceId', () => {
 	it('Should return the correct string when the api has the assets pallet', () => {
-		const res = fetchPalletInstanceId(mockSystemApi, false);
+		const res = fetchPalletInstanceId(mockSystemApi, false, false);
 
 		expect(res).toEqual('50');
 	});
@@ -19,15 +19,27 @@ describe('fetchPalletInstanceId', () => {
 				},
 			},
 		} as unknown as ApiPromise;
-		const res = () => fetchPalletInstanceId(mockApi, false);
+		const res = () => fetchPalletInstanceId(mockApi, false, false);
 
 		expect(res).toThrowError(
 			"No Assets pallet available, can't find a valid PalletInstance."
 		);
 	});
 	it('Should correctly grab the poolAssets pallet instance', () => {
-		const res = fetchPalletInstanceId(mockSystemApi, true);
+		const res = fetchPalletInstanceId(mockSystemApi, true, false);
 
 		expect(res).toEqual('55');
+	});
+	it('Should correctly grab the foreignAssets pallet instance', () => {
+		const res = fetchPalletInstanceId(mockSystemApi, false, true);
+
+		expect(res).toEqual('53');
+	});
+	it('Should correctly error when both foreign assets and pool assets are true', () => {
+		const err = () => fetchPalletInstanceId(mockSystemApi, true, true);
+
+		expect(err).toThrowError(
+			"Can't find the appropriate pallet when both liquid tokens and foreign assets"
+		);
 	});
 });

--- a/src/createXcmTypes/util/fetchPalletInstanceId.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.ts
@@ -12,9 +12,20 @@ import { BaseError, BaseErrorsEnum } from '../../errors';
  */
 export const fetchPalletInstanceId = (
 	api: ApiPromise,
-	isLiquidToken: boolean
+	isLiquidToken: boolean,
+	isForeignAsset: boolean
 ): string => {
-	const palletName = isLiquidToken ? 'PoolAssets' : 'Assets';
+	if (isLiquidToken && isForeignAsset) {
+		throw new BaseError(
+			"Can't find the appropriate pallet when both liquid tokens and foreign assets",
+			BaseErrorsEnum.InternalError
+		);
+	}
+	const palletName = isLiquidToken
+		? 'PoolAssets'
+		: isForeignAsset
+		? 'ForeignAssets'
+		: 'Assets';
 	const pallet = api.registry.metadata.pallets.filter(
 		(pallet) => pallet.name.toString() === palletName
 	);

--- a/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
+++ b/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
@@ -72,8 +72,6 @@ describe('foreignMultiAssetMultiLocationExists', () => {
 					'1000': {
 						assetsInfo: {},
 						poolPairsInfo: {},
-						foreignAssetsPalletInstance: null,
-						assetsPalletInstance: null,
 						specName: '',
 						tokens: [],
 						foreignAssetsInfo: {},

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -924,8 +924,6 @@ describe('checkParaAssets', () => {
 				'1000': {
 					assetsInfo: {},
 					poolPairsInfo: {},
-					foreignAssetsPalletInstance: null,
-					assetsPalletInstance: null,
 					specName: '',
 					tokens: [],
 					foreignAssetsInfo: {},
@@ -951,8 +949,6 @@ describe('checkParaAssets', () => {
 				'2023': {
 					assetsInfo: {},
 					poolPairsInfo: {},
-					foreignAssetsPalletInstance: null,
-					assetsPalletInstance: null,
 					specName: '',
 					tokens: [],
 					foreignAssetsInfo: {},
@@ -982,8 +978,6 @@ describe('checkParaAssets', () => {
 						'1000': {
 							assetsInfo: {},
 							poolPairsInfo: {},
-							foreignAssetsPalletInstance: null,
-							assetsPalletInstance: null,
 							specName: '',
 							tokens: [],
 							foreignAssetsInfo: {},
@@ -995,8 +989,6 @@ describe('checkParaAssets', () => {
 				'1000': {
 					assetsInfo: {},
 					poolPairsInfo: {},
-					foreignAssetsPalletInstance: null,
-					assetsPalletInstance: null,
 					specName: '',
 					tokens: [],
 					foreignAssetsInfo: {},
@@ -1031,8 +1023,6 @@ describe('checkParaAssets', () => {
 						'1000': {
 							assetsInfo: {},
 							poolPairsInfo: {},
-							foreignAssetsPalletInstance: null,
-							assetsPalletInstance: null,
 							specName: '',
 							tokens: [],
 							foreignAssetsInfo: {},
@@ -1044,8 +1034,6 @@ describe('checkParaAssets', () => {
 				'1000': {
 					assetsInfo: {},
 					poolPairsInfo: {},
-					foreignAssetsPalletInstance: null,
-					assetsPalletInstance: null,
 					specName: '',
 					tokens: [],
 					foreignAssetsInfo: {},

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -77,16 +77,10 @@ export class Registry {
 		assetKey: string
 	): ForeignAssetsData | undefined {
 		const currentChainId = getChainIdBySpecName(this, this.specName);
+		const lookup =
+			this.cache[this.relayChain][currentChainId]['foreignAssetsInfo'];
 
-		if (
-			this.cache[this.relayChain][currentChainId]['foreignAssetsInfo'][assetKey]
-		) {
-			return this.cache[this.relayChain][currentChainId]['foreignAssetsInfo'][
-				assetKey
-			] as ForeignAssetsData;
-		}
-
-		return undefined;
+		return lookup[assetKey] ? lookup[assetKey] : undefined;
 	}
 
 	/**
@@ -114,16 +108,9 @@ export class Registry {
 		assetKey: string
 	): { lpToken: string; pairInfo: string } | undefined {
 		const currentChainId = getChainIdBySpecName(this, this.specName);
+		const lookup = this.cache[this.relayChain][currentChainId]['poolPairsInfo'];
 
-		if (
-			this.cache[this.relayChain][currentChainId]['poolPairsInfo'][assetKey]
-		) {
-			return this.cache[this.relayChain][currentChainId]['poolPairsInfo'][
-				assetKey
-			] as { lpToken: string; pairInfo: string };
-		}
-
-		return undefined;
+		return lookup[assetKey] ? lookup[assetKey] : undefined;
 	}
 
 	/**
@@ -149,14 +136,9 @@ export class Registry {
 	 */
 	public cacheLookupAsset(assetKey: string): string | undefined {
 		const currentChainId = getChainIdBySpecName(this, this.specName);
+		const lookup = this.cache[this.relayChain][currentChainId]['assetsInfo'];
 
-		if (this.cache[this.relayChain][currentChainId]['assetsInfo'][assetKey]) {
-			return this.cache[this.relayChain][currentChainId]['assetsInfo'][
-				assetKey
-			];
-		}
-
-		return undefined;
+		return lookup[assetKey] ? lookup[assetKey] : undefined;
 	}
 
 	/**

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -47,8 +47,6 @@ export class Registry {
 			this.cache[this.relayChain][currentChainId] = {
 				assetsInfo: {},
 				poolPairsInfo: {},
-				foreignAssetsPalletInstance: null,
-				assetsPalletInstance: null,
 				specName: '',
 				tokens: [],
 				foreignAssetsInfo: {},
@@ -63,8 +61,6 @@ export class Registry {
 			this.cache[this.relayChain][ASSET_HUB_CHAIN_ID] = {
 				assetsInfo: {},
 				poolPairsInfo: {},
-				foreignAssetsPalletInstance: null,
-				assetsPalletInstance: null,
 				specName: '',
 				tokens: [],
 				foreignAssetsInfo: {},

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -83,7 +83,7 @@ export class Registry {
 		) {
 			return this.cache[this.relayChain][currentChainId]['foreignAssetsInfo'][
 				assetKey
-			];
+			] as ForeignAssetsData;
 		}
 
 		return undefined;

--- a/src/registry/parseRegistry.spec.ts
+++ b/src/registry/parseRegistry.spec.ts
@@ -22,8 +22,6 @@ describe('parseRegistry', () => {
 						assetsInfo,
 						foreignAssetsInfo,
 						specName: 'testing',
-						assetsPalletInstance: '100',
-						foreignAssetsPalletInstance: '1000',
 						poolPairsInfo: {},
 					},
 				},
@@ -36,8 +34,6 @@ describe('parseRegistry', () => {
 			assetsInfo: {},
 			foreignAssetsInfo: {},
 			specName: 'testing',
-			assetsPalletInstance: '100',
-			foreignAssetsPalletInstance: '1000',
 			poolPairsInfo: {},
 		});
 		// Ensure nothing was overwritten

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -26,8 +26,6 @@ export interface ChainInfoKeys {
 	tokens: string[];
 	assetsInfo: AssetsInfo;
 	foreignAssetsInfo: ForeignAssetsInfo | {};
-	assetsPalletInstance: string | null;
-	foreignAssetsPalletInstance: string | null;
 	poolPairsInfo: PoolPairsData | {};
 }
 

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -25,8 +25,8 @@ export interface ChainInfoKeys {
 	specName: string;
 	tokens: string[];
 	assetsInfo: AssetsInfo;
-	foreignAssetsInfo: ForeignAssetsInfo | {};
-	poolPairsInfo: PoolPairsData | {};
+	foreignAssetsInfo: ForeignAssetsInfo;
+	poolPairsInfo: PoolPairsData;
 }
 
 export type ExpandedChainInfoKeys = { chainId: string } & ChainInfoKeys;


### PR DESCRIPTION
rel: https://github.com/paritytech/asset-transfer-api/issues/268

This PR focuses on giving support for `ForeignAssets` inside of `fetchPalletInstanceId` so we can remove `foreignAssetsPalletInstance` from the registry. 