### PR TITLE
fix(internal): refactor all weight limits to not use createType

### DIFF
--- a/src/constructApiPromise.ts
+++ b/src/constructApiPromise.ts
@@ -50,6 +50,6 @@ export const constructApiPromise = async (wsUrl: string, opts: ApiOptions = {}):
 	return {
 		api,
 		specName: specName.toString(),
-		safeXcmVersion: safeXcmVersion.toNumber(),
+		safeXcmVersion: safeXcmVersion,
 	};
 };

--- a/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.ts
@@ -51,7 +51,7 @@ export const limitedReserveTransferAssets = async (
 		isLiquidTokenTransfer,
 		api,
 	});
-	const weightLimitType = typeCreator.createWeightLimit(api, {
+	const weightLimitType = typeCreator.createWeightLimit({
 		isLimited,
 		weightLimit,
 	});

--- a/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.ts
@@ -2,7 +2,6 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
-import { u32 } from '@polkadot/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { createXcmTypes } from '../../createXcmTypes';
@@ -56,7 +55,7 @@ export const limitedReserveTransferAssets = async (
 		weightLimit,
 	});
 
-	const feeAssetItem: u32 = paysWithFeeDest
+	const feeAssetItem = paysWithFeeDest
 		? await typeCreator.createFeeAssetItem(api, {
 				registry,
 				paysWithFeeDest,
@@ -67,7 +66,7 @@ export const limitedReserveTransferAssets = async (
 				isForeignAssetsTransfer,
 				isLiquidTokenTransfer,
 		  })
-		: api.registry.createType('u32', 0);
+		: 0;
 
 	return ext(dest, beneficiary, assets, feeAssetItem, weightLimitType);
 };

--- a/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.ts
@@ -60,7 +60,7 @@ export const limitedTeleportAssets = async (
 				isForeignAssetsTransfer,
 				isLiquidTokenTransfer: false,
 		  })
-		: api.registry.createType('u32', 0);
+		: 0;
 
 	return ext(dest, beneficiary, assets, feeAssetItem, weightLimitType);
 };

--- a/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.ts
@@ -49,7 +49,7 @@ export const limitedTeleportAssets = async (
 		isLiquidTokenTransfer: false,
 		api,
 	});
-	const weightLimitType = typeCreator.createWeightLimit(api, {
+	const weightLimitType = typeCreator.createWeightLimit({
 		isLimited,
 		weightLimit,
 	});

--- a/src/createXcmCalls/polkadotXcm/reserveTransferAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/reserveTransferAssets.ts
@@ -61,7 +61,7 @@ export const reserveTransferAssets = async (
 				isForeignAssetsTransfer,
 				isLiquidTokenTransfer,
 		  })
-		: api.registry.createType('u32', 0);
+		: 0;
 
 	return ext(dest, beneficiary, assets, feeAssetItem);
 };

--- a/src/createXcmCalls/polkadotXcm/teleportAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/teleportAssets.ts
@@ -56,7 +56,7 @@ export const teleportAssets = async (
 				isForeignAssetsTransfer,
 				isLiquidTokenTransfer: false,
 		  })
-		: api.registry.createType('u32', 0);
+		: 0;
 
 	return ext(dest, beneficiary, assets, feeAssetItem);
 };

--- a/src/createXcmCalls/util/fetchSafeXcmVersion.spec.ts
+++ b/src/createXcmCalls/util/fetchSafeXcmVersion.spec.ts
@@ -6,6 +6,6 @@ import { fetchSafeXcmVersion } from './fetchSafeXcmVersion';
 describe('fetchSafeXcmVersion', () => {
 	it('Should return the correct value when the Option is true', async () => {
 		const version = await fetchSafeXcmVersion(adjustedMockSystemApi);
-		expect(version.toNumber()).toEqual(2);
+		expect(version).toEqual(2);
 	});
 });

--- a/src/createXcmCalls/util/fetchSafeXcmVersion.ts
+++ b/src/createXcmCalls/util/fetchSafeXcmVersion.ts
@@ -12,10 +12,10 @@ import { establishXcmPallet } from './establishXcmPallet';
  *
  * @param api ApiPromise
  */
