### PR TITLE
test: fix jest tests running twice

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
 	testEnvironment: 'node',
 	maxConcurrency: 3,
 	maxWorkers: '50%',
-	testPathIgnorePatterns: ['/lib/', '/node_modules/'],
+	testPathIgnorePatterns: ['/lib/', '/node_modules/', '/build/'],
 	// The below resolves `jest-haste-map:...`
-	modulePathIgnorePatterns: ['/lib']
+	modulePathIgnorePatterns: ['/lib', '/build']
 };


### PR DESCRIPTION
Since the refactor of the createTypes, I had fixed the examples `build` for tsconfig, which caused the tests to run twice. This PR ensures that the `/build` folder is ignored for tests.