### PR TITLE
fix(internal): refactor dest and beneficiary types generators

### DIFF
--- a/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.ts
@@ -43,8 +43,8 @@ export const limitedReserveTransferAssets = async (
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].limitedReserveTransferAssets;
 	const typeCreator = createXcmTypes[direction];
-	const beneficiary = typeCreator.createBeneficiary(api, destAddr, xcmVersion);
-	const dest = typeCreator.createDest(api, destChainId, xcmVersion);
+	const beneficiary = typeCreator.createBeneficiary(destAddr, xcmVersion);
+	const dest = typeCreator.createDest(destChainId, xcmVersion);
 	const assets = await typeCreator.createAssets(api, normalizeArrToStr(amounts), xcmVersion, specName, assetIds, {
 		registry,
 		isForeignAssetsTransfer,

--- a/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.ts
@@ -41,8 +41,8 @@ export const limitedTeleportAssets = async (
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].limitedTeleportAssets;
 	const typeCreator = createXcmTypes[direction];
-	const beneficiary = typeCreator.createBeneficiary(api, destAddr, xcmVersion);
-	const dest = typeCreator.createDest(api, destChainId, xcmVersion);
+	const beneficiary = typeCreator.createBeneficiary(destAddr, xcmVersion);
+	const dest = typeCreator.createDest(destChainId, xcmVersion);
 	const assets = await typeCreator.createAssets(api, normalizeArrToStr(amounts), xcmVersion, specName, assetIds, {
 		registry,
 		isForeignAssetsTransfer,

--- a/src/createXcmCalls/polkadotXcm/reserveTransferAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/reserveTransferAssets.ts
@@ -41,8 +41,8 @@ export const reserveTransferAssets = async (
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].reserveTransferAssets;
 	const typeCreator = createXcmTypes[direction];
-	const beneficiary = typeCreator.createBeneficiary(api, destAddr, xcmVersion);
-	const dest = typeCreator.createDest(api, destChainId, xcmVersion);
+	const beneficiary = typeCreator.createBeneficiary(destAddr, xcmVersion);
+	const dest = typeCreator.createDest(destChainId, xcmVersion);
 	const assets = await typeCreator.createAssets(api, normalizeArrToStr(amounts), xcmVersion, specName, assetIds, {
 		registry,
 		isForeignAssetsTransfer,

--- a/src/createXcmCalls/polkadotXcm/teleportAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/teleportAssets.ts
@@ -41,8 +41,8 @@ export const teleportAssets = async (
 	const pallet = establishXcmPallet(api);
 	const ext = api.tx[pallet].teleportAssets;
 	const typeCreator = createXcmTypes[direction];
-	const beneficiary = typeCreator.createBeneficiary(api, destAddr, xcmVersion);
-	const dest = typeCreator.createDest(api, destChainId, xcmVersion);
+	const beneficiary = typeCreator.createBeneficiary(destAddr, xcmVersion);
+	const dest = typeCreator.createDest(destChainId, xcmVersion);
 	const assets = await typeCreator.createAssets(api, normalizeArrToStr(amounts), xcmVersion, specName, assetIds, {
 		registry,
 		isForeignAssetsTransfer,

--- a/src/createXcmTypes/ParaToPara.spec.ts
+++ b/src/createXcmTypes/ParaToPara.spec.ts
@@ -9,85 +9,80 @@ describe('ParaToPara', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = ParaToPara.createBeneficiary(
-				mockParachainApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
 						X1: {
 							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = ParaToPara.createBeneficiary(
-				mockParachainApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
 						X1: {
 							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = ParaToPara.createDest(mockParachainApi, '100', 2);
+			const destination = ParaToPara.createDest('100', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: 100,
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = ParaToPara.createDest(mockParachainApi, '100', 3);
+			const destination = ParaToPara.createDest('100', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: 100,
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Assets', () => {

--- a/src/createXcmTypes/ParaToPara.ts
+++ b/src/createXcmTypes/ParaToPara.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 import type { AnyJson } from '@polkadot/types/types';
 

--- a/src/createXcmTypes/ParaToPara.ts
+++ b/src/createXcmTypes/ParaToPara.ts
@@ -5,7 +5,6 @@ import type { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
@@ -32,6 +31,7 @@ import type {
 	CreateWeightLimitOpts,
 	ICreateXcmType,
 	IWeightLimit,
+	XcmBase,
 } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
@@ -45,66 +45,64 @@ export const ParaToPara: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion == 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1: { AccountId32: { network: 'Any', id: accountId } },
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1: { AccountId32: { id: accountId } },
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
 	 *
-	 * @param api ApiPromise
 	 * @param destId The parachain Id of the destination
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, destId: string, xcmVersion?: number) => {
+	createDest: (destId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 1,
 					interior: {
 						X1: {
-							parachain: destId,
+							Parachain: destId,
 						},
 					},
 				},
-			});
+			};
 		}
 
 		/**
 		 * Ensure that the `parents` field is a `1` when sending a destination MultiLocation
 		 * from a system parachain to a sovereign parachain.
 		 */
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 1,
 				interior: {
 					X1: {
-						parachain: destId,
+						Parachain: destId,
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/ParaToSystem.spec.ts
@@ -9,85 +9,80 @@ describe('ParaToSystem', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = ParaToSystem.createBeneficiary(
-				mockParachainApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
-					interior: mockParachainApi.registry.createType('InteriorMultiLocation', {
+					interior: {
 						X1: {
 							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
-					}),
+					},
 				},
 			};
 
-			expect(beneficiary.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = ParaToSystem.createBeneficiary(
-				mockParachainApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
-					interior: mockParachainApi.registry.createType('InteriorMultiLocation', {
+					interior: {
 						X1: {
 							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
-					}),
+					},
 				},
 			};
 
-			expect(beneficiary.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = ParaToSystem.createDest(mockParachainApi, '100', 2);
+			const destination = ParaToSystem.createDest('100', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 1,
-					interior: mockParachainApi.registry.createType('InteriorMultiLocation', {
+					interior: {
 						X1: {
-							Parachain: 100,
+							Parachain: '100',
 						},
-					}),
+					},
 				},
 			};
 
-			expect(destination.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = ParaToSystem.createDest(mockParachainApi, '100', 3);
+			const destination = ParaToSystem.createDest('100', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 1,
-					interior: mockParachainApi.registry.createType('InteriorMultiLocation', {
+					interior: {
 						X1: {
-							Parachain: 100,
+							Parachain: '100',
 						},
-					}),
+					},
 				},
 			};
 
-			expect(destination.toJSON()?.toString()).toStrictEqual(expectedRes.toString());
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Assets', () => {

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 import type { AnyJson } from '@polkadot/types/types';
 

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -5,7 +5,6 @@ import type { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
@@ -32,6 +31,7 @@ import type {
 	CreateWeightLimitOpts,
 	ICreateXcmType,
 	IWeightLimit,
+	XcmBase,
 } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
@@ -45,66 +45,64 @@ export const ParaToSystem: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion == 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1: { AccountId32: { network: 'Any', id: accountId } },
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1: { AccountId32: { id: accountId } },
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
 	 *
-	 * @param api ApiPromise
 	 * @param destId The parachain Id of the destination
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, destId: string, xcmVersion?: number) => {
+	createDest: (destId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 1,
 					interior: {
 						X1: {
-							parachain: destId,
+							Parachain: destId,
 						},
 					},
 				},
-			});
+			};
 		}
 
 		/**
 		 * Ensure that the `parents` field is a `1` when sending a destination MultiLocation
 		 * from a system parachain to a sovereign parachain.
 		 */
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 1,
 				interior: {
 					X1: {
-						parachain: destId,
+						Parachain: destId,
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -9,126 +9,118 @@ describe('RelayToPara XcmVersioned Generation', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = RelayToPara.createBeneficiary(
-				mockRelayApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V2 Ethereum address', () => {
-			const beneficiary = RelayToPara.createBeneficiary(mockRelayApi, '0x96Bd611EbE3Af39544104e26764F4939924F6Ece', 2);
+			const beneficiary = RelayToPara.createBeneficiary('0x96Bd611EbE3Af39544104e26764F4939924F6Ece', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountKey20: {
-								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
-								network: {
-									any: null,
-								},
+						X1: {
+							AccountKey20: {
+								key: '0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = RelayToPara.createBeneficiary(
-				mockRelayApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3 Ethereum address', () => {
-			const beneficiary = RelayToPara.createBeneficiary(mockRelayApi, '0x96Bd611EbE3Af39544104e26764F4939924F6Ece', 3);
+			const beneficiary = RelayToPara.createBeneficiary('0x96Bd611EbE3Af39544104e26764F4939924F6Ece', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountKey20: {
-								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
-								network: null,
+						X1: {
+							AccountKey20: {
+								key: '0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = RelayToPara.createDest(mockRelayApi, '100', 2);
+			const destination = RelayToPara.createDest('100', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							parachain: 100,
+						X1: {
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = RelayToPara.createDest(mockRelayApi, '100', 3);
+			const destination = RelayToPara.createDest('100', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							parachain: 100,
+						X1: {
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Assets', () => {

--- a/src/createXcmTypes/RelayToPara.ts
+++ b/src/createXcmTypes/RelayToPara.ts
@@ -5,13 +5,12 @@ import { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
-import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit } from './types';
+import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
 
 /**
  * XCM type generation for transactions from the relay chain to a parachain.
@@ -20,67 +19,65 @@ export const RelayToPara: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
 			const X1 = isEthereumAddress(accountId)
 				? { AccountKey20: { network: 'Any', key: accountId } }
 				: { AccountId32: { network: 'Any', id: accountId } };
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1,
 					},
 				},
-			});
+			};
 		}
 
 		const X1 = isEthereumAddress(accountId) ? { AccountKey20: { key: accountId } } : { AccountId32: { id: accountId } };
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1,
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
 	 *
-	 * @param api ApiPromise
 	 * @param destId The parachain Id of the destination
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, destId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createDest: (destId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1: {
-							parachain: destId,
+							Parachain: destId,
 						},
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1: {
-						parachain: destId,
+						Parachain: destId,
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/RelayToPara.ts
+++ b/src/createXcmTypes/RelayToPara.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 

--- a/src/createXcmTypes/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/RelayToSystem.spec.ts
@@ -9,86 +9,81 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = RelayToSystem.createBeneficiary(
-				mockRelayApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = RelayToSystem.createBeneficiary(
-				mockRelayApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = RelayToSystem.createDest(mockRelayApi, '100', 2);
+			const destination = RelayToSystem.createDest('100', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							parachain: 100,
+						X1: {
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = RelayToSystem.createDest(mockRelayApi, '100', 3);
+			const destination = RelayToSystem.createDest('100', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							parachain: 100,
+						X1: {
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Assets', () => {

--- a/src/createXcmTypes/RelayToSystem.ts
+++ b/src/createXcmTypes/RelayToSystem.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
 import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';

--- a/src/createXcmTypes/RelayToSystem.ts
+++ b/src/createXcmTypes/RelayToSystem.ts
@@ -5,12 +5,11 @@ import { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
-import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit } from './types';
+import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
 /**
  * XCM type generation for transactions from the relay chain to a system parachain.
  */
@@ -18,13 +17,12 @@ export const RelayToSystem: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
@@ -36,10 +34,10 @@ export const RelayToSystem: ICreateXcmType = {
 						},
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
@@ -50,7 +48,7 @@ export const RelayToSystem: ICreateXcmType = {
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
@@ -59,30 +57,30 @@ export const RelayToSystem: ICreateXcmType = {
 	 * @param destId The parachain Id of the destination
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, destId: string, xcmVersion: number): VersionedMultiLocation => {
+	createDest: (destId: string, xcmVersion: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1: {
-							parachain: destId,
+							Parachain: destId,
 						},
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1: {
-						parachain: destId,
+						Parachain: destId,
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -11,134 +11,124 @@ describe('SystemToPara XcmVersioned Generation', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = SystemToPara.createBeneficiary(
-				mockSystemApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V2 for an Ethereum Address', () => {
 			const beneficiary = SystemToPara.createBeneficiary(
-				mockSystemApi,
 				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountKey20: {
-								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
-								network: {
-									any: null,
-								},
+						X1: {
+							AccountKey20: {
+								key: '0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = SystemToPara.createBeneficiary(
-				mockSystemApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3 for an Ethereum Address', () => {
 			const beneficiary = SystemToPara.createBeneficiary(
-				mockSystemApi,
 				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountKey20: {
-								key: '0x96bd611ebe3af39544104e26764f4939924f6ece',
-								network: null,
+						X1: {
+							AccountKey20: {
+								key: '0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = SystemToPara.createDest(mockSystemApi, '100', 2);
+			const destination = SystemToPara.createDest('100', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 1,
 					interior: {
-						x1: {
-							parachain: 100,
+						X1: {
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = SystemToPara.createDest(mockSystemApi, '100', 3);
+			const destination = SystemToPara.createDest('100', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 1,
 					interior: {
-						x1: {
-							parachain: 100,
+						X1: {
+							Parachain: '100',
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -32,10 +32,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V2 for an Ethereum Address', () => {
-			const beneficiary = SystemToPara.createBeneficiary(
-				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
-				2
-			);
+			const beneficiary = SystemToPara.createBeneficiary('0x96Bd611EbE3Af39544104e26764F4939924F6Ece', 2);
 
 			const expectedRes = {
 				V2: {
@@ -75,10 +72,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3 for an Ethereum Address', () => {
-			const beneficiary = SystemToPara.createBeneficiary(
-				'0x96Bd611EbE3Af39544104e26764F4939924F6Ece',
-				3
-			);
+			const beneficiary = SystemToPara.createBeneficiary('0x96Bd611EbE3Af39544104e26764F4939924F6Ece', 3);
 
 			const expectedRes = {
 				V3: {

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -5,7 +5,6 @@ import type { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
@@ -17,7 +16,7 @@ import { FungibleStrMultiAsset, UnionXcmMultiLocation } from '../types';
 import { getFeeAssetItemIndex } from '../util/getFeeAssetItemIndex';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { validateNumber } from '../validate';
-import { CreateAssetsOpts, CreateFeeAssetItemOpts, CreateWeightLimitOpts, ICreateXcmType, IWeightLimit } from './types';
+import { CreateAssetsOpts, CreateFeeAssetItemOpts, CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
@@ -30,72 +29,70 @@ export const SystemToPara: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion == 2) {
 			const X1 = isEthereumAddress(accountId)
 				? { AccountKey20: { network: 'Any', key: accountId } }
 				: { AccountId32: { network: 'Any', id: accountId } };
 
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1,
 					},
 				},
-			});
+			};
 		}
 
 		const X1 = isEthereumAddress(accountId) ? { AccountKey20: { key: accountId } } : { AccountId32: { id: accountId } };
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1,
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
 	 *
-	 * @param api ApiPromise
 	 * @param destId The parachain Id of the destination
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, destId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createDest: (destId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 1,
 					interior: {
 						X1: {
-							parachain: destId,
+							Parachain: destId,
 						},
 					},
 				},
-			});
+			};
 		}
 
 		/**
 		 * Ensure that the `parents` field is a `1` when sending a destination MultiLocation
 		 * from a system parachain to a sovereign parachain.
 		 */
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 1,
 				interior: {
 					X1: {
-						parachain: destId,
+						Parachain: destId,
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
@@ -16,7 +12,14 @@ import { FungibleStrMultiAsset, UnionXcmMultiLocation } from '../types';
 import { getFeeAssetItemIndex } from '../util/getFeeAssetItemIndex';
 import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { validateNumber } from '../validate';
-import { CreateAssetsOpts, CreateFeeAssetItemOpts, CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
+import {
+	CreateAssetsOpts,
+	CreateFeeAssetItemOpts,
+	CreateWeightLimitOpts,
+	ICreateXcmType,
+	IWeightLimit,
+	XcmBase,
+} from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';

--- a/src/createXcmTypes/SystemToRelay.spec.ts
+++ b/src/createXcmTypes/SystemToRelay.spec.ts
@@ -10,59 +10,54 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = SystemToRelay.createBeneficiary(
-				mockSystemApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = SystemToRelay.createBeneficiary(
-				mockSystemApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
-						x1: {
-							accountId32: {
+						X1: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
 					},
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = SystemToRelay.createDest(mockSystemApi, '0', 2);
+			const destination = SystemToRelay.createDest('0', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 1,
 					interior: {
 						here: null,
@@ -70,13 +65,13 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = SystemToRelay.createDest(mockSystemApi, '0', 3);
+			const destination = SystemToRelay.createDest('0', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 1,
 					interior: {
 						here: null,
@@ -84,7 +79,7 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Assets', () => {

--- a/src/createXcmTypes/SystemToRelay.ts
+++ b/src/createXcmTypes/SystemToRelay.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
 import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';

--- a/src/createXcmTypes/SystemToRelay.ts
+++ b/src/createXcmTypes/SystemToRelay.ts
@@ -5,24 +5,22 @@ import { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
-import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit } from './types';
+import { CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
 
 export const SystemToRelay: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
@@ -34,10 +32,10 @@ export const SystemToRelay: ICreateXcmType = {
 						},
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
@@ -48,35 +46,34 @@ export const SystemToRelay: ICreateXcmType = {
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
 	 *
-	 * @param api ApiPromise
 	 * @param destId The destId in this case, which is the relay chain
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, _: string, xcmVersion: number): VersionedMultiLocation => {
+	createDest: (_: string, xcmVersion: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 1,
 					interior: {
 						here: null,
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 1,
 				interior: {
 					here: null,
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/SystemToSystem.spec.ts
@@ -10,7 +10,6 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = SystemToSystem.createBeneficiary(
-				mockSystemApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				2
 			);
@@ -19,7 +18,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 				v2: {
 					parents: 0,
 					interior: {
-						x1: {
+						X1: {
 							accountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 								network: {
@@ -31,11 +30,10 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
 			const beneficiary = SystemToSystem.createBeneficiary(
-				mockSystemApi,
 				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 				3
 			);
@@ -44,7 +42,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 				v3: {
 					parents: 0,
 					interior: {
-						x1: {
+						X1: {
 							accountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 								network: null,
@@ -54,41 +52,41 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 				},
 			};
 
-			expect(beneficiary.toJSON()).toStrictEqual(expectedRes);
+			expect(beneficiary).toStrictEqual(expectedRes);
 		});
 	});
 	describe('Destination', () => {
 		it('Should work for V2', () => {
-			const destination = SystemToSystem.createDest(mockSystemApi, '1000', 2);
+			const destination = SystemToSystem.createDest('1000', 2);
 
 			const expectedRes = {
 				v2: {
 					parents: 1,
 					interior: {
-						x1: {
-							parachain: 1000,
+						X1: {
+							Parachain: 1000,
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 		it('Should work for V3', () => {
-			const destination = SystemToSystem.createDest(mockSystemApi, '1002', 3);
+			const destination = SystemToSystem.createDest('1002', 3);
 
 			const expectedRes = {
 				v3: {
 					parents: 1,
 					interior: {
-						x1: {
-							parachain: 1002,
+						X1: {
+							Parachain: 1002,
 						},
 					},
 				},
 			};
 
-			expect(destination.toJSON()).toStrictEqual(expectedRes);
+			expect(destination).toStrictEqual(expectedRes);
 		});
 	});
 

--- a/src/createXcmTypes/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/SystemToSystem.spec.ts
@@ -15,15 +15,13 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 			);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 0,
 					interior: {
 						X1: {
-							accountId32: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: {
-									any: null,
-								},
+								network: 'Any',
 							},
 						},
 					},
@@ -39,13 +37,12 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 			);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 0,
 					interior: {
 						X1: {
-							accountId32: {
+							AccountId32: {
 								id: '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-								network: null,
 							},
 						},
 					},
@@ -60,11 +57,11 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 			const destination = SystemToSystem.createDest('1000', 2);
 
 			const expectedRes = {
-				v2: {
+				V2: {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: 1000,
+							Parachain: '1000',
 						},
 					},
 				},
@@ -76,11 +73,11 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 			const destination = SystemToSystem.createDest('1002', 3);
 
 			const expectedRes = {
-				v3: {
+				V3: {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: 1002,
+							Parachain: '1002',
 						},
 					},
 				},

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -5,7 +5,6 @@ import { u32 } from '@polkadot/types';
 import type {
 	MultiAssetsV2,
 	VersionedMultiAssets,
-	VersionedMultiLocation,
 	WeightLimitV2,
 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
@@ -17,7 +16,7 @@ import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { resolveMultiLocation } from '../util/resolveMultiLocation';
 import { validateNumber } from '../validate';
 import { FungibleStrMultiAsset, UnionXcmMultiLocation } from './../types';
-import { CreateAssetsOpts, CreateFeeAssetItemOpts, CreateWeightLimitOpts, ICreateXcmType, IWeightLimit } from './types';
+import { CreateAssetsOpts, CreateFeeAssetItemOpts, CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
 import { getAssetId } from './util/getAssetId';
@@ -25,70 +24,70 @@ import { isRelayNativeAsset } from './util/isRelayNativeAsset';
 import { isSystemChain } from './util/isSystemChain';
 import { sortMultiAssetsAscending } from './util/sortMultiAssetsAscending';
 
+
+
 export const SystemToSystem: ICreateXcmType = {
 	/**
 	 * Create a XcmVersionedMultiLocation type for a beneficiary.
 	 *
-	 * @param api ApiPromise
 	 * @param accountId The accountId of the beneficiary
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createBeneficiary: (accountId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion == 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 0,
 					interior: {
 						X1: { AccountId32: { network: 'Any', id: accountId } },
 					},
 				},
-			});
+			};
 		}
 
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 0,
 				interior: {
 					X1: { AccountId32: { id: accountId } },
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a XcmVersionedMultiLocation type for a destination.
 	 *
-	 * @param api ApiPromise
 	 * @param destId The parachain Id of the destination
 	 * @param xcmVersion The accepted xcm version
 	 */
-	createDest: (api: ApiPromise, destId: string, xcmVersion?: number): VersionedMultiLocation => {
+	createDest: (destId: string, xcmVersion?: number): XcmBase => {
 		if (xcmVersion === 2) {
-			return api.registry.createType('XcmVersionedMultiLocation', {
+			return {
 				V2: {
 					parents: 1,
 					interior: {
 						X1: {
-							parachain: destId,
+							Parachain: destId,
 						},
 					},
 				},
-			});
+			};
 		}
 
 		/**
 		 * Ensure that the `parents` field is a `1` when sending a destination MultiLocation
 		 * from a system parachain to a sovereign parachain.
 		 */
-		return api.registry.createType('XcmVersionedMultiLocation', {
+		return {
 			V3: {
 				parents: 1,
 				interior: {
 					X1: {
-						parachain: destId,
+						Parachain: destId,
 					},
 				},
 			},
-		});
+		};
 	},
 	/**
 	 * Create a VersionedMultiAsset type.

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -2,11 +2,7 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type {
-	MultiAssetsV2,
-	VersionedMultiAssets,
-	WeightLimitV2,
-} from '@polkadot/types/interfaces';
+import type { MultiAssetsV2, VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { XcmV3MultiassetMultiAssets } from '@polkadot/types/lookup';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -16,15 +12,20 @@ import { normalizeArrToStr } from '../util/normalizeArrToStr';
 import { resolveMultiLocation } from '../util/resolveMultiLocation';
 import { validateNumber } from '../validate';
 import { FungibleStrMultiAsset, UnionXcmMultiLocation } from './../types';
-import { CreateAssetsOpts, CreateFeeAssetItemOpts, CreateWeightLimitOpts, ICreateXcmType, IWeightLimit, XcmBase } from './types';
+import {
+	CreateAssetsOpts,
+	CreateFeeAssetItemOpts,
+	CreateWeightLimitOpts,
+	ICreateXcmType,
+	IWeightLimit,
+	XcmBase,
+} from './types';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
 import { getAssetId } from './util/getAssetId';
 import { isRelayNativeAsset } from './util/isRelayNativeAsset';
 import { isSystemChain } from './util/isSystemChain';
 import { sortMultiAssetsAscending } from './util/sortMultiAssetsAscending';
-
-
 
 export const SystemToSystem: ICreateXcmType = {
 	/**

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -16,18 +16,15 @@ export type XcmBase = {
 	}
 }
 
-export type XcmAccountId32 = {
+export type XcmJunction = {
 	AccountId32: {
 		network?: string;
 		id: string;
-	}
-}
-
-export type XcmJunction = {
-	AccountId32?: {
-		network?: string;
-		id: string;
 	},
+	AccountKey20: {
+		network?: string;
+		key: string;
+	}
 	Parachain: string
 }
 

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -2,10 +2,34 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type { VersionedMultiAssets, VersionedMultiLocation, WeightLimitV2 } from '@polkadot/types/interfaces';
+import type { VersionedMultiAssets, WeightLimitV2 } from '@polkadot/types/interfaces';
 
 import type { Registry } from '../registry';
 import type { RequireOnlyOne, XCMDestBenificiary, XcmMultiLocation, XcmVersionedMultiAsset, XcmWeight } from '../types';
+
+export type XcmBase = {
+	[x: string]: {
+		parents: number,
+		interior: {
+			[x: string]: RequireOnlyOne<XcmJunction>
+		}
+	}
+}
+
+export type XcmAccountId32 = {
+	AccountId32: {
+		network?: string;
+		id: string;
+	}
+}
+
+export type XcmJunction = {
+	AccountId32?: {
+		network?: string;
+		id: string;
+	},
+	Parachain: string
+}
 
 export interface CreateAssetsOpts {
 	registry: Registry;
@@ -37,8 +61,8 @@ export interface CheckXcmTxInputsOpts {
 }
 
 export interface ICreateXcmType {
-	createBeneficiary: (api: ApiPromise, accountId: string, xcmVersion: number) => VersionedMultiLocation;
-	createDest: (api: ApiPromise, destId: string, xcmVersion: number) => VersionedMultiLocation;
+	createBeneficiary: (accountId: string, xcmVersion: number) => XcmBase;
+	createDest: (destId: string, xcmVersion: number) => XcmBase;
 	createAssets: (
 		api: ApiPromise,
 		amounts: string[],

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -11,7 +11,7 @@ export type XcmBase = {
 	[x: string]: {
 		parents: number,
 		interior: {
-			[x: string]: RequireOnlyOne<XcmJunction>
+			[x: string]: RequireOnlyOne<XcmJunction> | null
 		}
 	}
 }

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -9,24 +9,24 @@ import type { RequireOnlyOne, XCMDestBenificiary, XcmMultiLocation, XcmVersioned
 
 export type XcmBase = {
 	[x: string]: {
-		parents: number,
+		parents: number;
 		interior: {
-			[x: string]: RequireOnlyOne<XcmJunction> | null
-		}
-	}
-}
+			[x: string]: RequireOnlyOne<XcmJunction> | null;
+		};
+	};
+};
 
 export type XcmJunction = {
 	AccountId32: {
 		network?: string;
 		id: string;
-	},
+	};
 	AccountKey20: {
 		network?: string;
 		key: string;
-	}
-	Parachain: string
-}
+	};
+	Parachain: string;
+};
 
 export interface CreateAssetsOpts {
 	registry: Registry;


### PR DESCRIPTION
rel: https://github.com/paritytech/asset-transfer-api/issues/301

part 1.

This ensures we don't rely on `createType` for type generation, and focuses first on refactoring destination and beneficiary type generators to ensure PR's stay small.