-export const fetchSafeXcmVersion = async (api: ApiPromise): Promise<u32> => {
+export const fetchSafeXcmVersion = async (api: ApiPromise): Promise<number> => {
 	const pallet = establishXcmPallet(api);
 	const safeVersion = await api.query[pallet].safeXcmVersion<Option<u32>>();
-	const version = safeVersion.isSome ? safeVersion.unwrap() : api.registry.createType('u32', DEFAULT_XCM_VERSION);
+	const version = safeVersion.isSome ? safeVersion.unwrap().toNumber() : DEFAULT_XCM_VERSION;
 
 	return version;
 };

--- a/src/createXcmCalls/xTokens/transferMultiAsset.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAsset.ts
@@ -43,7 +43,7 @@ export const transferMultiAsset = async (
 	const { isLimited, weightLimit, isForeignAssetsTransfer, isLiquidTokenTransfer } = opts;
 	const ext = api.tx[xcmPallet].transferMultiasset;
 	const typeCreator = createXcmTypes[direction];
-	const destWeightLimit = typeCreator.createWeightLimit(api, {
+	const destWeightLimit = typeCreator.createWeightLimit({
 		isLimited,
 		weightLimit,
 	});

--- a/src/createXcmCalls/xTokens/transferMultiAssetWithFee.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAssetWithFee.ts
@@ -43,7 +43,7 @@ export const transferMultiAssetWithFee = async (
 	const { isLimited, weightLimit, paysWithFeeDest, isForeignAssetsTransfer, isLiquidTokenTransfer } = opts;
 	const ext = api.tx[xcmPallet].transferMultiassetWithFee;
 	const typeCreator = createXcmTypes[direction];
-	const destWeightLimit = typeCreator.createWeightLimit(api, {
+	const destWeightLimit = typeCreator.createWeightLimit({
 		isLimited,
 		weightLimit,
 	});

--- a/src/createXcmCalls/xTokens/transferMultiAssets.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAssets.ts
@@ -46,7 +46,7 @@ export const transferMultiAssets = async (
 	const ext = api.tx[xcmPallet].transferMultiassets;
 	const typeCreator = createXcmTypes[direction];
 
-	const destWeightLimit = typeCreator.createWeightLimit(api, {
+	const destWeightLimit = typeCreator.createWeightLimit({
 		isLimited,
 		weightLimit,
 	});

--- a/src/createXcmTypes/ParaToPara.spec.ts
+++ b/src/createXcmTypes/ParaToPara.spec.ts
@@ -189,25 +189,25 @@ describe('ParaToPara', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = ParaToPara.createWeightLimit(mockParachainApi, {
+			const weightLimit = ParaToPara.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					proofSize: 1000,
-					refTime: 100000000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					proofSize: '1000',
+					refTime: '100000000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = ParaToPara.createWeightLimit(mockParachainApi, {});
+			const weightLimit = ParaToPara.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/ParaToPara.ts
+++ b/src/createXcmTypes/ParaToPara.ts
@@ -2,7 +2,6 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { AnyJson } from '@polkadot/types/types';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -20,7 +19,6 @@ import type {
 	FungibleObjMultiAsset,
 	FungibleStrMultiAsset,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcAssetsMultiAsset,
 	UnionXcAssetsMultiAssets,
 	UnionXcAssetsMultiLocation,
@@ -28,6 +26,7 @@ import type {
 	XcmDestBenificiary,
 	XcmDestBenificiaryXcAssets,
 	XcmV3MultiLocation,
+	XcmWeight,
 } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
@@ -144,18 +143,15 @@ export const ParaToPara: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit.refTime,
-							proofSize: opts.weightLimit.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit.refTime,
+						proofSize: opts.weightLimit.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 	/**
 	 * returns the correct feeAssetItem based on XCM direction.

--- a/src/createXcmTypes/ParaToPara.ts
+++ b/src/createXcmTypes/ParaToPara.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import type { u32 } from '@polkadot/types';
 import type { AnyJson } from '@polkadot/types/types';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -164,7 +163,7 @@ export const ParaToPara: ICreateXcmType = {
 	 * @xcmVersion number
 	 *
 	 */
-	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<u32> => {
+	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<number> => {
 		const { registry, paysWithFeeDest, specName, assetIds, amounts, xcmVersion, isForeignAssetsTransfer } = opts;
 		if (xcmVersion && xcmVersion === 3 && specName && amounts && assetIds && paysWithFeeDest) {
 			const multiAssets = await createParaToParaMultiAssets(
@@ -187,10 +186,10 @@ export const ParaToPara: ICreateXcmType = {
 				isForeignAssetsTransfer
 			);
 
-			return api.registry.createType('u32', assetIndex);
+			return assetIndex;
 		}
 
-		return api.registry.createType('u32', 0);
+		return 0;
 	},
 	createXTokensBeneficiary: (
 		destChainId: string,

--- a/src/createXcmTypes/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/ParaToSystem.spec.ts
@@ -189,25 +189,25 @@ describe('ParaToSystem', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = ParaToSystem.createWeightLimit(mockParachainApi, {
+			const weightLimit = ParaToSystem.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					proofSize: 1000,
-					refTime: 100000000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					proofSize: '1000',
+					refTime: '100000000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = ParaToSystem.createWeightLimit(mockParachainApi, {});
+			const weightLimit = ParaToSystem.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import type { u32 } from '@polkadot/types';
 import type { AnyJson } from '@polkadot/types/types';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -162,7 +161,7 @@ export const ParaToSystem: ICreateXcmType = {
 	 * @xcmVersion number
 	 *
 	 */
-	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<u32> => {
+	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<number> => {
 		const { registry, paysWithFeeDest, specName, assetIds, amounts, xcmVersion } = opts;
 		if (xcmVersion && xcmVersion === 3 && specName && amounts && assetIds && paysWithFeeDest) {
 			const multiAssets = await createParaToSystemMultiAssets(
@@ -185,10 +184,10 @@ export const ParaToSystem: ICreateXcmType = {
 				opts.isForeignAssetsTransfer
 			);
 
-			return api.registry.createType('u32', assetIndex);
+			return assetIndex;
 		}
 
-		return api.registry.createType('u32', 0);
+		return 0;
 	},
 	createXTokensBeneficiary: (
 		destChainId: string,

--- a/src/createXcmTypes/ParaToSystem.ts
+++ b/src/createXcmTypes/ParaToSystem.ts
@@ -2,7 +2,6 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { AnyJson } from '@polkadot/types/types';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -20,7 +19,6 @@ import type {
 	FungibleObjMultiAsset,
 	FungibleStrMultiAsset,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcAssetsMultiAsset,
 	UnionXcAssetsMultiAssets,
 	UnionXcAssetsMultiLocation,
@@ -28,6 +26,7 @@ import type {
 	XcmDestBenificiary,
 	XcmDestBenificiaryXcAssets,
 	XcmV3MultiLocation,
+	XcmWeight,
 } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
@@ -142,18 +141,15 @@ export const ParaToSystem: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit.refTime,
-							proofSize: opts.weightLimit.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit.refTime,
+						proofSize: opts.weightLimit.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 	/**
 	 * returns the correct feeAssetItem based on XCM direction.

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -192,25 +192,25 @@ describe('RelayToPara XcmVersioned Generation', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = RelayToPara.createWeightLimit(mockRelayApi, {
+			const weightLimit = RelayToPara.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					refTime: 100000000,
-					proofSize: 1000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					refTime: '100000000',
+					proofSize: '1000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = RelayToPara.createWeightLimit(mockRelayApi, {});
+			const weightLimit = RelayToPara.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/RelayToPara.ts
+++ b/src/createXcmTypes/RelayToPara.ts
@@ -2,16 +2,15 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import {
 	CreateWeightLimitOpts,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcmMultiAssets,
 	XcmDestBenificiary,
 	XcmMultiAsset,
+	XcmWeight,
 } from './types';
 
 /**
@@ -127,18 +126,15 @@ export const RelayToPara: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit?.refTime,
-							proofSize: opts.weightLimit?.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit?.refTime,
+						proofSize: opts.weightLimit?.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 
 	/**

--- a/src/createXcmTypes/RelayToPara.ts
+++ b/src/createXcmTypes/RelayToPara.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import { u32 } from '@polkadot/types';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import {
@@ -142,7 +141,7 @@ export const RelayToPara: ICreateXcmType = {
 	 *
 	 * @param api ApiPromise
 	 */
-	createFeeAssetItem: async (api: ApiPromise): Promise<u32> => {
-		return await Promise.resolve(api.registry.createType('u32', 0));
+	createFeeAssetItem: async (_: ApiPromise): Promise<number> => {
+		return await Promise.resolve(0);
 	},
 };

--- a/src/createXcmTypes/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/RelayToSystem.spec.ts
@@ -154,25 +154,25 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = RelayToSystem.createWeightLimit(mockRelayApi, {
+			const weightLimit = RelayToSystem.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					refTime: 100000000,
-					proofSize: 1000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					refTime: '100000000',
+					proofSize: '1000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = RelayToSystem.createWeightLimit(mockRelayApi, {});
+			const weightLimit = RelayToSystem.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/RelayToSystem.ts
+++ b/src/createXcmTypes/RelayToSystem.ts
@@ -2,15 +2,14 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 
 import {
 	CreateWeightLimitOpts,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcmMultiAssets,
 	XcmDestBenificiary,
 	XcmMultiAsset,
+	XcmWeight,
 } from './types';
 /**
  * XCM type generation for transactions from the relay chain to a system parachain.
@@ -130,18 +129,15 @@ export const RelayToSystem: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit?.refTime,
-							proofSize: opts.weightLimit?.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit?.refTime,
+						proofSize: opts.weightLimit?.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 
 	/**

--- a/src/createXcmTypes/RelayToSystem.ts
+++ b/src/createXcmTypes/RelayToSystem.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import { u32 } from '@polkadot/types';
 
 import {
 	CreateWeightLimitOpts,
@@ -145,7 +144,7 @@ export const RelayToSystem: ICreateXcmType = {
 	 *
 	 * @param api ApiPromise
 	 */
-	createFeeAssetItem: async (api: ApiPromise): Promise<u32> => {
-		return await Promise.resolve(api.registry.createType('u32', 0));
+	createFeeAssetItem: async (_: ApiPromise): Promise<number> => {
+		return await Promise.resolve(0);
 	},
 };

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -262,25 +262,25 @@ describe('SystemToPara XcmVersioned Generation', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = SystemToPara.createWeightLimit(mockSystemApi, {
+			const weightLimit = SystemToPara.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					refTime: 100000000,
-					proofSize: 1000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					refTime: '100000000',
+					proofSize: '1000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = SystemToPara.createWeightLimit(mockSystemApi, {});
+			const weightLimit = SystemToPara.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import type { u32 } from '@polkadot/types';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -166,7 +165,7 @@ export const SystemToPara: ICreateXcmType = {
 	 * @xcmVersion number
 	 *
 	 */
-	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<u32> => {
+	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<number> => {
 		const {
 			registry,
 			paysWithFeeDest,
@@ -207,10 +206,10 @@ export const SystemToPara: ICreateXcmType = {
 				isForeignAssetsTransfer
 			);
 
-			return api.registry.createType('u32', assetIndex);
+			return assetIndex;
 		}
 
-		return api.registry.createType('u32', 0);
+		return 0;
 	},
 };
 

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -2,7 +2,6 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import type { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
@@ -17,12 +16,12 @@ import type {
 	CreateWeightLimitOpts,
 	FungibleStrMultiAsset,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcmMultiAssets,
 	UnionXcmMultiLocation,
 	XcmDestBenificiary,
 	XcmV2Junctions,
 	XcmV3Junctions,
+	XcmWeight,
 } from './types';
 import { constructForeignAssetMultiLocationFromAssetId } from './util/constructForeignAssetMultiLocationFromAssetId';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
@@ -145,18 +144,15 @@ export const SystemToPara: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit?.refTime,
-							proofSize: opts.weightLimit?.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit?.refTime,
+						proofSize: opts.weightLimit?.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 
 	/**

--- a/src/createXcmTypes/SystemToRelay.spec.ts
+++ b/src/createXcmTypes/SystemToRelay.spec.ts
@@ -148,25 +148,25 @@ describe('SystemToRelay XcmVersioned Generation', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = SystemToRelay.createWeightLimit(mockSystemApi, {
+			const weightLimit = SystemToRelay.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					refTime: 100000000,
-					proofSize: 1000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					refTime: '100000000',
+					proofSize: '1000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = SystemToRelay.createWeightLimit(mockSystemApi, {});
+			const weightLimit = SystemToRelay.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/SystemToRelay.ts
+++ b/src/createXcmTypes/SystemToRelay.ts
@@ -2,15 +2,14 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 
 import {
 	CreateWeightLimitOpts,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcmMultiAssets,
 	XcmDestBenificiary,
 	XcmMultiAsset,
+	XcmWeight,
 } from './types';
 
 export const SystemToRelay: ICreateXcmType = {
@@ -122,18 +121,15 @@ export const SystemToRelay: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit?.refTime,
-							proofSize: opts.weightLimit?.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit?.refTime,
+						proofSize: opts.weightLimit?.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 
 	/**

--- a/src/createXcmTypes/SystemToRelay.ts
+++ b/src/createXcmTypes/SystemToRelay.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import { u32 } from '@polkadot/types';
 
 import {
 	CreateWeightLimitOpts,
@@ -137,7 +136,7 @@ export const SystemToRelay: ICreateXcmType = {
 	 *
 	 * @param api ApiPromise
 	 */
-	createFeeAssetItem: async (api: ApiPromise): Promise<u32> => {
-		return Promise.resolve(api.registry.createType('u32', 0));
+	createFeeAssetItem: async (_: ApiPromise): Promise<number> => {
+		return await Promise.resolve(0);
 	},
 };

--- a/src/createXcmTypes/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/SystemToSystem.spec.ts
@@ -195,25 +195,25 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 			const refTime = '100000000';
 			const proofSize = '1000';
 
-			const weightLimit = SystemToSystem.createWeightLimit(mockSystemApi, {
+			const weightLimit = SystemToSystem.createWeightLimit({
 				isLimited,
 				weightLimit: {
 					refTime,
 					proofSize,
 				},
 			});
-			expect(weightLimit.toJSON()).toStrictEqual({
-				limited: {
-					refTime: 100000000,
-					proofSize: 1000,
+			expect(weightLimit).toStrictEqual({
+				Limited: {
+					refTime: '100000000',
+					proofSize: '1000',
 				},
 			});
 		});
 		it('Should work when isLimited is falsy', () => {
-			const weightLimit = SystemToSystem.createWeightLimit(mockSystemApi, {});
+			const weightLimit = SystemToSystem.createWeightLimit({});
 
-			expect(weightLimit.toJSON()).toStrictEqual({
-				unlimited: null,
+			expect(weightLimit).toStrictEqual({
+				Unlimited: null,
 			});
 		});
 	});

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import { u32 } from '@polkadot/types';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
 import type { Registry } from '../registry';
@@ -160,7 +159,7 @@ export const SystemToSystem: ICreateXcmType = {
 	 * @xcmVersion number
 	 *
 	 */
-	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<u32> => {
+	createFeeAssetItem: async (api: ApiPromise, opts: CreateFeeAssetItemOpts): Promise<number> => {
 		const {
 			registry,
 			paysWithFeeDest,
@@ -202,10 +201,10 @@ export const SystemToSystem: ICreateXcmType = {
 				opts.isForeignAssetsTransfer
 			);
 
-			return api.registry.createType('u32', assetIndex);
+			return assetIndex;
 		}
 
-		return api.registry.createType('u32', 0);
+		return 0;
 	},
 };
 

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -2,7 +2,6 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 
 import { BaseError, BaseErrorsEnum } from '../errors';
 import type { Registry } from '../registry';
@@ -17,12 +16,12 @@ import {
 	CreateWeightLimitOpts,
 	FungibleStrMultiAsset,
 	ICreateXcmType,
-	IWeightLimit,
 	UnionXcmMultiAssets,
 	UnionXcmMultiLocation,
 	XcmDestBenificiary,
 	XcmV2Junctions,
 	XcmV3Junctions,
+	XcmWeight,
 } from './types';
 import { dedupeMultiAssets } from './util/dedupeMultiAssets';
 import { fetchPalletInstanceId } from './util/fetchPalletInstanceId';
@@ -139,18 +138,15 @@ export const SystemToSystem: ICreateXcmType = {
 	 * @param refTime amount of computation time
 	 * @param proofSize amount of storage to be used
 	 */
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts): WeightLimitV2 => {
-		const limit: IWeightLimit =
-			opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
-				? {
-						Limited: {
-							refTime: opts.weightLimit?.refTime,
-							proofSize: opts.weightLimit?.proofSize,
-						},
-				  }
-				: { Unlimited: null };
-
-		return api.registry.createType('XcmV3WeightLimit', limit);
+	createWeightLimit: (opts: CreateWeightLimitOpts): XcmWeight => {
+		return opts.isLimited && opts.weightLimit?.refTime && opts.weightLimit?.proofSize
+			? {
+					Limited: {
+						refTime: opts.weightLimit?.refTime,
+						proofSize: opts.weightLimit?.proofSize,
+					},
+			  }
+			: { Unlimited: null };
 	},
 
 	/**

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -2,7 +2,6 @@
 
 import type { ApiPromise } from '@polkadot/api';
 import { u32 } from '@polkadot/types';
-import type { WeightLimitV2 } from '@polkadot/types/interfaces';
 import type { AnyJson } from '@polkadot/types/types';
 
 import type { Registry } from '../registry';
@@ -294,7 +293,7 @@ export interface ICreateXcmType {
 		assets: string[],
 		opts: CreateAssetsOpts
 	) => Promise<UnionXcmMultiAssets>;
-	createWeightLimit: (api: ApiPromise, opts: CreateWeightLimitOpts) => WeightLimitV2;
+	createWeightLimit: (opts: CreateWeightLimitOpts) => XcmWeight;
 	createFeeAssetItem: (api: ApiPromise, opts: CreateFeeAssetItemOpts) => Promise<u32>;
 	createXTokensBeneficiary?: (destChainId: string, accountId: string, xcmVersion: number) => XcmDestBenificiaryXcAssets;
 	createXTokensAssets?: (
@@ -314,13 +313,3 @@ export interface ICreateXcmType {
 	createXTokensWeightLimit?: (opts: CreateWeightLimitOpts) => XcmWeight;
 	createXTokensFeeAssetItem?: (opts: CreateFeeAssetItemOpts) => UnionXcAssetsMultiLocation;
 }
-
-interface IWeightLimitBase {
-	Unlimited: null;
-	Limited: {
-		refTime: string;
-		proofSize: string;
-	};
-}
-
-export type IWeightLimit = RequireOnlyOne<IWeightLimitBase>;

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -1,7 +1,6 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
-import { u32 } from '@polkadot/types';
 import type { AnyJson } from '@polkadot/types/types';
 
 import type { Registry } from '../registry';
@@ -294,7 +293,7 @@ export interface ICreateXcmType {
 		opts: CreateAssetsOpts
 	) => Promise<UnionXcmMultiAssets>;
 	createWeightLimit: (opts: CreateWeightLimitOpts) => XcmWeight;
-	createFeeAssetItem: (api: ApiPromise, opts: CreateFeeAssetItemOpts) => Promise<u32>;
+	createFeeAssetItem: (api: ApiPromise, opts: CreateFeeAssetItemOpts) => Promise<number>;
 	createXTokensBeneficiary?: (destChainId: string, accountId: string, xcmVersion: number) => XcmDestBenificiaryXcAssets;
 	createXTokensAssets?: (
 		amounts: string[],


### PR DESCRIPTION
## Summary

- Refactor all `createWeightLimit` calls to be return `XcmWeight` types instead of Polkadot-js weight types.
- Refactor all `createFeeAssetItem` calls to return a `number` type instead of a `u32` polkadot-js type.

rel: https://github.com/paritytech/asset-transfer-api/issues/301