### PR TITLE
fix: xtokens and xTokens naming

### DIFF
--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -308,7 +308,7 @@ export class AssetTransferApi {
 		let transaction: SubmittableExtrinsic<'promise', ISubmittableResult>;
 
 		if (
-			xcmPallet === XcmPalletName.xTokens &&
+			(xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens) &&
 			(xcmDirection === Direction.ParaToSystem || xcmDirection === Direction.ParaToPara)
 		) {
 			if (!paysWithFeeDest && assetIds.length < 2) {

--- a/src/createXcmCalls/util/establishXcmPallet.ts
+++ b/src/createXcmCalls/util/establishXcmPallet.ts
@@ -9,6 +9,7 @@ export enum XcmPalletName {
 	xcmPallet = 'xcmPallet',
 	polkadotXcm = 'polkadotXcm',
 	xTokens = 'xTokens',
+	xtokens = 'xtokens',
 }
 
 /**
@@ -24,11 +25,20 @@ export const establishXcmPallet = (
 	isForeignAssetsTransfer?: boolean,
 	isParachainPrimaryNativeAsset?: boolean
 ): XcmPalletName => {
+	let xPallet: XcmPalletName | undefined;
+	if (api.tx.xTokens) {
+		xPallet = XcmPalletName.xTokens;
+	} else if (api.tx.xtokens) {
+		xPallet = XcmPalletName.xtokens;
+	}
+
 	// checks for the existence of the xTokens pallet
 	// for direction ParaToSystem or ParaToPara, if it exists and the tx is
 	// not a foreign assets transfer we return the xTokens pallet
-	if (isXTokensOriginNonForeignAssetsPalletTx(api, direction, isForeignAssetsTransfer, isParachainPrimaryNativeAsset)) {
-		return XcmPalletName.xTokens;
+	if (
+		isXTokensOriginNonForeignAssetsPalletTx(xPallet, direction, isForeignAssetsTransfer, isParachainPrimaryNativeAsset)
+	) {
+		return xPallet as XcmPalletName;
 	}
 
 	if (api.tx.polkadotXcm) {
@@ -49,7 +59,7 @@ export const establishXcmPallet = (
  * @param api ApiPromise
  */
 const isXTokensOriginNonForeignAssetsPalletTx = (
-	api: ApiPromise,
+	xPallet?: XcmPalletName,
 	direction?: Direction | string,
 	isForeignAssetsTransfer?: boolean,
 	isParachainPrimaryNativeAsset?: boolean
@@ -59,7 +69,7 @@ const isXTokensOriginNonForeignAssetsPalletTx = (
 		!isParachainPrimaryNativeAsset &&
 		direction &&
 		(direction === Direction.ParaToSystem || direction === Direction.ParaToPara) &&
-		api.tx.xTokens
+		xPallet
 	) {
 		return true;
 	}

--- a/src/createXcmTypes/util/getAssetId.ts
+++ b/src/createXcmTypes/util/getAssetId.ts
@@ -160,7 +160,7 @@ export const getAssetId = async (
 
 			if (assetId.length === 0) {
 				throw new BaseError(
-					`parachain assetId ${asset} is not a valid symbol assetIid in ${specName}`,
+					`parachain assetId ${asset} is not a valid symbol assetId in ${specName}`,
 					BaseErrorsEnum.InvalidAsset
 				);
 			}
@@ -173,7 +173,7 @@ export const getAssetId = async (
 				registry.setAssetInCache(assetId, asset);
 			} else {
 				throw new BaseError(
-					`parachain assetId ${asset} is not a valid integer assetIid in ${specName}`,
+					`parachain assetId ${asset} is not a valid integer assetId in ${specName}`,
 					BaseErrorsEnum.InvalidAsset
 				);
 			}

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -128,7 +128,7 @@ export const CheckXTokensPalletOriginIsNonForeignAssetTx = (
 	xcmPallet: XcmPalletName,
 	isForeignAssetsTransfer: boolean
 ) => {
-	if (xcmPallet === XcmPalletName.xTokens && isForeignAssetsTransfer) {
+	if ((xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens) && isForeignAssetsTransfer) {
 		throw new BaseError(
 			`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`,
 			BaseErrorsEnum.InvalidPallet


### PR DESCRIPTION
This ensures we check and supply the right naming of `xTokens` pallet depending on the chain we are dealing with.