### PR TITLE
feat: add disabled options config and function

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -127,7 +127,7 @@ export class AssetsTransferApi {
 		 * Ensure that the options passed in are compatible with eachother.
 		 * It will throw an error if any are incorrect.
 		 */
-		checkBaseInputOptions(opts);
+		checkBaseInputOptions(opts, this._specName);
 		/**
 		 * Ensure all the inputs are the corrects primitive and or object types.
 		 * It will throw an error if any are incorrect.

--- a/src/config/disabledOpts.ts
+++ b/src/config/disabledOpts.ts
@@ -1,10 +1,12 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { BaseError, BaseErrorsEnum } from '../errors/BaseError';
 import { Format, TransferArgsOpts } from '../types';
 
 interface DisabledOptionsInfo {
 	disabled: boolean;
 	chains: string[];
+	error: (opts: string, chain: string) => never;
 }
 
 type MappedOpts = Extract<keyof TransferArgsOpts<Format>, string>;
@@ -13,41 +15,57 @@ type DisabledOptions = {
 	[key in MappedOpts]: DisabledOptionsInfo;
 };
 
+const callError = (opt: string, chain: string) => {
+	throw new BaseError(
+		`${opt} is disbaled for ${chain}.`,
+		BaseErrorsEnum.DisabledOption
+	);
+};
+
 export const disabledOpts: DisabledOptions = {
 	format: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	paysWithFeeOrigin: {
 		disabled: true,
 		chains: ['westend', 'westmint'],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	paysWithFeeDest: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	sendersAddr: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	isLimited: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	weightLimit: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	xcmVersion: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	keepAlive: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	transferLiquidToken: {
 		disabled: false,
 		chains: [],
+		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 };

--- a/src/config/disabledOpts.ts
+++ b/src/config/disabledOpts.ts
@@ -30,7 +30,7 @@ export const disabledOpts: DisabledOptions = {
 	},
 	paysWithFeeOrigin: {
 		disabled: true,
-		chains: ['westend', 'westmint'],
+		chains: ['westmint'],
 		error: (opt: string, chain: string) => callError(opt, chain),
 	},
 	paysWithFeeDest: {

--- a/src/config/disabledOpts.ts
+++ b/src/config/disabledOpts.ts
@@ -9,7 +9,7 @@ interface DisabledOptionsInfo {
 	error: (opts: string, chain: string) => never;
 }
 
-type MappedOpts = Extract<keyof TransferArgsOpts<Format>, string>;
+export type MappedOpts = Extract<keyof TransferArgsOpts<Format>, string>;
 
 type DisabledOptions = {
 	[key in MappedOpts]: DisabledOptionsInfo;

--- a/src/config/disabledOpts.ts
+++ b/src/config/disabledOpts.ts
@@ -1,0 +1,53 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { Format, TransferArgsOpts } from '../types';
+
+interface DisabledOptionsInfo {
+	disabled: boolean;
+	chains: string[];
+}
+
+type MappedOpts = Extract<keyof TransferArgsOpts<Format>, string>;
+
+type DisabledOptions = {
+	[key in MappedOpts]: DisabledOptionsInfo;
+};
+
+export const disabledOpts: DisabledOptions = {
+	format: {
+		disabled: false,
+		chains: [],
+	},
+	paysWithFeeOrigin: {
+		disabled: true,
+		chains: ['westend', 'westmint'],
+	},
+	paysWithFeeDest: {
+		disabled: false,
+		chains: [],
+	},
+	sendersAddr: {
+		disabled: false,
+		chains: [],
+	},
+	isLimited: {
+		disabled: false,
+		chains: [],
+	},
+	weightLimit: {
+		disabled: false,
+		chains: [],
+	},
+	xcmVersion: {
+		disabled: false,
+		chains: [],
+	},
+	keepAlive: {
+		disabled: false,
+		chains: [],
+	},
+	transferLiquidToken: {
+		disabled: false,
+		chains: [],
+	},
+};

--- a/src/errors/BaseError.ts
+++ b/src/errors/BaseError.ts
@@ -55,6 +55,10 @@ export enum BaseErrorsEnum {
 	 * The inputted address is invalid.
 	 */
 	InvalidAddress = 'InvalidAddress',
+	/**
+	 * The following option is disabled given the inputs.
+	 */
+	DisabledOption = 'DisabledOption',
 }
 
 export class BaseError extends Error {

--- a/src/errors/checkBaseInputOptions.spec.ts
+++ b/src/errors/checkBaseInputOptions.spec.ts
@@ -1,3 +1,5 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
 import type { Format, TransferArgsOpts } from '../types';
 import { checkBaseInputOptions } from './checkBaseInputOptions';
 
@@ -7,7 +9,7 @@ describe('checkBaseInputOptions', () => {
 			format: 'call',
 			paysWithFeeOrigin: '1984',
 		} as TransferArgsOpts<Format>;
-		const err = () => checkBaseInputOptions(opts);
+		const err = () => checkBaseInputOptions(opts, 'statemine');
 
 		expect(err).toThrow(
 			'PaysWithFeeOrigin is only compatible with the format type payload. Received: call'
@@ -18,7 +20,7 @@ describe('checkBaseInputOptions', () => {
 			format: 'submittable',
 			paysWithFeeOrigin: '1984',
 		} as TransferArgsOpts<Format>;
-		const err = () => checkBaseInputOptions(opts);
+		const err = () => checkBaseInputOptions(opts, 'statemine');
 
 		expect(err).toThrow(
 			'PaysWithFeeOrigin is only compatible with the format type payload. Received: submittable'
@@ -29,7 +31,7 @@ describe('checkBaseInputOptions', () => {
 			format: 'payload',
 			paysWithFeeOrigin: '1984',
 		} as TransferArgsOpts<Format>;
-		const err = () => checkBaseInputOptions(opts);
+		const err = () => checkBaseInputOptions(opts, 'statemine');
 
 		expect(err).toThrow(
 			"The 'sendersAddr' option must be present when constructing a 'payload' format."
@@ -41,7 +43,7 @@ describe('checkBaseInputOptions', () => {
 			paysWithFeeOrigin: '1984',
 			sendersAddr: '0x000',
 		} as TransferArgsOpts<Format>;
-		const err = () => checkBaseInputOptions(opts);
+		const err = () => checkBaseInputOptions(opts, 'statemine');
 
 		expect(err).toThrow(
 			'The inputted sendersAddr is not valid. Invalid base58 character "0" (0x30) at index 0'
@@ -53,7 +55,7 @@ describe('checkBaseInputOptions', () => {
 			paysWithFeeOrigin: '1984',
 			sendersAddr: 'FBeL7DanUDs5SZrxZY1CizMaPgG9vZgJgvr52C2dg81SsF1',
 		} as TransferArgsOpts<Format>;
-		const res = () => checkBaseInputOptions(opts);
+		const res = () => checkBaseInputOptions(opts, 'statemine');
 
 		expect(res).not.toThrow();
 	});

--- a/src/errors/checkBaseInputOptions.ts
+++ b/src/errors/checkBaseInputOptions.ts
@@ -1,14 +1,22 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
 import { Format, TransferArgsOpts } from '../types';
 import { validateAddress } from '../validate';
 import { BaseError, BaseErrorsEnum } from './BaseError';
+import { disableOpts } from './disableOpts';
 
 /**
  * Ensure that options that require certain inputs are validated.
  *
  * @param opts
  */
-export const checkBaseInputOptions = (opts: TransferArgsOpts<Format>) => {
+export const checkBaseInputOptions = (
+	opts: TransferArgsOpts<Format>,
+	specName: string
+) => {
 	const { paysWithFeeOrigin, format, sendersAddr } = opts;
+
+	disableOpts(opts, specName);
 
 	if (paysWithFeeOrigin) {
 		if (format === 'call' || format === 'submittable') {

--- a/src/errors/disableOpts.spec.ts
+++ b/src/errors/disableOpts.spec.ts
@@ -1,0 +1,10 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { disableOpts } from './disableOpts';
+
+describe('disableOpts', () => {
+	it('Should error for paysWithFeeOrigin', () => {
+		const err = () => disableOpts({ paysWithFeeOrigin: 'DOT' }, 'westend');
+		expect(err).toThrow('paysWithFeeOrigin is disbaled for westend.');
+	});
+});

--- a/src/errors/disableOpts.spec.ts
+++ b/src/errors/disableOpts.spec.ts
@@ -4,7 +4,7 @@ import { disableOpts } from './disableOpts';
 
 describe('disableOpts', () => {
 	it('Should error for paysWithFeeOrigin', () => {
-		const err = () => disableOpts({ paysWithFeeOrigin: 'DOT' }, 'westend');
-		expect(err).toThrow('paysWithFeeOrigin is disbaled for westend.');
+		const err = () => disableOpts({ paysWithFeeOrigin: 'DOT' }, 'westmint');
+		expect(err).toThrow('paysWithFeeOrigin is disbaled for westmint.');
 	});
 });

--- a/src/errors/disableOpts.ts
+++ b/src/errors/disableOpts.ts
@@ -1,5 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import type { MappedOpts } from '../config/disabledOpts';
 import { disabledOpts } from '../config/disabledOpts';
 import type { Format, TransferArgsOpts } from '../types';
 
@@ -13,15 +14,18 @@ export const disableOpts = <T extends Format>(
 	opts: TransferArgsOpts<T>,
 	specName: string
 ) => {
-	if (opts.paysWithFeeOrigin) {
-		const { paysWithFeeOrigin } = disabledOpts;
-		const chain = specName.toLowerCase();
-		if (paysWithFeeOrigin.chains.includes(chain)) {
-			paysWithFeeOrigin.error(`paysWithFeeOrigin`, chain);
-		}
+	const optKeys = Object.keys(opts) as MappedOpts[];
+	const chain = specName.toLowerCase();
 
-		if (paysWithFeeOrigin.chains.includes('*')) {
-			paysWithFeeOrigin.error(`paysWithFeeOrigin`, `all chains`);
+	for (const key of optKeys) {
+		const disabledKeyInfo = disabledOpts[key];
+		if (opts[key] && disabledKeyInfo.disabled) {
+			if (disabledKeyInfo.chains.includes('*')) {
+				disabledKeyInfo.error(key, `all chains`);
+			}
+			if (disabledKeyInfo.chains.includes(chain)) {
+				disabledKeyInfo.error(key, chain);
+			}
 		}
 	}
 };

--- a/src/errors/disableOpts.ts
+++ b/src/errors/disableOpts.ts
@@ -2,7 +2,6 @@
 
 import { disabledOpts } from '../config/disabledOpts';
 import type { Format, TransferArgsOpts } from '../types';
-import { BaseError, BaseErrorsEnum } from './BaseError';
 
 /**
  * This checks specific options to ensure they are disabled when met in certain conditions.
@@ -16,11 +15,13 @@ export const disableOpts = <T extends Format>(
 ) => {
 	if (opts.paysWithFeeOrigin) {
 		const { paysWithFeeOrigin } = disabledOpts;
-		if (paysWithFeeOrigin.chains.includes(specName.toLowerCase())) {
-			throw new BaseError(
-				`paysWithFeeOrigin is disbaled for ${specName.toLowerCase()}.`,
-				BaseErrorsEnum.DisabledOption
-			);
+		const chain = specName.toLowerCase();
+		if (paysWithFeeOrigin.chains.includes(chain)) {
+			paysWithFeeOrigin.error(`paysWithFeeOrigin`, chain);
+		}
+
+		if (paysWithFeeOrigin.chains.includes('*')) {
+			paysWithFeeOrigin.error(`paysWithFeeOrigin`, `all chains`);
 		}
 	}
 };

--- a/src/errors/disableOpts.ts
+++ b/src/errors/disableOpts.ts
@@ -1,0 +1,26 @@
+// Copyright 2023 Parity Technologies (UK) Ltd.
+
+import { disabledOpts } from '../config/disabledOpts';
+import type { Format, TransferArgsOpts } from '../types';
+import { BaseError, BaseErrorsEnum } from './BaseError';
+
+/**
+ * This checks specific options to ensure they are disabled when met in certain conditions.
+ *
+ * @param opts Options for `createTransferTransaction`
+ * @param specName SpecName of the current chain
+ */
+export const disableOpts = <T extends Format>(
+	opts: TransferArgsOpts<T>,
+	specName: string
+) => {
+	if (opts.paysWithFeeOrigin) {
+		const { paysWithFeeOrigin } = disabledOpts;
+		if (paysWithFeeOrigin.chains.includes(specName.toLowerCase())) {
+			throw new BaseError(
+				`paysWithFeeOrigin is disbaled for ${specName.toLowerCase()}.`,
+				BaseErrorsEnum.DisabledOption
+			);
+		}
+	}
+};


### PR DESCRIPTION
## Internal functionality

This ensures and allows us to add disabling for certain options regarding the `createTransferTransaction` function ie `TransferArgsOpts<T extends Format>`. All one needs to do is going into `config/disabledOpts` and switch the `disabled` key to true, and add which chains are disabled in the `chains` field. 

NOTE: for the `chains` field if we need to disable it for all chains just add `*`.
