### PR TITLE
fix: rococo initialization in the registry

### DIFF
--- a/examples/rococoAssetHubToRelay.ts
+++ b/examples/rococoAssetHubToRelay.ts
@@ -1,0 +1,50 @@
+/**
+ * When importing from @substrate/asset-transfer-api it would look like the following
+ *
+ * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
+ */
+import { AssetTransferApi, constructApiPromise } from '../src';
+import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
+
+/**
+ * In this example we are creating a call to send 1 ROC from a asset-hub-rococo (System Parachain) account
+ * to a Rococo (Relay Chain) account, where the `xcmVersion` is set to 2, and the `isLimited` declaring that
+ * it will be `unlimited` since there is no `weightLimit` option as well.
+ *
+ * NOTE:
+ *
+ * - When `isLimited` is true it will use the `limited` version of the either `reserveAssetTransfer`, or `teleportAssets`.
+ *
+ * - Currently rococos asset-hub shares the same `specName` as kusamas asset-hub, therefore to use rococo you will need to hardcore the
+ * `specName` value as `asset-hub-rococo` into the `AssetTransferApi`.
+ */
+const main = async () => {
+	const { api, safeXcmVersion } = await constructApiPromise('wss://rococo-asset-hub-rpc.polkadot.io');
+	const assetApi = new AssetTransferApi(api, 'asset-hub-rococo', safeXcmVersion);
+
+	let callInfo: TxResult<'call'>;
+	try {
+		callInfo = await assetApi.createTransferTransaction(
+			'0', // NOTE: The destination id is `0` noting that we are sending to the relay chain.
+			'5EWNeodpcQ6iYibJ3jmWVe85nsok1EDG8Kk3aFg8ZzpfY1qX',
+			['ROC'],
+			['1000000000000'],
+			{
+				format: 'call',
+				isLimited: true,
+				xcmVersion: 2,
+			}
+		);
+
+		console.log(callInfo);
+	} catch (e) {
+		console.error(e);
+		throw Error(e as string);
+	}
+
+	const decoded = assetApi.decodeExtrinsic(callInfo.tx, 'call');
+	console.log(`\n${PURPLE}The following decoded tx:\n${GREEN} ${JSON.stringify(JSON.parse(decoded), null, 4)}${RESET}`);
+};
+
+main().finally(() => process.exit());

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -32,6 +32,9 @@ export const SYSTEM_PARACHAINS_NAMES = [
 export const POLKADOT_ASSET_HUB_SPEC_NAMES = ['statemint', 'asset-hub-polkadot'];
 export const KUSAMA_ASSET_HUB_SPEC_NAMES = ['statemine', 'asset-hub-kusama'];
 export const WESTEND_ASSET_HUB_SPEC_NAMES = ['westmint', 'asset-hub-westend'];
+// Rococo's asset hub is currently labeled as `statemine` within our registry.
+// There I put both names a recognizable just in case it changes in polkadot-js.
+export const ROCOCO_ASSET_HUB_SPEC_NAME = ['rococo', 'statemine', 'asset-hub-rococo'];
 
 /**
  * The default xcm version to construct a xcm message.

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -24,6 +24,7 @@ export const SYSTEM_PARACHAINS_NAMES = [
 	'asset-hub-kusama',
 	'asset-hub-polkadot',
 	'asset-hub-westend',
+	'asset-hub-rococo',
 	'bridge-hub-kusama',
 	'bridge-hub-polkadot',
 	'encointer-parachain',
@@ -32,9 +33,7 @@ export const SYSTEM_PARACHAINS_NAMES = [
 export const POLKADOT_ASSET_HUB_SPEC_NAMES = ['statemint', 'asset-hub-polkadot'];
 export const KUSAMA_ASSET_HUB_SPEC_NAMES = ['statemine', 'asset-hub-kusama'];
 export const WESTEND_ASSET_HUB_SPEC_NAMES = ['westmint', 'asset-hub-westend'];
-// Rococo's asset hub is currently labeled as `statemine` within our registry.
-// There I put both names a recognizable just in case it changes in polkadot-js.
-export const ROCOCO_ASSET_HUB_SPEC_NAME = ['rococo', 'statemine', 'asset-hub-rococo'];
+export const ROCOCO_ASSET_HUB_SPEC_NAME = ['asset-hub-rococo'];
 
 /**
  * The default xcm version to construct a xcm message.

--- a/src/registry/Registry.spec.ts
+++ b/src/registry/Registry.spec.ts
@@ -3,6 +3,12 @@ import type { ForeignAssetsData } from './types';
 
 describe('Registry', () => {
 	const registry = new Registry('polkadot', {});
+	describe('initialization', () => {
+		it('Should initalize rococo correctly', () => {
+			const registry = new Registry('rococo', {});
+			expect(registry.relayChain).toEqual('rococo');
+		});
+	});
 	describe('lookupTokenSymbol', () => {
 		it('Should return the correct result', () => {
 			const res = registry.lookupTokenSymbol('GLMR');

--- a/src/registry/findRelayChain.ts
+++ b/src/registry/findRelayChain.ts
@@ -1,4 +1,9 @@
-import { KUSAMA_ASSET_HUB_SPEC_NAMES, POLKADOT_ASSET_HUB_SPEC_NAMES, WESTEND_ASSET_HUB_SPEC_NAMES } from '../consts';
+import {
+	KUSAMA_ASSET_HUB_SPEC_NAMES,
+	POLKADOT_ASSET_HUB_SPEC_NAMES,
+	ROCOCO_ASSET_HUB_SPEC_NAME,
+	WESTEND_ASSET_HUB_SPEC_NAMES,
+} from '../consts';
 import { BaseError, BaseErrorsEnum } from '../errors';
 import type { ChainInfoRegistry, RelayChains } from './types';
 /**
@@ -20,6 +25,11 @@ export const findRelayChain = (specName: string, registry: ChainInfoRegistry): R
 	const westendChains = Object.keys(registry.westend).map((val) => registry.westend[val].specName);
 	if (westendChains.includes(specName.toLowerCase()) || WESTEND_ASSET_HUB_SPEC_NAMES.includes(specName.toLowerCase()))
 		return 'westend';
+
+	const rococoChains = Object.keys(registry.rococo).map((val) => registry.rococo[val].specName);
+	if (rococoChains.includes(specName.toLowerCase()) || ROCOCO_ASSET_HUB_SPEC_NAME) {
+		return 'rococo';
+	}
 
 	throw new BaseError(`Cannot find the relay chain for specName: ${specName}`, BaseErrorsEnum.InternalError);
 };

--- a/src/registry/parseRegistry.spec.ts
+++ b/src/registry/parseRegistry.spec.ts
@@ -11,7 +11,10 @@ describe('parseRegistry', () => {
 		expect(registry.westend['0'].tokens).toStrictEqual(['WND']);
 		expect(registry.rococo['0'].tokens).toStrictEqual(['ROC']);
 	});
-
+	it('Should correctly overwrite rococos asset-hub specName', () => {
+		const registry = parseRegistry({});
+		expect((registry.rococo['1000'].specName = 'asset-hub-rococo'));
+	});
 	it('Should correctly inject an injectedRegsitry', () => {
 		const assetsInfo = {};
 		const foreignAssetsInfo = {};

--- a/src/registry/parseRegistry.spec.ts
+++ b/src/registry/parseRegistry.spec.ts
@@ -13,7 +13,7 @@ describe('parseRegistry', () => {
 	});
 	it('Should correctly overwrite rococos asset-hub specName', () => {
 		const registry = parseRegistry({});
-		expect((registry.rococo['1000'].specName = 'asset-hub-rococo'));
+		expect(registry.rococo['1000'].specName).toEqual('asset-hub-rococo');
 	});
 	it('Should correctly inject an injectedRegsitry', () => {
 		const assetsInfo = {};

--- a/src/registry/parseRegistry.ts
+++ b/src/registry/parseRegistry.ts
@@ -2,6 +2,7 @@
 
 import registry from '@substrate/asset-transfer-api-registry';
 
+import { ASSET_HUB_CHAIN_ID } from '../consts';
 import type { AssetTransferApiOpts } from '../types';
 import type { ChainInfoRegistry } from './types';
 
@@ -18,6 +19,12 @@ export const parseRegistry = (assetsOpts: AssetTransferApiOpts): ChainInfoRegist
 		if (westend) Object.assign(registry.westend, westend);
 		if (rococo) Object.assign(registry.rococo, rococo);
 	}
+
+	/**
+	 * This is a temporary overwrite to ensure the statemine specName is not shared between
+	 * kusama and rococo for their asset-hub chains.
+	 */
+	registry.rococo[ASSET_HUB_CHAIN_ID].specName = 'asset-hub-rococo';
 
 	return registry as ChainInfoRegistry;
 };


### PR DESCRIPTION
rel: https://github.com/paritytech/asset-transfer-api/pull/293

This ensures that the registry can initialize with rococo as the relay chain.

## Important note:

In order to use rococo's asset hub with the `AssetTransferApi` one will need to hardcode the `specName` into the initialization like the following:

```typescript
new AssetTransferApi(api, `asset-hub-rococo`, xcmVersion);
```

The reason being, kusama's asset hub and and rococo's asset-hub both share the same specName currently and will cause conflicts. We currently do an overewrite in the registry that the api uses and set the `specName` for rococo's asset hub to be `asset-hub-rococo`. This should be resolved at a higher level in the below PR for asset-hub's spec.

rel: https://github.com/paritytech/polkadot-sdk/pull/1215