### PR TITLE
fix: remove remaining use of `parseInt`

### DIFF
--- a/src/AssetsTransferApi.ts
+++ b/src/AssetsTransferApi.ts
@@ -185,7 +185,7 @@ export class AssetsTransferApi {
 		if (isLocalSystemTx || isLocalRelayTx) {
 			let assetId = assetIds[0];
 			const amount = amounts[0];
-			const localAssetIdIsNotANumber = Number.isNaN(parseInt(assetId));
+			const isValidNumber = validateNumber(assetId);
 			let isNativeRelayChainAsset = false;
 			if (
 				assetIds.length === 0 ||
@@ -196,7 +196,7 @@ export class AssetsTransferApi {
 
 			if (
 				xcmDirection === Direction.SystemToSystem &&
-				localAssetIdIsNotANumber &&
+				!isValidNumber &&
 				!isNativeRelayChainAsset
 			) {
 				// for SystemToSystem, assetId is not the native relayChains asset and is not a number

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -537,10 +537,9 @@ const createParaToSystemMultiAssets = async (
 			const amount = amounts[i];
 			let assetId = assets[i];
 
-			const parsedAssetIdAsNumber = Number.parseInt(assetId);
-			const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+			const isValidNumber = validateNumber(assetId);
 
-			if (isNotANumber && !isPrimaryParachainNativeAsset) {
+			if (!isValidNumber && !isPrimaryParachainNativeAsset) {
 				assetId = await getAssetId(
 					api,
 					registry,

--- a/src/createXcmTypes/util/getAssetId.ts
+++ b/src/createXcmTypes/util/getAssetId.ts
@@ -1,6 +1,7 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { ApiPromise } from '@polkadot/api';
+import BN from 'bn.js';
 
 import { ASSET_HUB_CHAIN_ID } from '../../consts';
 import { BaseError, BaseErrorsEnum } from '../../errors';
@@ -31,7 +32,7 @@ export const getAssetId = async (
 ): Promise<string> => {
 	const currentChainId = getChainIdBySpecName(registry, specName);
 	const assetIsValidInt = validateNumber(asset);
-	const isParachain = parseInt(currentChainId) >= 2000;
+	const isParachain = new BN(currentChainId).gte(new BN(2000));
 
 	// if assets pallet, check the cache and return the cached assetId if found
 	if (!isForeignAssetsTransfer) {

--- a/src/createXcmTypes/util/isSystemChain.spec.ts
+++ b/src/createXcmTypes/util/isSystemChain.spec.ts
@@ -9,7 +9,7 @@ describe('isSystemChain', () => {
 		expect(result).toEqual(true);
 	});
 	it('Should correctly return false for a chainId of 2000', () => {
-		const result = isSystemChain(2000);
+		const result = isSystemChain('2000');
 
 		expect(result).toEqual(false);
 	});

--- a/src/createXcmTypes/util/isSystemChain.ts
+++ b/src/createXcmTypes/util/isSystemChain.ts
@@ -1,13 +1,12 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
+import BN from 'bn.js';
 
 /**
  * Determines if a chain is a system chain based on the value of its chainId being strictly greater than 0 and less than 2000
  * @param chainId
  * @returns boolean
  */
-export const isSystemChain = (chainId: string | number): boolean => {
-	const chainIdAsNumber =
-		typeof chainId === 'string' ? parseInt(chainId) : chainId;
-
-	return chainIdAsNumber > 0 && chainIdAsNumber < 2000;
+export const isSystemChain = (chainId: string): boolean => {
+	const chainIdAsNumber = new BN(chainId);
+	return chainIdAsNumber.gt(new BN(0)) && chainIdAsNumber.lt(new BN(2000));
 };

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -445,7 +445,7 @@ export const checkLiquidTokenValidity = async (
 			);
 
 			const poolAssetInfo = poolAsset[1].unwrap();
-			if (poolAssetInfo.lpToken.toNumber() === parseInt(assetId)) {
+			if (poolAssetInfo.lpToken.toString() === assetId) {
 				const asset: {
 					lpToken: string;
 					pairInfo: string;

--- a/src/util/getFeeAssetItemIndex.ts
+++ b/src/util/getFeeAssetItemIndex.ts
@@ -6,6 +6,7 @@ import { getAssetId } from '../createXcmTypes/util/getAssetId';
 import { BaseError, BaseErrorsEnum } from '../errors';
 import { Registry } from '../registry';
 import { MultiAsset } from '../types';
+import { validateNumber } from '../validate/validateNumber';
 
 /**
  * For System origin XCM V3 Tx's, if paysWithFeeDest option is provided, finds and returns the index
@@ -41,12 +42,11 @@ export const getFeeAssetItemIndex = async (
 					break;
 				}
 			} else {
-				const parsedAssetIdAsNumber = Number.parseInt(paysWithFeeDest);
-				const isNotANumber = Number.isNaN(parsedAssetIdAsNumber);
+				const isValidNumber = validateNumber(paysWithFeeDest);
 
 				// if not a number, get the general index of the pays with fee asset
 				// to compare against the current multi asset
-				if (isNotANumber) {
+				if (!isValidNumber) {
 					const paysWithFeeDestGeneralIndex = await getAssetId(
 						api,
 						registry,


### PR DESCRIPTION
This removes all the remaining instances of `parseInt`. It also chains the input of `isSystemChain` to only take in strings for `chainId`.