### PR TITLE
chore: use cdn hosted assets registry

### DIFF
--- a/examples/paraToParaParachainPrimaryNativeReserveTransfer.ts
+++ b/examples/paraToParaParachainPrimaryNativeReserveTransfer.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://phala.api.onfinality.io/public-ws');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToParaTransferMultiAsset.ts
+++ b/examples/paraToParaTransferMultiAsset.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToParaTransferMultiAssetWithFee.ts
+++ b/examples/paraToParaTransferMultiAssetWithFee.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToParaTransferMultiAssets.ts
+++ b/examples/paraToParaTransferMultiAssets.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToRelayTransferMultiAsset.ts
+++ b/examples/paraToRelayTransferMultiAsset.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToSystemParachainPrimaryNative.ts
+++ b/examples/paraToSystemParachainPrimaryNative.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToSystemTransferMultiAsset.ts
+++ b/examples/paraToSystemTransferMultiAsset.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToSystemTransferMultiAssetWithFee.ts
+++ b/examples/paraToSystemTransferMultiAssetWithFee.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/paraToSystemTransferMultiAssets.ts
+++ b/examples/paraToSystemTransferMultiAssets.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://moonriver.public.blastapi.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/relayToPara.ts
+++ b/examples/relayToPara.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://kusama-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/relayToSystem.ts
+++ b/examples/relayToSystem.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://westend-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 	let callInfo: TxResult<'call'>;
 	try {
 		callInfo = await assetApi.createTransferTransaction(

--- a/examples/rococoAssetHubToRelay.ts
+++ b/examples/rococoAssetHubToRelay.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -21,7 +22,10 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, safeXcmVersion } = await constructApiPromise('wss://rococo-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, 'asset-hub-rococo', safeXcmVersion);
+	const specName = 'asset-hub-rococo';
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/submittable.ts
+++ b/examples/submittable.ts
@@ -7,6 +7,7 @@ import { Keyring } from '@polkadot/keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -18,7 +19,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('ws://127.0.0.1:9944');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	// When declaring this type it will ensure that the inputted `format` matches it or the type checker will error.
 	let callInfo: TxResult<'submittable'>;

--- a/examples/systemToPara.ts
+++ b/examples/systemToPara.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://kusama-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/systemToParaLpToken.ts
+++ b/examples/systemToParaLpToken.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,20 +17,24 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://westmint-rpc.polkadot.io');
-	const injectedRegistry = {
-		westend: {
-			'2023': {
-				tokens: ['TST'],
-				assetsInfo: {},
-				foreignAssetsInfo: {},
-				specName: 'testing',
-				poolPairsInfo: {},
+	const assetRegistry = await parseRegistry({
+		injectedRegistry: {
+			polkadot: {},
+			kusama: {},
+			westend: {
+				'2023': {
+					tokens: ['TST'],
+					assetsInfo: {},
+					foreignAssetsInfo: {},
+					specName: 'testing',
+					poolPairsInfo: {},
+				},
 			},
+			rococo: {},
 		},
-	};
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, {
-		injectedRegistry,
 	});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/systemToParaPaysWithFeeOrigin.ts
+++ b/examples/systemToParaPaysWithFeeOrigin.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -18,7 +19,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://kusama-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'payload'>;
 	try {

--- a/examples/systemToParaReserveTransferForeignAssets.ts
+++ b/examples/systemToParaReserveTransferForeignAssets.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -17,7 +18,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://kusama-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/systemToParaTeleportForeignAssets.ts
+++ b/examples/systemToParaTeleportForeignAssets.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -17,7 +18,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://kusama-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/systemToRelay.ts
+++ b/examples/systemToRelay.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://westmint-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/systemToSystem.ts
+++ b/examples/systemToSystem.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -16,7 +17,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://westend-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/examples/systemToSystemLocalForeignAssets.ts
+++ b/examples/systemToSystemLocalForeignAssets.ts
@@ -4,6 +4,7 @@
  * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
  */
 import { AssetTransferApi, constructApiPromise } from '../src';
+import { parseRegistry, Registry } from '../src/registry';
 import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
@@ -17,7 +18,9 @@ import { GREEN, PURPLE, RESET } from './colors';
  */
 const main = async () => {
 	const { api, specName, safeXcmVersion } = await constructApiPromise('wss://kusama-asset-hub-rpc.polkadot.io');
-	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	const assetRegistry = await parseRegistry({});
+	const registry = new Registry(specName, assetRegistry);
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion, registry);
 
 	let callInfo: TxResult<'call'>;
 	try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@substrate/dev": "^0.6.7",
         "@types/node-fetch": "^2.6.9",
         "chalk": "4.1.2",
+        "node-fetch": "2.6.7",
         "typedoc": "^0.24.8",
         "typedoc-plugin-missing-exports": "^1.0.0",
         "typedoc-theme-hierarchy": "^4.0.0"
@@ -2496,6 +2497,7 @@
     },
     "node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -3159,6 +3161,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -4243,6 +4246,7 @@
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -4695,6 +4699,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -4951,6 +4956,7 @@
     },
     "node_modules/tr46": {
       "version": "0.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-jest": {
@@ -5194,10 +5200,12 @@
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -6934,6 +6942,7 @@
     },
     "encoding": {
       "version": "0.1.13",
+      "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
@@ -7348,6 +7357,7 @@
     },
     "iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "optional": true,
       "peer": true,
       "requires": {
@@ -8062,6 +8072,7 @@
     },
     "node-fetch": {
       "version": "2.6.7",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -8300,6 +8311,7 @@
     },
     "safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "optional": true,
       "peer": true
     },
@@ -8465,7 +8477,8 @@
       }
     },
     "tr46": {
-      "version": "0.0.3"
+      "version": "0.0.3",
+      "dev": true
     },
     "ts-jest": {
       "version": "29.1.0",
@@ -8594,10 +8607,12 @@
       "version": "3.2.1"
     },
     "webidl-conversions": {
-      "version": "3.0.1"
+      "version": "3.0.1",
+      "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8672 @@
+{
+  "name": "@substrate/asset-transfer-api",
+  "version": "0.1.3",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@substrate/asset-transfer-api",
+      "version": "0.1.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "^10.9.1",
+        "node-fetch": "2.6.7"
+      },
+      "devDependencies": {
+        "@substrate/dev": "^0.6.7",
+        "@types/node-fetch": "^2.6.9",
+        "chalk": "4.1.2",
+        "typedoc": "^0.24.8",
+        "typedoc-plugin-missing-exports": "^1.0.0",
+        "typedoc-theme-hierarchy": "^4.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
+        "@babel/helper-compilation-targets": "^7.21.4",
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.4",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.4",
+        "@babel/types": "^7.21.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.21.4",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.21.4",
+        "@babel/helper-validator-option": "^7.21.0",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-function-name": {
+      "version": "7.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.21.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.20.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-simple-access": {
+      "version": "7.20.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-split-export-declaration": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.21.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-jsx": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.20.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-modules-commonjs": {
+      "version": "7.21.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-simple-access": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.20.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.21.4",
+        "@babel/types": "^7.21.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse/node_modules/globals": {
+      "version": "11.12.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.21.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.5.1",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.39.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.8",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.5.0",
+        "@jest/reporters": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.5.0",
+        "jest-config": "^29.5.0",
+        "jest-haste-map": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-resolve-dependencies": "^29.5.0",
+        "jest-runner": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "jest-watcher": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "jest-mock": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.5.0",
+        "jest-snapshot": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.4.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "jest-mock": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-worker": "^29.5.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.25.16"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.5.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.5.0",
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/types": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@polkadot/api": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-augment": "10.9.1",
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/api-derive": "10.9.1",
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/rpc-provider": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/types-known": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/api-augment": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/api-base": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/api-derive": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/api": "10.9.1",
+        "@polkadot/api-augment": "10.9.1",
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/keyring": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/util-crypto": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/util-crypto": "12.3.2"
+      }
+    },
+    "node_modules/@polkadot/networks": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "12.3.2",
+        "@substrate/ss58-registry": "^1.40.0",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/rpc-augment": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/rpc-core": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/rpc-provider": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/rpc-provider": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-support": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "@polkadot/x-fetch": "^12.3.1",
+        "@polkadot/x-global": "^12.3.1",
+        "@polkadot/x-ws": "^12.3.1",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.2.1",
+        "nock": "^13.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@substrate/connect": "0.7.26"
+      }
+    },
+    "node_modules/@polkadot/types": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/types-augment": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/types-codec": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/x-bigint": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/types-create": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/types-known": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/networks": "^12.3.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/types-support": {
+      "version": "10.9.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/util": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-bigint": "12.3.2",
+        "@polkadot/x-global": "12.3.2",
+        "@polkadot/x-textdecoder": "12.3.2",
+        "@polkadot/x-textencoder": "12.3.2",
+        "@types/bn.js": "^5.1.1",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/util-crypto": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "1.1.0",
+        "@noble/hashes": "1.3.1",
+        "@polkadot/networks": "12.3.2",
+        "@polkadot/util": "12.3.2",
+        "@polkadot/wasm-crypto": "^7.2.1",
+        "@polkadot/wasm-util": "^7.2.1",
+        "@polkadot/x-bigint": "12.3.2",
+        "@polkadot/x-randomvalues": "12.3.2",
+        "@scure/base": "1.1.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.3.2"
+      }
+    },
+    "node_modules/@polkadot/wasm-bridge": {
+      "version": "7.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto": {
+      "version": "7.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-init": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-asmjs": {
+      "version": "7.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-init": {
+      "version": "7.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*",
+        "@polkadot/x-randomvalues": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-crypto-wasm": {
+      "version": "7.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/wasm-util": {
+      "version": "7.2.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-bigint": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/x-fetch": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "node-fetch": "^3.3.1",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/x-fetch/node_modules/node-fetch": {
+      "version": "3.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@polkadot/x-global": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/x-randomvalues": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/wasm-util": "*"
+      }
+    },
+    "node_modules/@polkadot/x-textdecoder": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/x-textencoder": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@polkadot/x-ws": {
+      "version": "12.3.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3",
+        "ws": "^8.13.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.25.24",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sinonjs/commons": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "node_modules/@substrate/connect": {
+      "version": "0.7.26",
+      "license": "GPL-3.0-only",
+      "optional": true,
+      "dependencies": {
+        "@substrate/connect-extension-protocol": "^1.0.1",
+        "eventemitter3": "^4.0.7",
+        "smoldot": "1.0.4"
+      }
+    },
+    "node_modules/@substrate/connect-extension-protocol": {
+      "version": "1.0.1",
+      "license": "GPL-3.0-only",
+      "optional": true
+    },
+    "node_modules/@substrate/connect/node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@substrate/dev": {
+      "version": "0.6.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@types/jest": "^29.5.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.0",
+        "@typescript-eslint/parser": "^5.59.0",
+        "eslint": "8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
+        "jest": "^29.5.0",
+        "prettier": "^2.8.7",
+        "rimraf": "^3.0.2",
+        "ts-jest": "^29.1.0",
+        "typescript": "^4.9.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "substrate-dev-run-lint": "scripts/substrate-dev-run-lint.cjs",
+        "substrate-exec-eslint": "scripts/substrate-exec-eslint.cjs",
+        "substrate-exec-jest": "scripts/substrate-exec-jest.cjs",
+        "substrate-exec-rimraf": "scripts/substrate-exec-rimraf.cjs",
+        "substrate-exec-tsc": "scripts/substrate-exec-tsc.cjs",
+        "substrate-update-pjs-deps": "scripts/substrate-update-pjs-deps.cjs"
+      }
+    },
+    "node_modules/@substrate/ss58-registry": {
+      "version": "1.40.0",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.1.20",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.6.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.18.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.18",
+      "license": "MIT"
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.7.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.3.13",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/type-utils": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/estraverse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.59.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.8.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-sequence-parser": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/babel-jest": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.5.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.5.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.5.0",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.1",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.21.4",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bser": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001445",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "3.7.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/dedent": {
+      "version": "0.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.4.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.284",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.39.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.39.0",
+        "@humanwhocodes/config-array": "^0.11.8",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.8.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.28.0",
+        "prettier": ">=2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint-config-prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "10.0.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.5.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.12",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fb-watchman": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bser": "2.1.1"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "13.19.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.11.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.5.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.5.0",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.5.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "prompts": "^2.0.1",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "babel-jest": "^29.5.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.5.0",
+        "jest-environment-node": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-runner": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "29.4.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "jest-worker": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.5.0",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "jest-util": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.4.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.4.3",
+        "jest-snapshot": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.5.0",
+        "@jest/environment": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.4.3",
+        "jest-environment-node": "^29.5.0",
+        "jest-haste-map": "^29.5.0",
+        "jest-leak-detector": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-resolve": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-watcher": "^29.5.0",
+        "jest-worker": "^29.5.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/globals": "^29.5.0",
+        "@jest/source-map": "^29.4.3",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.5.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.5.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.5.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.4.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.5.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.5.0",
+        "string-length": "^4.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.5.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.4.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "2.5.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "license": "ISC"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "license": "MIT"
+    },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/makeerror": {
+      "version": "1.0.12",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/mock-socket": {
+      "version": "9.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare-lite": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nock": {
+      "version": "13.3.1",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "license": "(MIT AND Zlib)",
+      "optional": true
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.0.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react-is": {
+      "version": "18.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "0.14.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smoldot": {
+      "version": "1.0.4",
+      "license": "GPL-3.0-or-later WITH Classpath-exception-2.0",
+      "optional": true,
+      "dependencies": {
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tmpl": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "license": "MIT"
+    },
+    "node_modules/ts-jest": {
+      "version": "29.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/types": "^29.0.0",
+        "babel-jest": "^29.0.0",
+        "jest": "^29.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.3",
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typedoc": {
+      "version": "0.24.8",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 14.14"
+      },
+      "peerDependencies": {
+        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x"
+      }
+    },
+    "node_modules/typedoc-plugin-missing-exports": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typedoc": "0.22.x || 0.23.x"
+      }
+    },
+    "node_modules/typedoc-theme-hierarchy": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fs-extra": "^10.0.0"
+      },
+      "peerDependencies": {
+        "typedoc": "^0.24.0"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "9.0.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.1.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/walker": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.13.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
+  "dependencies": {
+    "@ampproject/remapping": {
+      "version": "2.2.1",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@babel/code-frame": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.18.6"
+      }
+    },
+    "@babel/compat-data": {
+      "version": "7.21.4",
+      "dev": true
+    },
+    "@babel/core": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
+        "@babel/helper-compilation-targets": "^7.21.4",
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helpers": "^7.21.0",
+        "@babel/parser": "^7.21.4",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.4",
+        "@babel/types": "^7.21.4",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.2",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.21.4",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.21.4",
+        "@babel/helper-validator-option": "^7.21.0",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "6.3.1",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-environment-visitor": {
+      "version": "7.18.9",
+      "dev": true
+    },
+    "@babel/helper-function-name": {
+      "version": "7.21.0",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.20.7",
+        "@babel/types": "^7.21.0"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.18.6",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.18.6",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.21.2",
+      "dev": true,
+      "requires": {
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.2",
+        "@babel/types": "^7.21.2"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.20.2",
+      "dev": true
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.20.2",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.20.2"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.18.6",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.18.6"
+      }
+    },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "dev": true
+    },
+    "@babel/helper-validator-option": {
+      "version": "7.21.0",
+      "dev": true
+    },
+    "@babel/helpers": {
+      "version": "7.21.0",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.21.0",
+        "@babel/types": "^7.21.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.18.6",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.21.4",
+      "dev": true
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      }
+    },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.20.2"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.20.0",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.21.2",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.21.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-simple-access": "^7.20.2"
+      }
+    },
+    "@babel/template": {
+      "version": "7.20.7",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.21.4",
+        "@babel/generator": "^7.21.4",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.21.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.21.4",
+        "@babel/types": "^7.21.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.21.4",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "dev": true
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.5.0",
+      "dev": true
+    },
+    "@eslint/eslintrc": {
+      "version": "2.0.2",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.5.1",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "@eslint/js": {
+      "version": "8.39.0",
+      "dev": true
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.11.8",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.5"
+      }
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "dev": true
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.3",
+      "dev": true
+    },
+    "@jest/console": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.5.0",
+        "@jest/reporters": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.5.0",
+        "jest-config": "^29.5.0",
+        "jest-haste-map": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-resolve-dependencies": "^29.5.0",
+        "jest-runner": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "jest-watcher": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "@jest/environment": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "jest-mock": "^29.5.0"
+      }
+    },
+    "@jest/expect": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "expect": "^29.5.0",
+        "jest-snapshot": "^29.5.0"
+      }
+    },
+    "@jest/expect-utils": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.4.3"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0"
+      }
+    },
+    "@jest/globals": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "jest-mock": "^29.5.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^5.1.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-worker": "^29.5.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      }
+    },
+    "@jest/schemas": {
+      "version": "29.4.3",
+      "dev": true,
+      "requires": {
+        "@sinclair/typebox": "^0.25.16"
+      }
+    },
+    "@jest/source-map": {
+      "version": "29.4.3",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      }
+    },
+    "@jest/test-result": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.5.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.5.0",
+        "@jridgewell/trace-mapping": "^0.3.15",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "dev": true
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.4.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      }
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.3",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.18",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "@noble/curves": {
+      "version": "1.1.0",
+      "requires": {
+        "@noble/hashes": "1.3.1"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.3.1"
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@polkadot/api": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/api-augment": "10.9.1",
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/api-derive": "10.9.1",
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/rpc-provider": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/types-known": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "eventemitter3": "^5.0.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/api-augment": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/api-base": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/api-derive": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/api": "10.9.1",
+        "@polkadot/api-augment": "10.9.1",
+        "@polkadot/api-base": "10.9.1",
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/keyring": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/util": "12.3.2",
+        "@polkadot/util-crypto": "12.3.2",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/networks": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/util": "12.3.2",
+        "@substrate/ss58-registry": "^1.40.0",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/rpc-augment": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/rpc-core": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/rpc-core": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/rpc-augment": "10.9.1",
+        "@polkadot/rpc-provider": "10.9.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/rpc-provider": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-support": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "@polkadot/x-fetch": "^12.3.1",
+        "@polkadot/x-global": "^12.3.1",
+        "@polkadot/x-ws": "^12.3.1",
+        "@substrate/connect": "0.7.26",
+        "eventemitter3": "^5.0.1",
+        "mock-socket": "^9.2.1",
+        "nock": "^13.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/types": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/keyring": "^12.3.1",
+        "@polkadot/types-augment": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/util-crypto": "^12.3.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/types-augment": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/types-codec": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/util": "^12.3.1",
+        "@polkadot/x-bigint": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/types-create": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/types-known": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/networks": "^12.3.1",
+        "@polkadot/types": "10.9.1",
+        "@polkadot/types-codec": "10.9.1",
+        "@polkadot/types-create": "10.9.1",
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/types-support": {
+      "version": "10.9.1",
+      "requires": {
+        "@polkadot/util": "^12.3.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/util": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-bigint": "12.3.2",
+        "@polkadot/x-global": "12.3.2",
+        "@polkadot/x-textdecoder": "12.3.2",
+        "@polkadot/x-textencoder": "12.3.2",
+        "@types/bn.js": "^5.1.1",
+        "bn.js": "^5.2.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/util-crypto": {
+      "version": "12.3.2",
+      "requires": {
+        "@noble/curves": "1.1.0",
+        "@noble/hashes": "1.3.1",
+        "@polkadot/networks": "12.3.2",
+        "@polkadot/util": "12.3.2",
+        "@polkadot/wasm-crypto": "^7.2.1",
+        "@polkadot/wasm-util": "^7.2.1",
+        "@polkadot/x-bigint": "12.3.2",
+        "@polkadot/x-randomvalues": "12.3.2",
+        "@scure/base": "1.1.1",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/wasm-bridge": {
+      "version": "7.2.1",
+      "requires": {
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/wasm-crypto": {
+      "version": "7.2.1",
+      "requires": {
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-init": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/wasm-crypto-asmjs": {
+      "version": "7.2.1",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/wasm-crypto-init": {
+      "version": "7.2.1",
+      "requires": {
+        "@polkadot/wasm-bridge": "7.2.1",
+        "@polkadot/wasm-crypto-asmjs": "7.2.1",
+        "@polkadot/wasm-crypto-wasm": "7.2.1",
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/wasm-crypto-wasm": {
+      "version": "7.2.1",
+      "requires": {
+        "@polkadot/wasm-util": "7.2.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/wasm-util": {
+      "version": "7.2.1",
+      "requires": {
+        "tslib": "^2.5.0"
+      }
+    },
+    "@polkadot/x-bigint": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/x-fetch": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-global": "12.3.2",
+        "node-fetch": "^3.3.1",
+        "tslib": "^2.5.3"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "3.3.1",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
+      }
+    },
+    "@polkadot/x-global": {
+      "version": "12.3.2",
+      "requires": {
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/x-randomvalues": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/x-textdecoder": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/x-textencoder": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3"
+      }
+    },
+    "@polkadot/x-ws": {
+      "version": "12.3.2",
+      "requires": {
+        "@polkadot/x-global": "12.3.2",
+        "tslib": "^2.5.3",
+        "ws": "^8.13.0"
+      }
+    },
+    "@scure/base": {
+      "version": "1.1.1"
+    },
+    "@sinclair/typebox": {
+      "version": "0.25.24",
+      "dev": true
+    },
+    "@sinonjs/commons": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "10.0.2",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^2.0.0"
+      }
+    },
+    "@substrate/connect": {
+      "version": "0.7.26",
+      "optional": true,
+      "requires": {
+        "@substrate/connect-extension-protocol": "^1.0.1",
+        "eventemitter3": "^4.0.7",
+        "smoldot": "1.0.4"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "optional": true
+        }
+      }
+    },
+    "@substrate/connect-extension-protocol": {
+      "version": "1.0.1",
+      "optional": true
+    },
+    "@substrate/dev": {
+      "version": "0.6.7",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-transform-modules-commonjs": "^7.21.2",
+        "@types/jest": "^29.5.1",
+        "@typescript-eslint/eslint-plugin": "^5.59.0",
+        "@typescript-eslint/parser": "^5.59.0",
+        "eslint": "8.39.0",
+        "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-prettier": "^4.2.1",
+        "eslint-plugin-simple-import-sort": "^10.0.0",
+        "jest": "^29.5.0",
+        "prettier": "^2.8.7",
+        "rimraf": "^3.0.2",
+        "ts-jest": "^29.1.0",
+        "typescript": "^4.9.4",
+        "yargs": "^17.5.1"
+      }
+    },
+    "@substrate/ss58-registry": {
+      "version": "1.40.0"
+    },
+    "@types/babel__core": {
+      "version": "7.1.20",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.6.4",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.4.1",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.18.3",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/bn.js": {
+      "version": "5.1.1",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/graceful-fs": {
+      "version": "4.1.6",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.4",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.5.1",
+      "dev": true,
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.11",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.11.18"
+    },
+    "@types/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-bQVlnMLFJ2d35DkPNjEPmd9ueO/rh5EiaZt2bhqiSarPjZIuIV6bPQVqcrEyvNo+AfTrRGVazle1tl597w3gfA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "@types/prettier": {
+      "version": "2.7.2",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.13",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "17.0.24",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.0",
+      "dev": true
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/type-utils": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
+        "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "natural-compare-lite": "^1.4.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "debug": "^4.3.4"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/utils": "5.59.0",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.59.0",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/visitor-keys": "5.59.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.59.0",
+        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.1",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "5.59.0",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "5.59.0",
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "acorn": {
+      "version": "8.8.1",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "requires": {}
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.2",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.21.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.21.3",
+          "dev": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "dev": true
+    },
+    "ansi-sequence-parser": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.3",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "array-union": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "babel-jest": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^29.5.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.5.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^29.5.0",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "bn.js": {
+      "version": "5.2.1"
+    },
+    "brace-expansion": {
+      "version": "2.0.1",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.21.4",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
+    "bser": {
+      "version": "2.1.1",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001445",
+      "dev": true
+    },
+    "chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "char-regex": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "ci-info": {
+      "version": "3.7.1",
+      "dev": true
+    },
+    "cjs-module-lexer": {
+      "version": "1.2.2",
+      "dev": true
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "dev": true
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.9.0",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "data-uri-to-buffer": {
+      "version": "4.0.1"
+    },
+    "debug": {
+      "version": "4.3.4",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "dev": true
+    },
+    "deep-is": {
+      "version": "0.1.4",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "29.4.3",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "electron-to-chromium": {
+      "version": "1.4.284",
+      "dev": true
+    },
+    "emittery": {
+      "version": "0.13.1",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "dev": true
+    },
+    "encoding": {
+      "version": "0.1.13",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "eslint": {
+      "version": "8.39.0",
+      "dev": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@eslint/eslintrc": "^2.0.2",
+        "@eslint/js": "8.39.0",
+        "@humanwhocodes/config-array": "^0.11.8",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.0",
+        "eslint-visitor-keys": "^3.4.0",
+        "espree": "^9.5.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-sdsl": "^4.1.4",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "8.8.0",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-plugin-prettier": {
+      "version": "4.2.1",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "10.0.0",
+      "dev": true,
+      "requires": {}
+    },
+    "eslint-scope": {
+      "version": "7.2.0",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.4.0",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.5.1",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.5.0",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "5.0.1"
+    },
+    "execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "dev": true
+    },
+    "expect": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/expect-utils": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "fast-glob": {
+      "version": "3.2.12",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "fb-watchman": {
+      "version": "2.0.2",
+      "dev": true,
+      "requires": {
+        "bser": "2.1.1"
+      }
+    },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "locate-path": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        }
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.7",
+      "dev": true
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "globals": {
+      "version": "13.19.0",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.20.2"
+      }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "dev": true
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "ignore": {
+      "version": "5.2.4",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "dev": true
+        }
+      }
+    },
+    "import-local": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-core-module": {
+      "version": "2.11.0",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "3.0.3",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "istanbul-lib-coverage": {
+      "version": "3.2.0",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.1.5",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "jest": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.5.0"
+      }
+    },
+    "jest-changed-files": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0",
+        "p-limit": "^3.1.0"
+      }
+    },
+    "jest-circus": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.5.0",
+        "@jest/expect": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^0.7.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.5.0",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.5.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      }
+    },
+    "jest-cli": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "prompts": "^2.0.1",
+        "yargs": "^17.3.1"
+      }
+    },
+    "jest-config": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "babel-jest": "^29.5.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.5.0",
+        "jest-environment-node": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-runner": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      }
+    },
+    "jest-diff": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.4.3",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      }
+    },
+    "jest-docblock": {
+      "version": "29.4.3",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-each": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "pretty-format": "^29.5.0"
+      }
+    },
+    "jest-environment-node": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "jest-mock": "^29.5.0",
+        "jest-util": "^29.5.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "29.4.3",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.4.3",
+        "jest-util": "^29.5.0",
+        "jest-worker": "^29.5.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "pretty-format": "^29.5.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.5.0",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.5.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      }
+    },
+    "jest-mock": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "jest-util": "^29.5.0"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.3",
+      "dev": true,
+      "requires": {}
+    },
+    "jest-regex-util": {
+      "version": "29.4.3",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.5.0",
+        "jest-validate": "^29.5.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "jest-regex-util": "^29.4.3",
+        "jest-snapshot": "^29.5.0"
+      }
+    },
+    "jest-runner": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^29.5.0",
+        "@jest/environment": "^29.5.0",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.4.3",
+        "jest-environment-node": "^29.5.0",
+        "jest-haste-map": "^29.5.0",
+        "jest-leak-detector": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-resolve": "^29.5.0",
+        "jest-runtime": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "jest-watcher": "^29.5.0",
+        "jest-worker": "^29.5.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      }
+    },
+    "jest-runtime": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^29.5.0",
+        "@jest/fake-timers": "^29.5.0",
+        "@jest/globals": "^29.5.0",
+        "@jest/source-map": "^29.4.3",
+        "@jest/test-result": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-mock": "^29.5.0",
+        "jest-regex-util": "^29.4.3",
+        "jest-resolve": "^29.5.0",
+        "jest-snapshot": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      }
+    },
+    "jest-snapshot": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/traverse": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.5.0",
+        "@jest/transform": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/babel__traverse": "^7.0.6",
+        "@types/prettier": "^2.1.5",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.5.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.5.0",
+        "jest-get-type": "^29.4.3",
+        "jest-matcher-utils": "^29.5.0",
+        "jest-message-util": "^29.5.0",
+        "jest-util": "^29.5.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.5.0",
+        "semver": "^7.3.5"
+      }
+    },
+    "jest-util": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "graceful-fs": "^4.2.9",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "jest-validate": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^29.5.0",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.4.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.5.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.3.0",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^29.5.0",
+        "@jest/types": "^29.5.0",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.5.0",
+        "string-length": "^4.0.1"
+      }
+    },
+    "jest-worker": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "jest-util": "^29.5.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "8.1.1",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-sdsl": {
+      "version": "4.4.0",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1"
+    },
+    "json5": {
+      "version": "2.2.3",
+      "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "6.1.0",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "dev": true
+    },
+    "leven": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true
+    },
+    "locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21"
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "dev": true
+    },
+    "lunr": {
+      "version": "2.3.9",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "dev": true
+        }
+      }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "dev": true
+    },
+    "makeerror": {
+      "version": "1.0.12",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.5"
+      }
+    },
+    "marked": {
+      "version": "4.3.0",
+      "dev": true
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        }
+      }
+    },
+    "mock-socket": {
+      "version": "9.2.1"
+    },
+    "ms": {
+      "version": "2.1.2"
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "dev": true
+    },
+    "natural-compare-lite": {
+      "version": "1.4.0",
+      "dev": true
+    },
+    "nock": {
+      "version": "13.3.1",
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      }
+    },
+    "node-domexception": {
+      "version": "1.0.0"
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-int64": {
+      "version": "0.4.0",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "2.0.8",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.9.1",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
+    "p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "pako": {
+      "version": "2.1.0",
+      "optional": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "pirates": {
+      "version": "4.0.5",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "pretty-format": {
+      "version": "29.5.0",
+      "dev": true,
+      "requires": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "dev": true
+        }
+      }
+    },
+    "prompts": {
+      "version": "2.4.2",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "propagate": {
+      "version": "2.0.1"
+    },
+    "punycode": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "pure-rand": {
+      "version": "6.0.1",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "dev": true
+    },
+    "react-is": {
+      "version": "18.2.0",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.22.1",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "5.0.0",
+      "dev": true
+    },
+    "resolve.exports": {
+      "version": "2.0.2",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.8.1",
+      "requires": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "optional": true,
+      "peer": true
+    },
+    "semver": {
+      "version": "7.3.8",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        }
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "shiki": {
+      "version": "0.14.1",
+      "dev": true,
+      "requires": {
+        "ansi-sequence-parser": "^1.1.0",
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.7",
+      "dev": true
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "slash": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "smoldot": {
+      "version": "1.0.4",
+      "optional": true,
+      "requires": {
+        "pako": "^2.0.4",
+        "ws": "^8.8.1"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.13",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "stack-utils": {
+      "version": "2.0.6",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "dev": true
+        }
+      }
+    },
+    "string-length": {
+      "version": "4.0.2",
+      "dev": true,
+      "requires": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-bom": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "dev": true
+    },
+    "tmpl": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3"
+    },
+    "ts-jest": {
+      "version": "29.1.0",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^29.0.0",
+        "json5": "^2.2.3",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "^21.0.1"
+      }
+    },
+    "tslib": {
+      "version": "2.5.3"
+    },
+    "tsutils": {
+      "version": "3.21.0",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "dev": true
+        }
+      }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "dev": true
+    },
+    "type-fest": {
+      "version": "0.20.2",
+      "dev": true
+    },
+    "typedoc": {
+      "version": "0.24.8",
+      "dev": true,
+      "requires": {
+        "lunr": "^2.3.9",
+        "marked": "^4.3.0",
+        "minimatch": "^9.0.0",
+        "shiki": "^0.14.1"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "9.0.1",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        }
+      }
+    },
+    "typedoc-plugin-missing-exports": {
+      "version": "1.0.0",
+      "dev": true,
+      "requires": {}
+    },
+    "typedoc-theme-hierarchy": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "typescript": {
+      "version": "4.9.4",
+      "dev": true
+    },
+    "universalify": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "dev": true,
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-to-istanbul": {
+      "version": "9.1.0",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0"
+      }
+    },
+    "vscode-oniguruma": {
+      "version": "1.7.0",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "8.0.0",
+      "dev": true
+    },
+    "walker": {
+      "version": "1.0.8",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.12"
+      }
+    },
+    "web-streams-polyfill": {
+      "version": "3.2.1"
+    },
+    "webidl-conversions": {
+      "version": "3.0.1"
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.5",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "4.0.2",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      }
+    },
+    "ws": {
+      "version": "8.13.0",
+      "requires": {}
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.7.1",
+      "dev": true,
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "dependencies": {
     "@polkadot/api": "^10.9.1",
-    "@substrate/asset-transfer-api-registry": "^0.2.11",
     "node-fetch": "2.6.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "devDependencies": {
     "@substrate/dev": "^0.6.7",
     "chalk": "4.1.2",
+    "node-fetch": "2.6.7",
     "typedoc": "^0.24.8",
     "typedoc-plugin-missing-exports": "^1.0.0",
     "typedoc-theme-hierarchy": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@polkadot/api": "^10.9.1",
-    "@substrate/asset-transfer-api-registry": "^0.2.11"
+    "@substrate/asset-transfer-api-registry": "^0.2.11",
+    "node-fetch": "2.6.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "packageManager": "yarn@3.6.4",
   "devDependencies": {
     "@substrate/dev": "^0.6.7",
+    "@types/node-fetch": "^2.6.9",
     "chalk": "4.1.2",
     "node-fetch": "2.6.7",
     "typedoc": "^0.24.8",

--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -12,15 +12,22 @@ import { mockSystemApi } from './testHelpers/mockSystemApi';
 import { mockWeightInfo } from './testHelpers/mockWeightInfo';
 import { Direction, UnsignedTransaction } from './types';
 import { AssetType } from './types';
+import { mockAssetRegistry } from './testHelpers/mockAssetRegistry';
+import { Registry } from './registry';
 
 const mockSubmittableExt = mockSystemApi.registry.createType(
 	'Extrinsic',
 	'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000'
 ) as SubmittableExtrinsic<'promise', ISubmittableResult>;
 
-const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
-const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2);
-const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const systemAssetsRegistry = new Registry('statemine', mockAssetRegistry);
+const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, systemAssetsRegistry);
+
+const relayAssetsRegistry = new Registry('kusama', mockAssetRegistry);
+const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, relayAssetsRegistry);
+
+const moonriverAssetsRegistry = new Registry('moonriver', mockAssetRegistry);
+const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, moonriverAssetsRegistry);
 
 describe('AssetTransferAPI', () => {
 	describe('establishDirection', () => {
@@ -354,27 +361,6 @@ describe('AssetTransferAPI', () => {
 
 				expect(assetCallType).toEqual('Reserve');
 			});
-		});
-	});
-
-	describe('Opts', () => {
-		it('Should correctly read in the injectedRegistry option', () => {
-			const injectedRegistry = {
-				polkadot: {
-					'9876': {
-						tokens: ['TST'],
-						assetsInfo: {},
-						foreignAssetsInfo: {},
-						specName: 'testing',
-						poolPairsInfo: {},
-					},
-				},
-			};
-			const mockSystemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, {
-				injectedRegistry,
-			});
-
-			expect(mockSystemAssetsApi._opts.injectedRegistry).toStrictEqual(injectedRegistry);
 		});
 	});
 

--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -5,15 +5,15 @@ import type { Weight } from '@polkadot/types/interfaces';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { AssetTransferApi } from './AssetTransferApi';
+import { Registry } from './registry';
 import { adjustedMockMoonriverParachainApi } from './testHelpers/adjustedMockMoonriverParachainApi';
 import { adjustedMockRelayApi } from './testHelpers/adjustedMockRelayApi';
 import { adjustedMockSystemApi } from './testHelpers/adjustedMockSystemApi';
+import { mockAssetRegistry } from './testHelpers/mockAssetRegistry';
 import { mockSystemApi } from './testHelpers/mockSystemApi';
 import { mockWeightInfo } from './testHelpers/mockWeightInfo';
 import { Direction, UnsignedTransaction } from './types';
 import { AssetType } from './types';
-import { mockAssetRegistry } from './testHelpers/mockAssetRegistry';
-import { Registry } from './registry';
 
 const mockSubmittableExt = mockSystemApi.registry.createType(
 	'Extrinsic',
@@ -27,7 +27,12 @@ const relayAssetsRegistry = new Registry('kusama', mockAssetRegistry);
 const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, relayAssetsRegistry);
 
 const moonriverAssetsRegistry = new Registry('moonriver', mockAssetRegistry);
-const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, moonriverAssetsRegistry);
+const moonriverAssetsApi = new AssetTransferApi(
+	adjustedMockMoonriverParachainApi,
+	'moonriver',
+	2,
+	moonriverAssetsRegistry
+);
 
 describe('AssetTransferAPI', () => {
 	describe('establishDirection', () => {

--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -43,7 +43,6 @@ import { Registry } from './registry';
 import { sanitizeAddress } from './sanitize/sanitizeAddress';
 import {
 	AssetCallType,
-	AssetTransferApiOpts,
 	AssetType,
 	ConstructedFormat,
 	Direction,
@@ -78,17 +77,15 @@ import { validateNumber } from './validate';
  */
 export class AssetTransferApi {
 	readonly _api: ApiPromise;
-	readonly _opts: AssetTransferApiOpts;
 	readonly _specName: string;
 	readonly _safeXcmVersion: number;
 	readonly registry: Registry;
 
-	constructor(api: ApiPromise, specName: string, safeXcmVersion: number, opts: AssetTransferApiOpts = {}) {
+	constructor(api: ApiPromise, specName: string, safeXcmVersion: number, registry: Registry) {
 		this._api = api;
-		this._opts = opts;
 		this._specName = specName;
 		this._safeXcmVersion = safeXcmVersion;
-		this.registry = new Registry(specName, this._opts);
+		this.registry = registry;
 	}
 
 	/**

--- a/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.spec.ts
@@ -4,9 +4,9 @@ import type { ApiPromise } from '@polkadot/api';
 
 import { Registry } from '../../registry';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { Direction } from '../../types';
 import { limitedReserveTransferAssets } from './limitedReserveTransferAssets';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('limitedReserveTransferAssets', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedReserveTransferAssets.spec.ts
@@ -6,9 +6,10 @@ import { Registry } from '../../registry';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
 import { Direction } from '../../types';
 import { limitedReserveTransferAssets } from './limitedReserveTransferAssets';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('limitedReserveTransferAssets', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 	describe('SystemToPara', () => {
 		const isLiquidTokenTransfer = false;
 		it('Should correctly construct a tx for a system parachain with V2', async () => {

--- a/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.spec.ts
@@ -1,10 +1,10 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Registry } from '../../registry';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { mockSystemApi } from '../../testHelpers/mockSystemApi';
 import { Direction } from '../../types';
 import { limitedTeleportAssets } from './limitedTeleportAssets';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('limitedTeleportAssets', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/limitedTeleportAssets.spec.ts
@@ -4,9 +4,10 @@ import { Registry } from '../../registry';
 import { mockSystemApi } from '../../testHelpers/mockSystemApi';
 import { Direction } from '../../types';
 import { limitedTeleportAssets } from './limitedTeleportAssets';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('limitedTeleportAssets', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 	describe('SystemToPara', () => {
 		const isLiquidTokenTransfer = false;
 		it('Should correctly construct a tx for a system parachain with V2', async () => {

--- a/src/createXcmCalls/polkadotXcm/reserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/reserveTransferAssets.spec.ts
@@ -4,9 +4,9 @@ import type { ApiPromise } from '@polkadot/api';
 
 import { Registry } from '../../registry';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { Direction } from '../../types';
 import { reserveTransferAssets } from './reserveTransferAssets';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('reserveTransferAssets', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmCalls/polkadotXcm/reserveTransferAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/reserveTransferAssets.spec.ts
@@ -6,9 +6,10 @@ import { Registry } from '../../registry';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
 import { Direction } from '../../types';
 import { reserveTransferAssets } from './reserveTransferAssets';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('reserveTransferAssets', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 	describe('SystemToPara', () => {
 		const isLiquidTokenTransfer = false;
 		it('Should correctly construct a tx for a system parachain with V2', async () => {

--- a/src/createXcmCalls/polkadotXcm/teleportAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/teleportAssets.spec.ts
@@ -1,10 +1,10 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { Registry } from '../../registry';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { mockSystemApi } from '../../testHelpers/mockSystemApi';
 import { Direction } from '../../types';
 import { teleportAssets } from './teleportAssets';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('teleportAssets', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmCalls/polkadotXcm/teleportAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/teleportAssets.spec.ts
@@ -4,9 +4,10 @@ import { Registry } from '../../registry';
 import { mockSystemApi } from '../../testHelpers/mockSystemApi';
 import { Direction } from '../../types';
 import { teleportAssets } from './teleportAssets';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('teleportAssets', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 	describe('SystemToPara', () => {
 		const isLiquidTokenTransfer = false;
 		it('Should correctly construct a tx for a system parachain with V2', async () => {

--- a/src/createXcmCalls/xTokens/transferMultiAsset.spec.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAsset.spec.ts
@@ -5,10 +5,11 @@ import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMoc
 import { Direction } from '../../types';
 import { XcmPalletName } from '../util/establishXcmPallet';
 import { transferMultiasset } from './transferMultiasset';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('transferMultiasset', () => {
 	describe('ParaToSystem', () => {
-		const registry = new Registry('moonriver', {});
+		const registry = new Registry('moonriver', mockAssetRegistry);
 
 		it('Should correctly construct an Unlimited transferMultiasset tx for V2', async () => {
 			const ext = await transferMultiasset(

--- a/src/createXcmCalls/xTokens/transferMultiAsset.spec.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAsset.spec.ts
@@ -2,10 +2,10 @@
 
 import { Registry } from '../../registry';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { Direction } from '../../types';
 import { XcmPalletName } from '../util/establishXcmPallet';
 import { transferMultiasset } from './transferMultiasset';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('transferMultiasset', () => {
 	describe('ParaToSystem', () => {

--- a/src/createXcmCalls/xTokens/transferMultiAssetWithFee.spec.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAssetWithFee.spec.ts
@@ -5,10 +5,11 @@ import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMoc
 import { Direction } from '../../types';
 import { XcmPalletName } from '../util/establishXcmPallet';
 import { transferMultiassetWithFee } from './transferMultiassetWithFee';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('transferMultiassetWithFee', () => {
 	describe('ParaToSystem', () => {
-		const registry = new Registry('moonriver', {});
+		const registry = new Registry('moonriver', mockAssetRegistry);
 
 		it('Should correctly construct an Unlimited transferMultiassetWithFee tx for V2', async () => {
 			const isLimited = false;

--- a/src/createXcmCalls/xTokens/transferMultiAssetWithFee.spec.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAssetWithFee.spec.ts
@@ -2,10 +2,10 @@
 
 import { Registry } from '../../registry';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { Direction } from '../../types';
 import { XcmPalletName } from '../util/establishXcmPallet';
 import { transferMultiassetWithFee } from './transferMultiassetWithFee';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('transferMultiassetWithFee', () => {
 	describe('ParaToSystem', () => {

--- a/src/createXcmCalls/xTokens/transferMultiAssets.spec.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAssets.spec.ts
@@ -5,10 +5,11 @@ import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMoc
 import { Direction } from '../../types';
 import { XcmPalletName } from '../util/establishXcmPallet';
 import { transferMultiassets } from './transferMultiassets';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('transferMultiassets', () => {
 	describe('ParaToSystem', () => {
-		const registry = new Registry('moonriver', {});
+		const registry = new Registry('moonriver', mockAssetRegistry);
 
 		it('Should correctly construct an Unlimited transferMultiassets tx for V2', async () => {
 			const isLimited = false;

--- a/src/createXcmCalls/xTokens/transferMultiAssets.spec.ts
+++ b/src/createXcmCalls/xTokens/transferMultiAssets.spec.ts
@@ -2,10 +2,10 @@
 
 import { Registry } from '../../registry';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { Direction } from '../../types';
 import { XcmPalletName } from '../util/establishXcmPallet';
 import { transferMultiassets } from './transferMultiassets';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('transferMultiassets', () => {
 	describe('ParaToSystem', () => {

--- a/src/createXcmTypes/ParaToPara.spec.ts
+++ b/src/createXcmTypes/ParaToPara.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { mockMoonriverParachainApi } from '../testHelpers/mockMoonriverParachainApi';
 import { ParaToPara } from './ParaToPara';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('ParaToPara', () => {
-	const registry = new Registry('kusama', {});
+	const registry = new Registry('kusama', mockAssetRegistry);
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = ParaToPara.createBeneficiary(

--- a/src/createXcmTypes/ParaToPara.spec.ts
+++ b/src/createXcmTypes/ParaToPara.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockMoonriverParachainApi } from '../testHelpers/mockMoonriverParachainApi';
 import { ParaToPara } from './ParaToPara';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('ParaToPara', () => {
 	const registry = new Registry('kusama', mockAssetRegistry);

--- a/src/createXcmTypes/ParaToRelay.spec.ts
+++ b/src/createXcmTypes/ParaToRelay.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { adjustedMockMoonriverParachainApi } from '../testHelpers/adjustedMockMoonriverParachainApi';
 import { ParaToRelay } from './ParaToRelay';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('ParaToRelay', () => {
-	const registry = new Registry('Moonriver', {});
+	const registry = new Registry('Moonriver', mockAssetRegistry);
 	const assetOpts = {
 		registry,
 		isLiquidTokenTransfer: false,

--- a/src/createXcmTypes/ParaToRelay.spec.ts
+++ b/src/createXcmTypes/ParaToRelay.spec.ts
@@ -2,8 +2,8 @@
 
 import { Registry } from '../registry';
 import { adjustedMockMoonriverParachainApi } from '../testHelpers/adjustedMockMoonriverParachainApi';
-import { ParaToRelay } from './ParaToRelay';
 import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
+import { ParaToRelay } from './ParaToRelay';
 
 describe('ParaToRelay', () => {
 	const registry = new Registry('Moonriver', mockAssetRegistry);

--- a/src/createXcmTypes/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/ParaToSystem.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { mockMoonriverParachainApi } from '../testHelpers/mockMoonriverParachainApi';
 import { ParaToSystem } from './ParaToSystem';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('ParaToSystem', () => {
-	const registry = new Registry('kusama', {});
+	const registry = new Registry('kusama', mockAssetRegistry);
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = ParaToSystem.createBeneficiary(

--- a/src/createXcmTypes/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/ParaToSystem.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockMoonriverParachainApi } from '../testHelpers/mockMoonriverParachainApi';
 import { ParaToSystem } from './ParaToSystem';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('ParaToSystem', () => {
 	const registry = new Registry('kusama', mockAssetRegistry);

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { RelayToPara } from './RelayToPara';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('RelayToPara XcmVersioned Generation', () => {
 	const registry = new Registry('kusama', mockAssetRegistry);

--- a/src/createXcmTypes/RelayToPara.spec.ts
+++ b/src/createXcmTypes/RelayToPara.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { RelayToPara } from './RelayToPara';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('RelayToPara XcmVersioned Generation', () => {
-	const registry = new Registry('kusama', {});
+	const registry = new Registry('kusama', mockAssetRegistry);
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = RelayToPara.createBeneficiary(

--- a/src/createXcmTypes/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/RelayToSystem.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { RelayToSystem } from './RelayToSystem';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('RelayToSystem XcmVersioned Generation', () => {
-	const registry = new Registry('kusama', {});
+	const registry = new Registry('kusama', mockAssetRegistry);
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = RelayToSystem.createBeneficiary(

--- a/src/createXcmTypes/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/RelayToSystem.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockRelayApi } from '../testHelpers/mockRelayApi';
 import { RelayToSystem } from './RelayToSystem';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('RelayToSystem XcmVersioned Generation', () => {
 	const registry = new Registry('kusama', mockAssetRegistry);

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -1,11 +1,11 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToPara } from './SystemToPara';
 import { createSystemToParaMultiAssets } from './SystemToPara';
 import { FungibleStrMultiAsset } from './types';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('SystemToPara XcmVersioned Generation', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmTypes/SystemToPara.spec.ts
+++ b/src/createXcmTypes/SystemToPara.spec.ts
@@ -5,9 +5,10 @@ import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToPara } from './SystemToPara';
 import { createSystemToParaMultiAssets } from './SystemToPara';
 import { FungibleStrMultiAsset } from './types';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('SystemToPara XcmVersioned Generation', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {
 			const beneficiary = SystemToPara.createBeneficiary(

--- a/src/createXcmTypes/SystemToRelay.spec.ts
+++ b/src/createXcmTypes/SystemToRelay.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToRelay } from './SystemToRelay';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('SystemToRelay XcmVersioned Generation', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {

--- a/src/createXcmTypes/SystemToRelay.spec.ts
+++ b/src/createXcmTypes/SystemToRelay.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToRelay } from './SystemToRelay';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('SystemToRelay XcmVersioned Generation', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmTypes/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/SystemToSystem.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToSystem } from './SystemToSystem';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('SystemToSystem XcmVersioned Generation', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/createXcmTypes/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/SystemToSystem.spec.ts
@@ -3,9 +3,10 @@
 import { Registry } from '../registry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { SystemToSystem } from './SystemToSystem';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('SystemToSystem XcmVersioned Generation', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 
 	describe('Beneficiary', () => {
 		it('Should work for V2', () => {

--- a/src/createXcmTypes/util/assetIdsContainsRelayAsset.spec.ts
+++ b/src/createXcmTypes/util/assetIdsContainsRelayAsset.spec.ts
@@ -2,10 +2,11 @@
 
 import { Registry } from '../../registry';
 import { assetIdsContainRelayAsset } from './assetIdsContainsRelayAsset';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('assetIdsContainsRelayAsset', () => {
 	it('Should return true when assetIds contains relay chain symbol', () => {
-		const registry = new Registry('statemine', {});
+		const registry = new Registry('statemine', mockAssetRegistry);
 		const assetIds = ['ksm', 'usdt', 'usdc'];
 
 		const result = assetIdsContainRelayAsset(assetIds, registry);
@@ -13,7 +14,7 @@ describe('assetIdsContainsRelayAsset', () => {
 		expect(result).toEqual(true);
 	});
 	it('Should return true when assetIds is an empty array', () => {
-		const registry = new Registry('statemint', {});
+		const registry = new Registry('statemint', mockAssetRegistry);
 		const assetIds = ['dot', 'usdt', 'usdc'];
 
 		const result = assetIdsContainRelayAsset(assetIds, registry);
@@ -21,7 +22,7 @@ describe('assetIdsContainsRelayAsset', () => {
 		expect(result).toEqual(true);
 	});
 	it('Should return true when assetIds contains the relay assets multilocation', () => {
-		const registry = new Registry('asset-hub-polkadot', {});
+		const registry = new Registry('asset-hub-polkadot', mockAssetRegistry);
 		const assetIds = [
 			`{"parents": 1, "interior": {"Here": ''}}`,
 			`{"parents": 1, interior: {"X1": {"Parachain": "2023"}}}`,
@@ -32,7 +33,7 @@ describe('assetIdsContainsRelayAsset', () => {
 		expect(result).toEqual(true);
 	});
 	it('Should return false when assetIds does not contain the relay assets multilocation', () => {
-		const registry = new Registry('statemine', {});
+		const registry = new Registry('statemine', mockAssetRegistry);
 		const assetIds = [`{"parents": 1, interior: {"X1": {"Parachain": "2023"}}}`];
 
 		const result = assetIdsContainRelayAsset(assetIds, registry);
@@ -40,7 +41,7 @@ describe('assetIdsContainsRelayAsset', () => {
 		expect(result).toEqual(false);
 	});
 	it('Should return false when assetIds does not contain the relay assets symbol', () => {
-		const registry = new Registry('statemine', {});
+		const registry = new Registry('statemine', mockAssetRegistry);
 		const assetIds = ['usdc', 'usdt'];
 
 		const result = assetIdsContainRelayAsset(assetIds, registry);

--- a/src/createXcmTypes/util/assetIdsContainsRelayAsset.spec.ts
+++ b/src/createXcmTypes/util/assetIdsContainsRelayAsset.spec.ts
@@ -1,8 +1,8 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../../registry';
-import { assetIdsContainRelayAsset } from './assetIdsContainsRelayAsset';
 import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
+import { assetIdsContainRelayAsset } from './assetIdsContainsRelayAsset';
 
 describe('assetIdsContainsRelayAsset', () => {
 	it('Should return true when assetIds contains relay chain symbol', () => {

--- a/src/createXcmTypes/util/foreignAssetMultiLocationIsInCacheOrRegistry.spec.ts
+++ b/src/createXcmTypes/util/foreignAssetMultiLocationIsInCacheOrRegistry.spec.ts
@@ -1,13 +1,13 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../../registry';
-import { foreignAssetMultiLocationIsInCacheOrRegistry } from './foreignAssetMultiLocationIsInCacheOrRegistry';
 import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
+import { foreignAssetMultiLocationIsInCacheOrRegistry } from './foreignAssetMultiLocationIsInCacheOrRegistry';
 
 describe('foreignAssetMultiLocationIsInCacheOrRegistry', () => {
 	it('Should return true if a given foreign asset multilocation exists in the asset api registry', () => {
 		const expected = true;
-		const multiLocation = '{"parents":1,"interior":{ "X2":[{"Parachain":2125},{"GeneralIndex":0}]}}';
+		const multiLocation = '{"Parents":"1","Interior":{ "X2":[{"Parachain":"2125"},{"GeneralIndex":"0"}]}}';
 		const registry = new Registry('statemine', mockAssetRegistry);
 
 		const foreignAssetExistsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(multiLocation, registry, 2);
@@ -17,7 +17,7 @@ describe('foreignAssetMultiLocationIsInCacheOrRegistry', () => {
 
 	it('Should return false if a given foreign asset multilocation does not exist in the asset api registry', () => {
 		const expected = false;
-		const multiLocation = '{"parents":"1","interior":{"X1": {"Parachain":"200100510"}}}';
+		const multiLocation = '{"Parents":"1","Interior":{"X1": {"Parachain":"200100510"}}}';
 		const registry = new Registry('statemine', mockAssetRegistry);
 
 		const foreignAssetExistsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(multiLocation, registry, 2);

--- a/src/createXcmTypes/util/foreignAssetMultiLocationIsInCacheOrRegistry.spec.ts
+++ b/src/createXcmTypes/util/foreignAssetMultiLocationIsInCacheOrRegistry.spec.ts
@@ -2,12 +2,13 @@
 
 import { Registry } from '../../registry';
 import { foreignAssetMultiLocationIsInCacheOrRegistry } from './foreignAssetMultiLocationIsInCacheOrRegistry';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('foreignAssetMultiLocationIsInCacheOrRegistry', () => {
 	it('Should return true if a given foreign asset multilocation exists in the asset api registry', () => {
 		const expected = true;
 		const multiLocation = '{"parents":1,"interior":{ "X2":[{"Parachain":2125},{"GeneralIndex":0}]}}';
-		const registry = new Registry('statemine', {});
+		const registry = new Registry('statemine', mockAssetRegistry);
 
 		const foreignAssetExistsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(multiLocation, registry, 2);
 
@@ -17,7 +18,7 @@ describe('foreignAssetMultiLocationIsInCacheOrRegistry', () => {
 	it('Should return false if a given foreign asset multilocation does not exist in the asset api registry', () => {
 		const expected = false;
 		const multiLocation = '{"parents":"1","interior":{"X1": {"Parachain":"200100510"}}}';
-		const registry = new Registry('statemine', {});
+		const registry = new Registry('statemine', mockAssetRegistry);
 
 		const foreignAssetExistsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(multiLocation, registry, 2);
 

--- a/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
+++ b/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
@@ -3,9 +3,11 @@
 import { Registry } from '../../registry';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
 import { foreignAssetsMultiLocationExists } from './foreignAssetsMultiLocationExists';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
+import { ChainInfoRegistry } from 'src/registry/types';
 
 describe('foreignMultiAssetMultiLocationExists', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 
 	it('Should return true for an existing foreign asset multilocation', async () => {
 		const expected = true;
@@ -57,7 +59,7 @@ describe('foreignMultiAssetMultiLocationExists', () => {
 					},
 				},
 			},
-		});
+		} as unknown as ChainInfoRegistry);
 		const multiLocation = '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}';
 
 		await foreignAssetsMultiLocationExists(adjustedMockSystemApi, emptyRegistry, multiLocation, 2);

--- a/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
+++ b/src/createXcmTypes/util/foreignAssetsMultiLocationExists.spec.ts
@@ -1,10 +1,11 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { ChainInfoRegistry } from 'src/registry/types';
+
 import { Registry } from '../../registry';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
-import { foreignAssetsMultiLocationExists } from './foreignAssetsMultiLocationExists';
 import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
-import { ChainInfoRegistry } from 'src/registry/types';
+import { foreignAssetsMultiLocationExists } from './foreignAssetsMultiLocationExists';
 
 describe('foreignMultiAssetMultiLocationExists', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);
@@ -48,17 +49,18 @@ describe('foreignMultiAssetMultiLocationExists', () => {
 
 	it('Should correctly cache a valid foreign asset not found in the cache or registry', async () => {
 		const emptyRegistry = new Registry('statemine', {
-			injectedRegistry: {
-				kusama: {
-					'1000': {
-						assetsInfo: {},
-						poolPairsInfo: {},
-						specName: '',
-						tokens: [],
-						foreignAssetsInfo: {},
-					},
+			polkadot: {},
+			kusama: {
+				'1000': {
+					assetsInfo: {},
+					poolPairsInfo: {},
+					specName: '',
+					tokens: [],
+					foreignAssetsInfo: {},
 				},
 			},
+			westend: {},
+			rococo: {},
 		} as unknown as ChainInfoRegistry);
 		const multiLocation = '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}';
 

--- a/src/createXcmTypes/util/getAssetId.spec.ts
+++ b/src/createXcmTypes/util/getAssetId.spec.ts
@@ -6,11 +6,12 @@ import { adjustedMockBifrostParachainApi } from '../../testHelpers/adjustedMockB
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
 import { getAssetId } from './getAssetId';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('getAssetId', () => {
 	describe('Statemine', () => {
-		const registry = new Registry('statemine', {});
-		const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
+		const registry = new Registry('statemine', mockAssetRegistry);
+		const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, registry);
 		it('Should correctly return the integer assetId when given a valid native system chain token symbol', async () => {
 			const expected = '10';
 
@@ -52,8 +53,8 @@ describe('getAssetId', () => {
 	});
 
 	describe('Bifrost', () => {
-		const registry = new Registry('bifrost', {});
-		const bifrostAssetsApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2);
+		const registry = new Registry('bifrost', mockAssetRegistry);
+		const bifrostAssetsApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2, registry);
 
 		it('Should correctly return the xcAsset multilocation when given a valid asset symbol', async () => {
 			const expected = '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}';
@@ -71,8 +72,8 @@ describe('getAssetId', () => {
 	});
 
 	describe('Moonriver', () => {
-		const registry = new Registry('moonriver', {});
-		const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'bifrost', 2);
+		const registry = new Registry('moonriver', mockAssetRegistry);
+		const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'bifrost', 2, registry);
 
 		it('Should correctly return the xcAsset integer assetId when given a valid xcAsset symbol', async () => {
 			const expected = '42259045809535163221576417993425387648';

--- a/src/createXcmTypes/util/getAssetId.spec.ts
+++ b/src/createXcmTypes/util/getAssetId.spec.ts
@@ -5,8 +5,8 @@ import { Registry } from '../../registry';
 import { adjustedMockBifrostParachainApi } from '../../testHelpers/adjustedMockBifrostParachainApi';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
 import { adjustedMockSystemApi } from '../../testHelpers/adjustedMockSystemApi';
-import { getAssetId } from './getAssetId';
 import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
+import { getAssetId } from './getAssetId';
 
 describe('getAssetId', () => {
 	describe('Statemine', () => {

--- a/src/createXcmTypes/util/getXcAssetMultiLocationByAssetId.spec.ts
+++ b/src/createXcmTypes/util/getXcAssetMultiLocationByAssetId.spec.ts
@@ -5,12 +5,13 @@ import { Registry } from '../../registry';
 import { adjustedMockBifrostParachainApi } from '../../testHelpers/adjustedMockBifrostParachainApi';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
 import { getXcAssetMultiLocationByAssetId } from './getXcAssetMultiLocationByAssetId';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
-const bifrostRegistry = new Registry('bifrost', {});
-const bifrostApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 3);
+const bifrostRegistry = new Registry('bifrost', mockAssetRegistry);
+const bifrostApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 3, bifrostRegistry);
 
-const moonriverRegistry = new Registry('moonriver', {});
-const moonriverApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const moonriverRegistry = new Registry('moonriver', mockAssetRegistry);
+const moonriverApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, moonriverRegistry);
 
 describe('getXcAssetMultiLocationByAssetId', () => {
 	describe('Bifrost', () => {

--- a/src/createXcmTypes/util/getXcAssetMultiLocationByAssetId.spec.ts
+++ b/src/createXcmTypes/util/getXcAssetMultiLocationByAssetId.spec.ts
@@ -4,8 +4,8 @@ import { AssetTransferApi } from '../../AssetTransferApi';
 import { Registry } from '../../registry';
 import { adjustedMockBifrostParachainApi } from '../../testHelpers/adjustedMockBifrostParachainApi';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
-import { getXcAssetMultiLocationByAssetId } from './getXcAssetMultiLocationByAssetId';
 import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
+import { getXcAssetMultiLocationByAssetId } from './getXcAssetMultiLocationByAssetId';
 
 const bifrostRegistry = new Registry('bifrost', mockAssetRegistry);
 const bifrostApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 3, bifrostRegistry);

--- a/src/createXcmTypes/util/isParachainPrimaryNativeAsset.spec.ts
+++ b/src/createXcmTypes/util/isParachainPrimaryNativeAsset.spec.ts
@@ -3,13 +3,14 @@
 import { Registry } from '../../registry';
 import { Direction } from '../../types';
 import { isParachainPrimaryNativeAsset } from './isParachainPrimaryNativeAsset';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('isParachainPrimaryNativeAsset', () => {
 	type Test = [primaryNativeAssetSymbol: string | undefined, specName: string, registry: Registry, expected: boolean];
 
 	it('Should correctly return true for valid parachain primary asset inputs', () => {
-		const moonriverRegistry = new Registry('moonriver', {});
-		const hydraDXRegistry = new Registry('hydradx', {});
+		const moonriverRegistry = new Registry('moonriver', mockAssetRegistry);
+		const hydraDXRegistry = new Registry('hydradx', mockAssetRegistry);
 
 		const tests: Test[] = [
 			['', 'moonriver', moonriverRegistry, true],
@@ -32,8 +33,8 @@ describe('isParachainPrimaryNativeAsset', () => {
 	});
 
 	it('Should correctly return false for invalid primary native parachain asset inputs', () => {
-		const moonriverRegistry = new Registry('moonriver', {});
-		const bifrostRegistry = new Registry('bifrost_polkadot', {});
+		const moonriverRegistry = new Registry('moonriver', mockAssetRegistry);
+		const bifrostRegistry = new Registry('bifrost_polkadot', mockAssetRegistry);
 
 		const tests: Test[] = [
 			['1', 'moonriver', moonriverRegistry, false],
@@ -57,8 +58,8 @@ describe('isParachainPrimaryNativeAsset', () => {
 	});
 
 	it('Should correctly return false when direction is not ParaToSystem', () => {
-		const moonriverRegistry = new Registry('moonriver', {});
-		const hydraDXRegistry = new Registry('hydradx', {});
+		const moonriverRegistry = new Registry('moonriver', mockAssetRegistry);
+		const hydraDXRegistry = new Registry('hydradx', mockAssetRegistry);
 
 		const tests: Test[] = [
 			['MOVR', 'moonriver', moonriverRegistry, false],

--- a/src/createXcmTypes/util/isParachainPrimaryNativeAsset.spec.ts
+++ b/src/createXcmTypes/util/isParachainPrimaryNativeAsset.spec.ts
@@ -1,9 +1,9 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { Registry } from '../../registry';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import { Direction } from '../../types';
 import { isParachainPrimaryNativeAsset } from './isParachainPrimaryNativeAsset';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('isParachainPrimaryNativeAsset', () => {
 	type Test = [primaryNativeAssetSymbol: string | undefined, specName: string, registry: Registry, expected: boolean];

--- a/src/errors/checkLocalTxInputs.spec.ts
+++ b/src/errors/checkLocalTxInputs.spec.ts
@@ -3,8 +3,8 @@
 import { AssetTransferApi } from '../AssetTransferApi';
 import { Registry } from '../registry';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
-import { checkLocalTxInput } from './checkLocalTxInputs';
 import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
+import { checkLocalTxInput } from './checkLocalTxInputs';
 
 describe('checkLocalTxInput', () => {
 	const registry = new Registry('statemine', mockAssetRegistry);

--- a/src/errors/checkLocalTxInputs.spec.ts
+++ b/src/errors/checkLocalTxInputs.spec.ts
@@ -4,12 +4,13 @@ import { AssetTransferApi } from '../AssetTransferApi';
 import { Registry } from '../registry';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
 import { checkLocalTxInput } from './checkLocalTxInputs';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('checkLocalTxInput', () => {
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
 	const specName = 'statemine';
 
-	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
+	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, registry);
 
 	it('Should correctly return Balances with an empty assetIds', async () => {
 		const res = await checkLocalTxInput(systemAssetsApi._api, [], ['10000'], specName, registry, 2, false, false);

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -1,10 +1,13 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import { ChainInfoRegistry } from 'src/registry/types';
+
 import { AssetTransferApi } from '../AssetTransferApi';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
 import { Registry } from '../registry';
 import { adjustedMockMoonriverParachainApi } from '../testHelpers/adjustedMockMoonriverParachainApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { Direction } from '../types';
 import {
@@ -24,11 +27,14 @@ import {
 	checkXcmVersionIsValidForPaysWithFeeDest,
 	CheckXTokensPalletOriginIsNonForeignAssetTx,
 } from './checkXcmTxInputs';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
-import { ChainInfoRegistry } from 'src/registry/types';
 
 const parachainAssetsRegistry = new Registry('moonriver', mockAssetRegistry);
-const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, parachainAssetsRegistry);
+const parachainAssetsApi = new AssetTransferApi(
+	adjustedMockMoonriverParachainApi,
+	'moonriver',
+	2,
+	parachainAssetsRegistry
+);
 
 const runTests = async (tests: Test[]) => {
 	for (const test of tests) {
@@ -865,16 +871,14 @@ describe('checkParaAssets', () => {
 
 		it('Should correctly cache a foreign asset that is not found in the registry after being queried', async () => {
 			const injectedChainRegistry = {
-				injectedRegistry: {
-					polkadot: {},
-					kusama: {
-						'1000': {
-							assetsInfo: {},
-							poolPairsInfo: {},
-							specName: '',
-							tokens: [],
-							foreignAssetsInfo: {},
-						},
+				polkadot: {},
+				kusama: {
+					'1000': {
+						assetsInfo: {},
+						poolPairsInfo: {},
+						specName: '',
+						tokens: [],
+						foreignAssetsInfo: {},
 					},
 				},
 				westend: {},
@@ -913,22 +917,19 @@ describe('checkParaAssets', () => {
 
 		it('Should correctly cache a liquid asset that is not found in the registry after being queried', async () => {
 			const injectedChainRegistry = {
-				injectedRegistry: {
-					polkadot: {},
-					kusama: {
-						'1000': {
-							assetsInfo: {},
-							poolPairsInfo: {},
-							specName: '',
-							tokens: [],
-							foreignAssetsInfo: {},
-						},
+				polkadot: {},
+				kusama: {
+					'1000': {
+						assetsInfo: {},
+						poolPairsInfo: {},
+						specName: '',
+						tokens: [],
+						foreignAssetsInfo: {},
 					},
 				},
 				westend: {},
 				rococo: {},
 			} as unknown as ChainInfoRegistry;
-
 
 			const registry = new Registry('statemine', injectedChainRegistry);
 			const chainInfo = {

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -24,12 +24,16 @@ import {
 	checkXcmVersionIsValidForPaysWithFeeDest,
 	CheckXTokensPalletOriginIsNonForeignAssetTx,
 } from './checkXcmTxInputs';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
+import { ChainInfoRegistry } from 'src/registry/types';
 
-const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const parachainAssetsRegistry = new Registry('moonriver', mockAssetRegistry);
+const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, parachainAssetsRegistry);
+
 const runTests = async (tests: Test[]) => {
 	for (const test of tests) {
 		const [specName, testInputs, direction, errorMessage] = test;
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 
 		await expect(async () => {
@@ -164,7 +168,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
@@ -207,7 +211,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
@@ -231,7 +235,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
@@ -274,7 +278,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
@@ -304,7 +308,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
@@ -334,7 +338,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 			await expect(async () => {
 				await checkAssetIdInput(
@@ -369,7 +373,7 @@ describe('checkAssetIds', () => {
 
 		for (const test of tests) {
 			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
+			const registry = new Registry(specName, mockAssetRegistry);
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
@@ -388,7 +392,7 @@ describe('checkAssetIds', () => {
 		}
 	});
 	it('Should error for an invalid erc20 token.', async () => {
-		const registry = new Registry('moonriver', {});
+		const registry = new Registry('moonriver', mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 
 		await expect(async () => {
@@ -406,7 +410,7 @@ describe('checkAssetIds', () => {
 		}).rejects.toThrowError('(ParaToSystem) assetId 0x1234, is not a valid erc20 token.');
 	});
 	it('Should error when an invalid token is passed into a liquidTokenTransfer', async () => {
-		const registry = new Registry('westmint', {});
+		const registry = new Registry('westmint', mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 		const isLiquidTokenTransfer = true;
 
@@ -425,7 +429,7 @@ describe('checkAssetIds', () => {
 		}).rejects.toThrowError('Liquid Tokens must be valid Integers');
 	});
 	it('Should error when a token does not exist in the registry or node', async () => {
-		const registry = new Registry('westmint', {});
+		const registry = new Registry('westmint', mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 		const isLiquidTokenTransfer = true;
 
@@ -446,7 +450,7 @@ describe('checkAssetIds', () => {
 		);
 	});
 	it('Should not error when a valid liquid token exists', async () => {
-		const registry = new Registry('westmint', {});
+		const registry = new Registry('westmint', mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 		const isLiquidTokenTransfer = true;
 
@@ -466,7 +470,7 @@ describe('checkAssetIds', () => {
 		}).not.toThrow();
 	});
 	it('Should not throw an error for ParaToRelay when its a valid', async () => {
-		const registry = new Registry('moonriver', {});
+		const registry = new Registry('moonriver', mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 		// eslint-disable-next-line @typescript-eslint/await-thenable
 		await expect(async () => {
@@ -526,7 +530,7 @@ describe('checkAssetIds', () => {
 		}).not.toThrow();
 	});
 	it('Should error when an invalid assetId is inputted for ParaToRelay', async () => {
-		const registry = new Registry('karura', {});
+		const registry = new Registry('karura', mockAssetRegistry);
 		const currentRegistry = registry.currentRelayRegistry;
 
 		await expect(async () => {
@@ -553,7 +557,7 @@ describe('checkIfNativeRelayChainAssetPresentInMultiAssetIdList', () => {
 			'Found the relay chains native asset in list [ksm,usdc]. `assetIds` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.';
 		const assetIds = ['ksm', 'usdc'];
 		const specName = 'statemine';
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 
 		const err = () => checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
 		expect(err).toThrowError(expectErrorMessage);
@@ -752,7 +756,7 @@ describe('checkParaAssets', () => {
 	it('Should correctly resolve when a valid symbol assetId is provided', async () => {
 		const assetId = 'xcUSDt';
 		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 		let didNotError = true;
 
 		try {
@@ -766,7 +770,7 @@ describe('checkParaAssets', () => {
 	it('Should correctly resolve when a valid integer assetId is provided', async () => {
 		const assetId = '311091173110107856861649819128533077277';
 		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 		let didNotError = true;
 
 		try {
@@ -780,7 +784,7 @@ describe('checkParaAssets', () => {
 	it('Should correctly error when an invalid symbol assetId is provided', async () => {
 		const assetId = 'xcUSDfake';
 		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 
 		await expect(async () => {
 			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
@@ -789,7 +793,7 @@ describe('checkParaAssets', () => {
 	it('Should correctly error when an invalid integer assetId is provided', async () => {
 		const assetId = '2096586909097964981698161';
 		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 
 		await expect(async () => {
 			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
@@ -798,7 +802,7 @@ describe('checkParaAssets', () => {
 	it('Should correctly error when a valid assetId is not found in the xcAsset registry', async () => {
 		const assetId = '999999999999999999999999999999999999999';
 		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+		const registry = new Registry(specName, mockAssetRegistry);
 
 		await expect(async () => {
 			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
@@ -807,7 +811,7 @@ describe('checkParaAssets', () => {
 
 	describe('cache', () => {
 		it('Should correctly cache an asset that is not found in the registry after being queried for origin System', async () => {
-			const registry = new Registry('statemine', {});
+			const registry = new Registry('statemine', mockAssetRegistry);
 			const chainInfo = {
 				'1000': {
 					assetsInfo: {},
@@ -833,7 +837,7 @@ describe('checkParaAssets', () => {
 			expect(registry.cacheLookupAsset('1984')).toEqual('USDt');
 		});
 		it('Should correctly cache an asset that is not found in the registry after being queried for origin Para', async () => {
-			const registry = new Registry('moonriver', {});
+			const registry = new Registry('moonriver', mockAssetRegistry);
 			const chainInfo = {
 				'2023': {
 					assetsInfo: {},
@@ -860,8 +864,9 @@ describe('checkParaAssets', () => {
 		});
 
 		it('Should correctly cache a foreign asset that is not found in the registry after being queried', async () => {
-			const registry = new Registry('statemine', {
+			const injectedChainRegistry = {
 				injectedRegistry: {
+					polkadot: {},
 					kusama: {
 						'1000': {
 							assetsInfo: {},
@@ -872,7 +877,11 @@ describe('checkParaAssets', () => {
 						},
 					},
 				},
-			});
+				westend: {},
+				rococo: {},
+			} as unknown as ChainInfoRegistry;
+
+			const registry = new Registry('statemine', injectedChainRegistry);
 			const chainInfo = {
 				'1000': {
 					assetsInfo: {},
@@ -903,8 +912,9 @@ describe('checkParaAssets', () => {
 		});
 
 		it('Should correctly cache a liquid asset that is not found in the registry after being queried', async () => {
-			const registry = new Registry('statemine', {
+			const injectedChainRegistry = {
 				injectedRegistry: {
+					polkadot: {},
 					kusama: {
 						'1000': {
 							assetsInfo: {},
@@ -915,7 +925,12 @@ describe('checkParaAssets', () => {
 						},
 					},
 				},
-			});
+				westend: {},
+				rococo: {},
+			} as unknown as ChainInfoRegistry;
+
+
+			const registry = new Registry('statemine', injectedChainRegistry);
 			const chainInfo = {
 				'1000': {
 					assetsInfo: {},

--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -2,11 +2,11 @@
 
 import { AssetTransferApi } from '../AssetTransferApi';
 import { CreateXcmCallOpts } from '../createXcmCalls/types';
+import { Registry } from '../registry';
 import { adjustedMockRelayApi } from '../testHelpers/adjustedMockRelayApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
-import type { Format, TxResult } from '../types';
-import { Registry } from '../registry';
 import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
+import type { Format, TxResult } from '../types';
 
 const relayAssetsRegistry = new Registry('kusama', mockAssetRegistry);
 const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, relayAssetsRegistry);

--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -5,9 +5,14 @@ import { CreateXcmCallOpts } from '../createXcmCalls/types';
 import { adjustedMockRelayApi } from '../testHelpers/adjustedMockRelayApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
 import type { Format, TxResult } from '../types';
+import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
-const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2);
-const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
+const relayAssetsRegistry = new Registry('kusama', mockAssetRegistry);
+const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, relayAssetsRegistry);
+
+const systemAssetsRegistry = new Registry('statemine', mockAssetRegistry);
+const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, systemAssetsRegistry);
 
 describe('AssetTransferApi Integration Tests', () => {
 	describe('createTransferTransaction', () => {

--- a/src/integrationTests/parachains/bifrost.spec.ts
+++ b/src/integrationTests/parachains/bifrost.spec.ts
@@ -1,15 +1,15 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { AssetTransferApi } from '../../AssetTransferApi';
+import { Registry } from '../../registry';
 import { adjustedMockBifrostParachainApi } from '../../testHelpers/adjustedMockBifrostParachainApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import type { Direction, Format } from '../../types';
 import type { TestMultiasset, TestMultiassets, TestMultiassetWithFormat } from '../util';
 import { paraTransferMultiasset as bifrostTransferMultiasset } from '../util';
 import { paraTransferMultiassets as bifrostTransferMultiassets } from '../util';
 import { paraTransferMultiassetWithFee as bifrostTransferMultiassetWithFee } from '../util';
 import { paraTeleportNativeAsset as bifrsotTeleportNativeAsset } from '../util';
-import { Registry } from '../../registry';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('Bifrost', () => {
 	const bifrostRegistry = new Registry('bifrost', mockAssetRegistry);

--- a/src/integrationTests/parachains/bifrost.spec.ts
+++ b/src/integrationTests/parachains/bifrost.spec.ts
@@ -8,10 +8,13 @@ import { paraTransferMultiasset as bifrostTransferMultiasset } from '../util';
 import { paraTransferMultiassets as bifrostTransferMultiassets } from '../util';
 import { paraTransferMultiassetWithFee as bifrostTransferMultiassetWithFee } from '../util';
 import { paraTeleportNativeAsset as bifrsotTeleportNativeAsset } from '../util';
-
-const bifrostATA = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2);
+import { Registry } from '../../registry';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('Bifrost', () => {
+	const bifrostRegistry = new Registry('bifrost', mockAssetRegistry);
+	const bifrostATA = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2, bifrostRegistry);
+
 	describe('ParaToPara', () => {
 		describe('transferMultiasset', () => {
 			describe('XCM V2', () => {

--- a/src/integrationTests/parachains/moonriver.spec.ts
+++ b/src/integrationTests/parachains/moonriver.spec.ts
@@ -1,15 +1,15 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { AssetTransferApi } from '../../AssetTransferApi';
+import { Registry } from '../../registry';
 import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMockMoonriverParachainApi';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 import type { Direction, Format } from '../../types';
 import type { TestMultiassetsWithFormat, TestMultiassetWithFormat } from '../util';
 import { paraTransferMultiasset as moonriverTransferMultiasset } from '../util';
 import { paraTransferMultiassets as moonriverTransferMultiassets } from '../util';
 import { paraTransferMultiassetWithFee as moonriverTransferMultiassetWithFee } from '../util';
 import { paraTeleportNativeAsset as moonriverTeleportNativeAsset } from '../util';
-import { Registry } from '../../registry';
-import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('Moonriver', () => {
 	const moonriverRegistry = new Registry('moonriver', mockAssetRegistry);

--- a/src/integrationTests/parachains/moonriver.spec.ts
+++ b/src/integrationTests/parachains/moonriver.spec.ts
@@ -8,10 +8,13 @@ import { paraTransferMultiasset as moonriverTransferMultiasset } from '../util';
 import { paraTransferMultiassets as moonriverTransferMultiassets } from '../util';
 import { paraTransferMultiassetWithFee as moonriverTransferMultiassetWithFee } from '../util';
 import { paraTeleportNativeAsset as moonriverTeleportNativeAsset } from '../util';
-
-const moonriverATA = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+import { Registry } from '../../registry';
+import { mockAssetRegistry } from '../../testHelpers/mockAssetRegistry';
 
 describe('Moonriver', () => {
+	const moonriverRegistry = new Registry('moonriver', mockAssetRegistry);
+	const moonriverATA = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, moonriverRegistry);
+
 	describe('ParaToPara', () => {
 		describe('transferMultiasset', () => {
 			describe('XCM V2', () => {

--- a/src/registry/Registry.spec.ts
+++ b/src/registry/Registry.spec.ts
@@ -1,12 +1,12 @@
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { Registry } from './Registry';
 import type { ForeignAssetsData } from './types';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
-describe('Registry',() => {
+describe('Registry', () => {
 	const registry = new Registry('polkadot', mockAssetRegistry);
-	
+
 	describe('initialization', () => {
-		it('Should initalize rococo correctly', async () => {
+		it('Should initalize rococo correctly', () => {
 			const registry = new Registry('rococo', mockAssetRegistry);
 			expect(registry.relayChain).toEqual('rococo');
 		});
@@ -31,33 +31,48 @@ describe('Registry',() => {
 							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
 						},
 						{
+							asset: '166377000701797186346254371275954761085',
+							decimals: 6,
+							paraID: 1000,
+							symbol: 'USDC',
+							xcmV1MultiLocation:
+								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}',
+						},
+						{
 							asset: '311091173110107856861649819128533077277',
 							decimals: 6,
 							paraID: 1000,
 							symbol: 'USDT',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":1984}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+						},
+						{
+							asset: '225719522181998468294117309041779353812',
+							decimals: 10,
+							paraID: 2000,
+							symbol: 'LDOT',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0003"}]}}}',
 						},
 						{
 							asset: '110021739665376159354538090254163045594',
 							decimals: 12,
 							paraID: 2000,
 							symbol: 'aUSD',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2000},{"GeneralKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '224821240862170613278369189818311486111',
 							decimals: 12,
 							paraID: 2000,
 							symbol: 'ACA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2000},{"GeneralKey":"0x0000"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0000"}]}}}',
 						},
 						{
 							asset: '224077081838586484055667086558292981199',
 							decimals: 18,
 							paraID: 2006,
 							symbol: 'ASTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2006}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
 						},
 						{
 							asset: '187224307232923873519830480073807488153',
@@ -65,14 +80,14 @@ describe('Registry',() => {
 							paraID: 2011,
 							symbol: 'EQD',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2011},{"GeneralKey":"0x657164"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
 						},
 						{
 							asset: '190590555344745888270686124937537713878',
 							decimals: 9,
 							paraID: 2011,
 							symbol: 'EQ',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2011}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
 						},
 						{
 							asset: '32615670524745285411807346420584982855',
@@ -80,105 +95,119 @@ describe('Registry',() => {
 							paraID: 2012,
 							symbol: 'PARA',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2012},{"GeneralKey":"0x50415241"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
 						},
 						{
 							asset: '309163521958167876851250718453738106865',
 							decimals: 11,
 							paraID: 2026,
 							symbol: 'NODL',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2026},{"palletInstance":2}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2026},{"palletInstance":2}]}}}',
 						},
 						{
 							asset: '144012926827374458669278577633504620722',
 							decimals: 18,
 							paraID: 2030,
 							symbol: 'FIL',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0804"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0804"}]}}}',
 						},
 						{
 							asset: '29085784439601774464560083082574142143',
 							decimals: 10,
 							paraID: 2030,
 							symbol: 'vDOT',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0900"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
 						},
 						{
 							asset: '204507659831918931608354793288110796652',
 							decimals: 18,
 							paraID: 2030,
 							symbol: 'vGLMR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0901"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0901"}]}}}',
 						},
 						{
 							asset: '165823357460190568952172802245839421906',
 							decimals: 12,
 							paraID: 2030,
 							symbol: 'BNC',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '272547899416482196831721420898811311297',
 							decimals: 18,
 							paraID: 2030,
 							symbol: 'vFIL',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0904"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0904"}]}}}',
 						},
 						{
 							asset: '91372035960551235635465443179559840483',
 							decimals: 18,
 							paraID: 2031,
 							symbol: 'CFG',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2031},{"GeneralKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2031},{"generalKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '120637696315203257380661607956669368914',
 							decimals: 8,
 							paraID: 2032,
 							symbol: 'IBTC',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '101170542313601871197860408087030232491',
 							decimals: 10,
 							paraID: 2032,
 							symbol: 'INTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0002"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
 						},
 						{
 							asset: '69606720909260275826784788104880799692',
 							decimals: 12,
 							paraID: 2034,
 							symbol: 'HDX',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2034},{"GeneralIndex":0}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2034},{"generalIndex":0}]}}}',
 						},
 						{
 							asset: '132685552157663328694213725410064821485',
 							decimals: 12,
 							paraID: 2035,
 							symbol: 'PHA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2035}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+						},
+						{
+							asset: '238111524681612888331172110363070489924',
+							decimals: 12,
+							paraID: 2043,
+							symbol: 'OTP',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2043},{"palletInstance":10}]}}}',
 						},
 						{
 							asset: '125699734534028342599692732320197985871',
 							decimals: 18,
 							paraID: 2046,
 							symbol: 'RING',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2046},{"palletInstance":5}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2046},{"palletInstance":5}]}}}',
+						},
+						{
+							asset: '150874409661081770150564009349448205842',
+							decimals: 10,
+							paraID: 2092,
+							symbol: 'ZTG',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '89994634370519791027168048838578580624',
 							decimals: 10,
 							paraID: 2101,
 							symbol: 'SUB',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2101}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2101}}}}',
 						},
 						{
 							asset: '166446646689194205559791995948102903873',
 							decimals: 18,
 							paraID: 2104,
 							symbol: 'MANTA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2104}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2104}}}}',
 						},
 					],
 				},
@@ -208,7 +237,9 @@ describe('Registry',() => {
 						'15': 'Meme',
 						'20': 'StabCP',
 						'21': 'WBTC',
+						'23': 'PINK',
 						'77': 'TRQ',
+						'79': 'PGOLD',
 						'99': 'Cypress',
 						'100': 'WETH',
 						'101': 'DOTMA',
@@ -222,29 +253,28 @@ describe('Registry',() => {
 						'1984': 'USDt',
 						'862812': 'CUBO',
 						'868367': 'VSC',
-						'19120101': 'NTDC',
-						'19760401': 'APPL',
 						'20090103': 'BTC',
 					},
 					specName: 'statemint',
 					chainId: '1000',
 					poolPairsInfo: {},
 					foreignAssetsInfo: {
-						'0x02010903': {
-							multiLocation: '{"parents":2,"interior":{"x1":{"globalConsensus":{"kusama":null}}}}',
-							name: '',
-							symbol: '',
-						},
+						'0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a224b7573616d61227d7d7d':
+							{
+								multiLocation: '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Kusama"}}}',
+								name: '',
+								symbol: '',
+							},
 						EQ: {
 							symbol: 'EQ',
 							name: 'Equilibrium',
-							multiLocation: '{"parents":1,"interior":{"x1":{"Parachain":2011}}}',
+							multiLocation: '{"parents":"1","interior":{"X1":{"Parachain":"2011"}}}',
 						},
 						EQD: {
 							symbol: 'EQD',
 							name: 'Equilibrium Dollar',
 							multiLocation:
-								'{"parents":1,"interior":{"x2":[{"Parachain":2011},{"GeneralKey":{"length":3,"data":"0x6571640000000000000000000000000000000000000000000000000000000000"}}]}}',
+								'{"parents":"1","interior":{"X2":[{"Parachain":"2011"},{"GeneralKey":{"length":"3","data":"0x6571640000000000000000000000000000000000000000000000000000000000"}}]}}',
 						},
 					},
 				},
@@ -281,7 +311,7 @@ describe('Registry',() => {
 							paraID: 1000,
 							symbol: 'USDT',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":1984}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
 						},
 						{
 							asset: {
@@ -291,7 +321,7 @@ describe('Registry',() => {
 							paraID: 1000,
 							symbol: 'WETH',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":100}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":100}]}}}',
 						},
 						{
 							asset: {
@@ -301,7 +331,7 @@ describe('Registry',() => {
 							paraID: 1000,
 							symbol: 'WBTC',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":21}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":21}]}}}',
 						},
 						{
 							asset: {
@@ -310,7 +340,7 @@ describe('Registry',() => {
 							decimals: 18,
 							paraID: 2004,
 							symbol: 'GLMR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2004},{"palletInstance":10}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
 						},
 						{
 							asset: {
@@ -319,7 +349,7 @@ describe('Registry',() => {
 							decimals: 18,
 							paraID: 2006,
 							symbol: 'ASTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2006}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
 						},
 						{
 							asset: {
@@ -328,7 +358,7 @@ describe('Registry',() => {
 							decimals: 12,
 							paraID: 2008,
 							symbol: 'CRU',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2008}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2008}}}}',
 						},
 						{
 							asset: {
@@ -338,7 +368,7 @@ describe('Registry',() => {
 							paraID: 2011,
 							symbol: 'EQD',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2011},{"GeneralKey":"0x657164"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
 						},
 						{
 							asset: {
@@ -347,7 +377,7 @@ describe('Registry',() => {
 							decimals: 9,
 							paraID: 2011,
 							symbol: 'EQ',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2011}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
 						},
 						{
 							asset: {
@@ -357,7 +387,7 @@ describe('Registry',() => {
 							paraID: 2012,
 							symbol: 'PARA',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2012},{"GeneralKey":"0x50415241"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
 						},
 						{
 							asset: {
@@ -366,7 +396,7 @@ describe('Registry',() => {
 							decimals: 8,
 							paraID: 2032,
 							symbol: 'IBTC',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
 						},
 						{
 							asset: {
@@ -375,7 +405,7 @@ describe('Registry',() => {
 							decimals: 10,
 							paraID: 2032,
 							symbol: 'INTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0002"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
 						},
 						{
 							asset: {
@@ -384,7 +414,7 @@ describe('Registry',() => {
 							decimals: 12,
 							paraID: 2035,
 							symbol: 'PHA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2035}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
 						},
 						{
 							asset: {
@@ -393,7 +423,7 @@ describe('Registry',() => {
 							decimals: 18,
 							paraID: 2037,
 							symbol: 'UNQ',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2037}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2037}}}}',
 						},
 					],
 				},
@@ -434,7 +464,7 @@ describe('Registry',() => {
 			const foreignAssetData: ForeignAssetsData = {
 				symbol: 'TNKR',
 				name: 'Tinkernet',
-				multiLocation: '{"parents":1,"interior":{"x2":[{"Parachain":2125},{"GeneralIndex":0}]}}',
+				multiLocation: '{"parents":1,"interior":{"x2":[{"parachain":2125},{"generalIndex":0}]}}',
 			};
 			registry.setForeignAssetInCache('TNKR', foreignAssetData);
 

--- a/src/registry/Registry.spec.ts
+++ b/src/registry/Registry.spec.ts
@@ -1,11 +1,13 @@
 import { Registry } from './Registry';
 import type { ForeignAssetsData } from './types';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
-describe('Registry', () => {
-	const registry = new Registry('polkadot', {});
+describe('Registry',() => {
+	const registry = new Registry('polkadot', mockAssetRegistry);
+	
 	describe('initialization', () => {
-		it('Should initalize rococo correctly', () => {
-			const registry = new Registry('rococo', {});
+		it('Should initalize rococo correctly', async () => {
+			const registry = new Registry('rococo', mockAssetRegistry);
 			expect(registry.relayChain).toEqual('rococo');
 		});
 	});
@@ -34,28 +36,28 @@ describe('Registry', () => {
 							paraID: 1000,
 							symbol: 'USDT',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":1984}]}}}',
 						},
 						{
 							asset: '110021739665376159354538090254163045594',
 							decimals: 12,
 							paraID: 2000,
 							symbol: 'aUSD',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2000},{"GeneralKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '224821240862170613278369189818311486111',
 							decimals: 12,
 							paraID: 2000,
 							symbol: 'ACA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0000"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2000},{"GeneralKey":"0x0000"}]}}}',
 						},
 						{
 							asset: '224077081838586484055667086558292981199',
 							decimals: 18,
 							paraID: 2006,
 							symbol: 'ASTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2006}}}}',
 						},
 						{
 							asset: '187224307232923873519830480073807488153',
@@ -63,14 +65,14 @@ describe('Registry', () => {
 							paraID: 2011,
 							symbol: 'EQD',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2011},{"GeneralKey":"0x657164"}]}}}',
 						},
 						{
 							asset: '190590555344745888270686124937537713878',
 							decimals: 9,
 							paraID: 2011,
 							symbol: 'EQ',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2011}}}}',
 						},
 						{
 							asset: '32615670524745285411807346420584982855',
@@ -78,105 +80,105 @@ describe('Registry', () => {
 							paraID: 2012,
 							symbol: 'PARA',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2012},{"GeneralKey":"0x50415241"}]}}}',
 						},
 						{
 							asset: '309163521958167876851250718453738106865',
 							decimals: 11,
 							paraID: 2026,
 							symbol: 'NODL',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2026},{"palletInstance":2}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2026},{"palletInstance":2}]}}}',
 						},
 						{
 							asset: '144012926827374458669278577633504620722',
 							decimals: 18,
 							paraID: 2030,
 							symbol: 'FIL',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0804"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0804"}]}}}',
 						},
 						{
 							asset: '29085784439601774464560083082574142143',
 							decimals: 10,
 							paraID: 2030,
 							symbol: 'vDOT',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0900"}]}}}',
 						},
 						{
 							asset: '204507659831918931608354793288110796652',
 							decimals: 18,
 							paraID: 2030,
 							symbol: 'vGLMR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0901"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0901"}]}}}',
 						},
 						{
 							asset: '165823357460190568952172802245839421906',
 							decimals: 12,
 							paraID: 2030,
 							symbol: 'BNC',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '272547899416482196831721420898811311297',
 							decimals: 18,
 							paraID: 2030,
 							symbol: 'vFIL',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0904"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2030},{"GeneralKey":"0x0904"}]}}}',
 						},
 						{
 							asset: '91372035960551235635465443179559840483',
 							decimals: 18,
 							paraID: 2031,
 							symbol: 'CFG',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2031},{"generalKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2031},{"GeneralKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '120637696315203257380661607956669368914',
 							decimals: 8,
 							paraID: 2032,
 							symbol: 'IBTC',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0001"}]}}}',
 						},
 						{
 							asset: '101170542313601871197860408087030232491',
 							decimals: 10,
 							paraID: 2032,
 							symbol: 'INTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0002"}]}}}',
 						},
 						{
 							asset: '69606720909260275826784788104880799692',
 							decimals: 12,
 							paraID: 2034,
 							symbol: 'HDX',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2034},{"generalIndex":0}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2034},{"GeneralIndex":0}]}}}',
 						},
 						{
 							asset: '132685552157663328694213725410064821485',
 							decimals: 12,
 							paraID: 2035,
 							symbol: 'PHA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2035}}}}',
 						},
 						{
 							asset: '125699734534028342599692732320197985871',
 							decimals: 18,
 							paraID: 2046,
 							symbol: 'RING',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2046},{"palletInstance":5}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2046},{"palletInstance":5}]}}}',
 						},
 						{
 							asset: '89994634370519791027168048838578580624',
 							decimals: 10,
 							paraID: 2101,
 							symbol: 'SUB',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2101}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2101}}}}',
 						},
 						{
 							asset: '166446646689194205559791995948102903873',
 							decimals: 18,
 							paraID: 2104,
 							symbol: 'MANTA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2104}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2104}}}}',
 						},
 					],
 				},
@@ -236,13 +238,13 @@ describe('Registry', () => {
 						EQ: {
 							symbol: 'EQ',
 							name: 'Equilibrium',
-							multiLocation: '{"parents":1,"interior":{"x1":{"parachain":2011}}}',
+							multiLocation: '{"parents":1,"interior":{"x1":{"Parachain":2011}}}',
 						},
 						EQD: {
 							symbol: 'EQD',
 							name: 'Equilibrium Dollar',
 							multiLocation:
-								'{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":{"length":3,"data":"0x6571640000000000000000000000000000000000000000000000000000000000"}}]}}',
+								'{"parents":1,"interior":{"x2":[{"Parachain":2011},{"GeneralKey":{"length":3,"data":"0x6571640000000000000000000000000000000000000000000000000000000000"}}]}}',
 						},
 					},
 				},
@@ -279,7 +281,7 @@ describe('Registry', () => {
 							paraID: 1000,
 							symbol: 'USDT',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":1984}]}}}',
 						},
 						{
 							asset: {
@@ -289,7 +291,7 @@ describe('Registry', () => {
 							paraID: 1000,
 							symbol: 'WETH',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":100}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":100}]}}}',
 						},
 						{
 							asset: {
@@ -299,7 +301,7 @@ describe('Registry', () => {
 							paraID: 1000,
 							symbol: 'WBTC',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":21}]}}}',
+								'{"v1":{"parents":1,"interior":{"x3":[{"Parachain":1000},{"palletInstance":50},{"GeneralIndex":21}]}}}',
 						},
 						{
 							asset: {
@@ -308,7 +310,7 @@ describe('Registry', () => {
 							decimals: 18,
 							paraID: 2004,
 							symbol: 'GLMR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2004},{"palletInstance":10}]}}}',
 						},
 						{
 							asset: {
@@ -317,7 +319,7 @@ describe('Registry', () => {
 							decimals: 18,
 							paraID: 2006,
 							symbol: 'ASTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2006}}}}',
 						},
 						{
 							asset: {
@@ -326,7 +328,7 @@ describe('Registry', () => {
 							decimals: 12,
 							paraID: 2008,
 							symbol: 'CRU',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2008}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2008}}}}',
 						},
 						{
 							asset: {
@@ -336,7 +338,7 @@ describe('Registry', () => {
 							paraID: 2011,
 							symbol: 'EQD',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2011},{"GeneralKey":"0x657164"}]}}}',
 						},
 						{
 							asset: {
@@ -345,7 +347,7 @@ describe('Registry', () => {
 							decimals: 9,
 							paraID: 2011,
 							symbol: 'EQ',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2011}}}}',
 						},
 						{
 							asset: {
@@ -355,7 +357,7 @@ describe('Registry', () => {
 							paraID: 2012,
 							symbol: 'PARA',
 							xcmV1MultiLocation:
-								'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
+								'{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2012},{"GeneralKey":"0x50415241"}]}}}',
 						},
 						{
 							asset: {
@@ -364,7 +366,7 @@ describe('Registry', () => {
 							decimals: 8,
 							paraID: 2032,
 							symbol: 'IBTC',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0001"}]}}}',
 						},
 						{
 							asset: {
@@ -373,7 +375,7 @@ describe('Registry', () => {
 							decimals: 10,
 							paraID: 2032,
 							symbol: 'INTR',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"Parachain":2032},{"GeneralKey":"0x0002"}]}}}',
 						},
 						{
 							asset: {
@@ -382,7 +384,7 @@ describe('Registry', () => {
 							decimals: 12,
 							paraID: 2035,
 							symbol: 'PHA',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2035}}}}',
 						},
 						{
 							asset: {
@@ -391,7 +393,7 @@ describe('Registry', () => {
 							decimals: 18,
 							paraID: 2037,
 							symbol: 'UNQ',
-							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2037}}}}',
+							xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"Parachain":2037}}}}',
 						},
 					],
 				},
@@ -432,7 +434,7 @@ describe('Registry', () => {
 			const foreignAssetData: ForeignAssetsData = {
 				symbol: 'TNKR',
 				name: 'Tinkernet',
-				multiLocation: '{"parents":1,"interior":{"x2":[{"parachain":2125},{"generalIndex":0}]}}',
+				multiLocation: '{"parents":1,"interior":{"x2":[{"Parachain":2125},{"GeneralIndex":0}]}}',
 			};
 			registry.setForeignAssetInCache('TNKR', foreignAssetData);
 

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -17,8 +17,7 @@ export class Registry {
 
 	constructor(specName: string, registry: ChainInfoRegistry) {
 		this.specName = specName;
-		this.registry = registry,
-		this.relayChain = findRelayChain(this.specName, this.registry);
+		(this.registry = registry), (this.relayChain = findRelayChain(this.specName, this.registry));
 		this.currentRelayRegistry = this.registry[this.relayChain];
 		this.specNameToIdCache = new Map<string, string>();
 		this.cache = {

--- a/src/registry/Registry.ts
+++ b/src/registry/Registry.ts
@@ -4,8 +4,7 @@ import {
 	POLKADOT_ASSET_HUB_SPEC_NAMES,
 	WESTEND_ASSET_HUB_SPEC_NAMES,
 } from '../consts';
-import type { AssetTransferApiOpts } from '../types';
-import { findRelayChain, parseRegistry } from './';
+import { findRelayChain } from './';
 import type { ChainInfo, ChainInfoRegistry, ExpandedChainInfoKeys, ForeignAssetsData, RelayChains } from './types';
 
 export class Registry {
@@ -16,9 +15,9 @@ export class Registry {
 	cache: ChainInfoRegistry;
 	specNameToIdCache: Map<string, string>;
 
-	constructor(specName: string, opts: AssetTransferApiOpts) {
+	constructor(specName: string, registry: ChainInfoRegistry) {
 		this.specName = specName;
-		this.registry = parseRegistry(opts);
+		this.registry = registry,
 		this.relayChain = findRelayChain(this.specName, this.registry);
 		this.currentRelayRegistry = this.registry[this.relayChain];
 		this.specNameToIdCache = new Map<string, string>();

--- a/src/registry/findRelayChain.spec.ts
+++ b/src/registry/findRelayChain.spec.ts
@@ -1,5 +1,5 @@
-import { findRelayChain } from './findRelayChain';
 import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
+import { findRelayChain } from './findRelayChain';
 
 describe('findRelayChain', () => {
 	it('Should correctly discover the right relay chain', () => {

--- a/src/registry/findRelayChain.spec.ts
+++ b/src/registry/findRelayChain.spec.ts
@@ -1,21 +1,20 @@
 import { findRelayChain } from './findRelayChain';
-import { parseRegistry } from './parseRegistry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 
 describe('findRelayChain', () => {
-	const registry = parseRegistry({});
 	it('Should correctly discover the right relay chain', () => {
-		const findPolkadot = findRelayChain('statemint', registry);
-		const findKusama = findRelayChain('statemine', registry);
-		const findWestend = findRelayChain('westmint', registry);
+		const findPolkadot = findRelayChain('statemint', mockAssetRegistry);
+		const findKusama = findRelayChain('statemine', mockAssetRegistry);
+		const findWestend = findRelayChain('westmint', mockAssetRegistry);
 
 		expect(findPolkadot).toEqual('polkadot');
 		expect(findKusama).toEqual('kusama');
 		expect(findWestend).toEqual('westend');
 	});
 	it('Should correctly discover the right relay chain when using asset-hub specNames', () => {
-		const findPolkadot = findRelayChain('asset-hub-polkadot', registry);
-		const findKusama = findRelayChain('asset-hub-kusama', registry);
-		const findWestend = findRelayChain('asset-hub-westend', registry);
+		const findPolkadot = findRelayChain('asset-hub-polkadot', mockAssetRegistry);
+		const findKusama = findRelayChain('asset-hub-kusama', mockAssetRegistry);
+		const findWestend = findRelayChain('asset-hub-westend', mockAssetRegistry);
 
 		expect(findPolkadot).toEqual('polkadot');
 		expect(findKusama).toEqual('kusama');

--- a/src/registry/parseRegistry.spec.ts
+++ b/src/registry/parseRegistry.spec.ts
@@ -1,21 +1,25 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
-import { parseRegistry } from './parseRegistry';
+import { mockAssetRegistry } from "../testHelpers/mockAssetRegistry";
+import { parseRegistry } from "./parseRegistry";
 
+const injectedRegistry = {
+	injectedRegistry: mockAssetRegistry
+}
 describe('parseRegistry', () => {
-	it('Should return the correct object structure', () => {
-		const registry = parseRegistry({});
+	it('Should return the correct object structure', async () => {
+		const registry = await parseRegistry(injectedRegistry);
 
 		expect(registry.polkadot['0'].tokens).toStrictEqual(['DOT']);
 		expect(registry.kusama['0'].tokens).toStrictEqual(['KSM']);
 		expect(registry.westend['0'].tokens).toStrictEqual(['WND']);
 		expect(registry.rococo['0'].tokens).toStrictEqual(['ROC']);
 	});
-	it('Should correctly overwrite rococos asset-hub specName', () => {
-		const registry = parseRegistry({});
+	it('Should correctly overwrite rococos asset-hub specName', async () => {
+		const registry = await parseRegistry(injectedRegistry);
 		expect(registry.rococo['1000'].specName).toEqual('asset-hub-rococo');
 	});
-	it('Should correctly inject an injectedRegsitry', () => {
+	it('Should correctly inject an injectedRegsitry', async () => {
 		const assetsInfo = {};
 		const foreignAssetsInfo = {};
 		const opts = {
@@ -31,7 +35,7 @@ describe('parseRegistry', () => {
 				},
 			},
 		};
-		const registry = parseRegistry(opts);
+		const registry = await parseRegistry(opts);
 
 		expect(registry.polkadot['9876']).toStrictEqual({
 			tokens: ['TST'],

--- a/src/registry/parseRegistry.spec.ts
+++ b/src/registry/parseRegistry.spec.ts
@@ -1,11 +1,11 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
-import { mockAssetRegistry } from "../testHelpers/mockAssetRegistry";
-import { parseRegistry } from "./parseRegistry";
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
+import { parseRegistry } from './parseRegistry';
 
 const injectedRegistry = {
-	injectedRegistry: mockAssetRegistry
-}
+	injectedRegistry: mockAssetRegistry,
+};
 describe('parseRegistry', () => {
 	it('Should return the correct object structure', async () => {
 		const registry = await parseRegistry(injectedRegistry);

--- a/src/registry/parseRegistry.ts
+++ b/src/registry/parseRegistry.ts
@@ -1,13 +1,15 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
+import fetch from 'node-fetch';
 
 import { ASSET_HUB_CHAIN_ID } from '../consts';
 import type { AssetTransferApiOpts } from '../types';
 import type { ChainInfoRegistry } from './types';
-import fetch from 'node-fetch';
 
 export const parseRegistry = async (assetsOpts: AssetTransferApiOpts): Promise<ChainInfoRegistry> => {
-	const registry = (await (await fetch('https://paritytech.github.io/asset-transfer-api-registry/registry.json')).json()) as ChainInfoRegistry;
+	const registry = (await (
+		await fetch('https://paritytech.github.io/asset-transfer-api-registry/registry.json')
+	).json()) as ChainInfoRegistry;
 
 	if (assetsOpts.injectedRegistry) {
 		const { injectedRegistry } = assetsOpts;

--- a/src/registry/parseRegistry.ts
+++ b/src/registry/parseRegistry.ts
@@ -1,12 +1,14 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
-import registry from '@substrate/asset-transfer-api-registry';
 
 import { ASSET_HUB_CHAIN_ID } from '../consts';
 import type { AssetTransferApiOpts } from '../types';
 import type { ChainInfoRegistry } from './types';
+import fetch from 'node-fetch';
 
-export const parseRegistry = (assetsOpts: AssetTransferApiOpts): ChainInfoRegistry => {
+export const parseRegistry = async (assetsOpts: AssetTransferApiOpts): Promise<ChainInfoRegistry> => {
+	const registry = (await (await fetch('https://paritytech.github.io/asset-transfer-api-registry/registry.json')).json()) as ChainInfoRegistry;
+
 	if (assetsOpts.injectedRegistry) {
 		const { injectedRegistry } = assetsOpts;
 		const polkadot = injectedRegistry.polkadot;
@@ -26,5 +28,5 @@ export const parseRegistry = (assetsOpts: AssetTransferApiOpts): ChainInfoRegist
 	 */
 	registry.rococo[ASSET_HUB_CHAIN_ID].specName = 'asset-hub-rococo';
 
-	return registry as ChainInfoRegistry;
+	return registry;
 };

--- a/src/testHelpers/mockAssetRegistry.ts
+++ b/src/testHelpers/mockAssetRegistry.ts
@@ -1,4154 +1,4075 @@
-import { ChainInfoRegistry } from "../registry/types";
+import { ChainInfoRegistry } from '../registry/types';
 
 export const mockAssetRegistry = {
-    "polkadot": {
-      "0": {
-        "tokens": [
-          "DOT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "polkadot"
-      },
-      "1000": {
-        "tokens": [
-          "DOT"
-        ],
-        "assetsInfo": {
-          "1": "no1",
-          "2": "BTC",
-          "3": "DOT",
-          "4": "EFI",
-          "5": "PLX",
-          "6": "LPHP",
-          "7": "lucky7",
-          "8": "JOE",
-          "9": "PINT",
-          "10": "BEAST",
-          "11": "web3",
-          "12": "USDcp",
-          "15": "Meme",
-          "20": "StabCP",
-          "21": "WBTC",
-          "23": "PINK",
-          "77": "TRQ",
-          "79": "PGOLD",
-          "99": "Cypress",
-          "100": "WETH",
-          "101": "DOTMA",
-          "123": "123",
-          "256": "ICE",
-          "666": "DANGER",
-          "777": "777",
-          "999": "gold",
-          "1000": "BRZ",
-          "1337": "USDC",
-          "1984": "USDt",
-          "862812": "CUBO",
-          "868367": "VSC",
-          "20090103": "BTC"
-        },
-        "foreignAssetsInfo": {
-          "EQ": {
-            "symbol": "EQ",
-            "name": "Equilibrium",
-            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X1\":{\"Parachain\":\"2011\"}}}"
-          },
-          "0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a224b7573616d61227d7d7d": {
-            "symbol": "",
-            "name": "",
-            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Kusama\"}}}"
-          },
-          "EQD": {
-            "symbol": "EQD",
-            "name": "Equilibrium Dollar",
-            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X2\":[{\"Parachain\":\"2011\"},{\"GeneralKey\":{\"length\":\"3\",\"data\":\"0x6571640000000000000000000000000000000000000000000000000000000000\"}}]}}"
-          }
-        },
-        "poolPairsInfo": {},
-        "specName": "statemint"
-      },
-      "1001": {
-        "tokens": [
-          "DOT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "collectives"
-      },
-      "1002": {
-        "tokens": [
-          "DOT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bridge-hub-polkadot"
-      },
-      "2000": {
-        "tokens": [
-          "ACA",
-          "AUSD",
-          "DOT",
-          "LDOT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "acala",
-        "xcAssetsData": [
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "ForeignAsset": "12"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "WETH",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":100}]}}}",
-            "asset": {
-              "ForeignAsset": "6"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "WBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":21}]}}}",
-            "asset": {
-              "ForeignAsset": "5"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "ForeignAsset": "0"
-            }
-          },
-          {
-            "paraID": 2006,
-            "symbol": "ASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
-            "asset": {
-              "ForeignAsset": "2"
-            }
-          },
-          {
-            "paraID": 2008,
-            "symbol": "CRU",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2008}}}}",
-            "asset": {
-              "ForeignAsset": "11"
-            }
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQD",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
-            "asset": {
-              "ForeignAsset": "8"
-            }
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQ",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
-            "asset": {
-              "ForeignAsset": "7"
-            }
-          },
-          {
-            "paraID": 2012,
-            "symbol": "PARA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
-            "asset": {
-              "ForeignAsset": "1"
-            }
-          },
-          {
-            "paraID": 2032,
-            "symbol": "IBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": {
-              "ForeignAsset": "3"
-            }
-          },
-          {
-            "paraID": 2032,
-            "symbol": "INTR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
-            "asset": {
-              "ForeignAsset": "4"
-            }
-          },
-          {
-            "paraID": 2035,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
-            "asset": {
-              "ForeignAsset": "9"
-            }
-          },
-          {
-            "paraID": 2037,
-            "symbol": "UNQ",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2037}}}}",
-            "asset": {
-              "ForeignAsset": "10"
-            }
-          }
-        ]
-      },
-      "2004": {
-        "tokens": [
-          "GLMR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "moonbeam",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "42259045809535163221576417993425387648"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
-            "asset": "166377000701797186346254371275954761085"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "311091173110107856861649819128533077277"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
-            "asset": "225719522181998468294117309041779353812"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "110021739665376159354538090254163045594"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "ACA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
-            "asset": "224821240862170613278369189818311486111"
-          },
-          {
-            "paraID": 2006,
-            "symbol": "ASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
-            "asset": "224077081838586484055667086558292981199"
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQD",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
-            "asset": "187224307232923873519830480073807488153"
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQ",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
-            "asset": "190590555344745888270686124937537713878"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "PARA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
-            "asset": "32615670524745285411807346420584982855"
-          },
-          {
-            "paraID": 2026,
-            "symbol": "NODL",
-            "decimals": 11,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2026},{\"palletInstance\":2}]}}}",
-            "asset": "309163521958167876851250718453738106865"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "FIL",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0804\"}]}}}",
-            "asset": "144012926827374458669278577633504620722"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
-            "asset": "29085784439601774464560083082574142143"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vGLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0901\"}]}}}",
-            "asset": "204507659831918931608354793288110796652"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "165823357460190568952172802245839421906"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vFIL",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0904\"}]}}}",
-            "asset": "272547899416482196831721420898811311297"
-          },
-          {
-            "paraID": 2031,
-            "symbol": "CFG",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "91372035960551235635465443179559840483"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "IBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "120637696315203257380661607956669368914"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "INTR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
-            "asset": "101170542313601871197860408087030232491"
-          },
-          {
-            "paraID": 2034,
-            "symbol": "HDX",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
-            "asset": "69606720909260275826784788104880799692"
-          },
-          {
-            "paraID": 2035,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
-            "asset": "132685552157663328694213725410064821485"
-          },
-          {
-            "paraID": 2043,
-            "symbol": "OTP",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2043},{\"palletInstance\":10}]}}}",
-            "asset": "238111524681612888331172110363070489924"
-          },
-          {
-            "paraID": 2046,
-            "symbol": "RING",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
-            "asset": "125699734534028342599692732320197985871"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "ZTG",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "150874409661081770150564009349448205842"
-          },
-          {
-            "paraID": 2101,
-            "symbol": "SUB",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2101}}}}",
-            "asset": "89994634370519791027168048838578580624"
-          },
-          {
-            "paraID": 2104,
-            "symbol": "MANTA",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2104}}}}",
-            "asset": "166446646689194205559791995948102903873"
-          }
-        ]
-      },
-      "2006": {
-        "tokens": [
-          "ASTR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "astar",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "340282366920938463463374607431768211455"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
-            "asset": "4294969281"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "4294969280"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
-            "asset": "18446744073709551618"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "ACA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
-            "asset": "18446744073709551616"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aSEED",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "18446744073709551617"
-          },
-          {
-            "paraID": 2002,
-            "symbol": "CLV",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2002}}}}",
-            "asset": "18446744073709551625"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": "18446744073709551619"
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQD",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
-            "asset": "18446744073709551629"
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQ",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
-            "asset": "18446744073709551628"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vsDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0403\"}]}}}",
-            "asset": "18446744073709551626"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
-            "asset": "18446744073709551624"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0903\"}]}}}",
-            "asset": "18446744073709551632"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "18446744073709551623"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "IBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "18446744073709551620"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "INTR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
-            "asset": "18446744073709551621"
-          },
-          {
-            "paraID": 2034,
-            "symbol": "HDX",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
-            "asset": "18446744073709551630"
-          },
-          {
-            "paraID": 2035,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
-            "asset": "18446744073709551622"
-          },
-          {
-            "paraID": 2037,
-            "symbol": "UNQ",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2037}}}}",
-            "asset": "18446744073709551631"
-          },
-          {
-            "paraID": 2046,
-            "symbol": "RING",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
-            "asset": "18446744073709551627"
-          }
-        ]
-      },
-      "2007": {
-        "tokens": [
-          "KPX"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "totem-parachain"
-      },
-      "2008": {
-        "tokens": [
-          "CRU"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "polkadot-crust-parachain"
-      },
-      "2011": {
-        "tokens": [
-          "TOKEN"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "Equilibrium-parachain"
-      },
-      "2012": {
-        "tokens": [
-          "PARA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "parallel",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "101"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "102"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
-            "asset": "110"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "ACA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
-            "asset": "108"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "lcDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x040d000000\"}]}}}",
-            "asset": "106"
-          },
-          {
-            "paraID": 2002,
-            "symbol": "CLV",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2002}}}}",
-            "asset": "130"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": "114"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "sDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x73444f54\"}]}}}",
-            "asset": "1001"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "cDOT-7/14",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200070014}]}}}",
-            "asset": "200070014"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "cDOT-8/15",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200080015}]}}}",
-            "asset": "200080015"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "cDOT-10/17",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200100017}]}}}",
-            "asset": "200100017"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "cDOT-6/13",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200060013}]}}}",
-            "asset": "200060013"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "cDOT-9/16",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200090016}]}}}",
-            "asset": "200090016"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "INTR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
-            "asset": "120"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "IBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "122"
-          },
-          {
-            "paraID": 2035,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
-            "asset": "115"
-          }
-        ]
-      },
-      "2013": {
-        "tokens": [
-          "LIT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "litentry-parachain"
-      },
-      "2019": {
-        "tokens": [
-          "LAYR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "composable"
-      },
-      "2026": {
-        "tokens": [
-          "NODL"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "nodle-para"
-      },
-      "2030": {
-        "tokens": [
-          "BNC"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bifrost_polkadot",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": {
-              "Token2": "0"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "Token2": "2"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
-            "asset": {
-              "Token2": "5"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "Token2": "1"
-            }
-          },
-          {
-            "paraID": 2006,
-            "symbol": "ASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
-            "asset": {
-              "Token2": "3"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vGLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0901\"}]}}}",
-            "asset": {
-              "VToken2": "1"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vFIL",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0904\"}]}}}",
-            "asset": {
-              "VToken2": "4"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "FIL",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0804\"}]}}}",
-            "asset": {
-              "Token2": "4"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0903\"}]}}}",
-            "asset": {
-              "VToken2": "3"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
-            "asset": {
-              "VToken2": "0"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vsDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0403\"}]}}}",
-            "asset": {
-              "VSToken2": "0"
-            }
-          },
-          {
-            "paraID": 2032,
-            "symbol": "IBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": {
-              "Token2": "6"
-            }
-          },
-          {
-            "paraID": 2032,
-            "symbol": "INTR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
-            "asset": {
-              "Token2": "7"
-            }
-          },
-          {
-            "paraID": 2104,
-            "symbol": "MANTA",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2104}}}}",
-            "asset": {
-              "Token2": "8"
-            }
-          }
-        ]
-      },
-      "2031": {
-        "tokens": [
-          "CFG"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "centrifuge",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": {
-              "ForeignAsset": "5"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
-            "asset": {
-              "ForeignAsset": "6"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "ForeignAsset": "1"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": {
-              "ForeignAsset": "3"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "ForeignAsset": "4"
-            }
-          },
-          {
-            "paraID": 2031,
-            "symbol": "LpArbUSDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":42161}}},{\"accountKey20\":{\"network\":null,\"key\":\"0xaf88d065e77c8cc2239327c5edb3a432268e5831\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "100,003"
-            }
-          },
-          {
-            "paraID": 2031,
-            "symbol": "CFG",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "Native"
-          },
-          {
-            "paraID": 2031,
-            "symbol": "LpBaseUSDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":8453}}},{\"accountKey20\":{\"network\":null,\"key\":\"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "100,002"
-            }
-          },
-          {
-            "paraID": 2031,
-            "symbol": "LpEthUSDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":1}}},{\"accountKey20\":{\"network\":null,\"key\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "100,001"
-            }
-          },
-          {
-            "paraID": 2031,
-            "symbol": "LpCeloUSDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":42220}}},{\"accountKey20\":{\"network\":null,\"key\":\"0x37f750b7cc259a2f741af45294f6a16572cf5cad\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "100,004"
-            }
-          }
-        ]
-      },
-      "2032": {
-        "tokens": [
-          "INTR",
-          "IBTC",
-          "DOT",
-          "KINT",
-          "KBTC",
-          "KSM"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "interlay-parachain",
-        "xcAssetsData": [
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "ForeignAsset": "2"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
-            "asset": {
-              "ForeignAsset": "1"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": {
-              "ForeignAsset": "11"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "WBNB.wh",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe3b841c3f96e647e6dc01b468d6d0ad3562a9eeb\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "7"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "TBTC.wh",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xecd65e4b89495ae63b4f11ca872a23680a7c419c\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "5"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "USDC.wh",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x931715fee2d06333043d11f658c8ce934ac61d0c\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "8"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "WBTC.wh",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "9"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "ForeignAsset": "10"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "WETH.wh",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xab3f0245b83feb11d15aaffefd7ad465a59817ed\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "6"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "DAI.wh",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x06e605775296e851ff43b4daa541bb0984e9d6fd\"}}]}}}",
-            "asset": {
-              "ForeignAsset": "4"
-            }
-          },
-          {
-            "paraID": 2030,
-            "symbol": "VDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
-            "asset": {
-              "ForeignAsset": "3"
-            }
-          }
-        ]
-      },
-      "2034": {
-        "tokens": [
-          "HDX"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "hydradx",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "5"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
-            "asset": "22"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "10"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce\"}]}}}",
-            "asset": "7"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "DAI",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae\"}]}}}",
-            "asset": "2"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "APE",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02f4c723e61709d90f89939c1852f516e373d418a8\"}]}}}",
-            "asset": "6"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "WBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02c80084af223c8b598536178d9361dc55bfda6818\"}]}}}",
-            "asset": "3"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "WETH",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x025a4d6acdc4e3e5ab15717f407afe957f7a242578\"}]}}}",
-            "asset": "4"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "WETH",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xab3f0245b83feb11d15aaffefd7ad465a59817ed\"}}]}}}",
-            "asset": "20"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "WBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d\"}}]}}}",
-            "asset": "19"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": "16"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x931715fee2d06333043d11f658c8ce934ac61d0c\"}}]}}}",
-            "asset": "21"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "DAI",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x06e605775296e851ff43b4daa541bb0984e9d6fd\"}}]}}}",
-            "asset": "18"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xc30e9ca94cf52f3bf5692aacf81353a27052c46f\"}}]}}}",
-            "asset": "23"
-          },
-          {
-            "paraID": 2006,
-            "symbol": "ASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
-            "asset": "9"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "14"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "vDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
-            "asset": "15"
-          },
-          {
-            "paraID": 2031,
-            "symbol": "CFG",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "13"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "iBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "11"
-          },
-          {
-            "paraID": 2032,
-            "symbol": "INTR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
-            "asset": "17"
-          },
-          {
-            "paraID": 2035,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
-            "asset": "8"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "ZTG",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "12"
-          },
-          {
-            "paraID": 2101,
-            "symbol": "SUB",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2101}}}}",
-            "asset": "24"
-          }
-        ]
-      },
-      "2035": {
-        "tokens": [
-          "PHA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "phala",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "DOT",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "0"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "ACA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
-            "asset": "5"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "AUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "3"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LDOT",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
-            "asset": "4"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "GLMR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
-            "asset": "1"
-          },
-          {
-            "paraID": 2006,
-            "symbol": "ASTR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
-            "asset": "6"
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQ",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
-            "asset": "9"
-          },
-          {
-            "paraID": 2011,
-            "symbol": "EQD",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
-            "asset": "10"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "PARA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
-            "asset": "2"
-          },
-          {
-            "paraID": 2030,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "8"
-          },
-          {
-            "paraID": 2034,
-            "symbol": "HDX",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
-            "asset": "11"
-          },
-          {
-            "paraID": 2046,
-            "symbol": "RING",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
-            "asset": "7"
-          }
-        ]
-      },
-      "2037": {
-        "tokens": [
-          "UNQ"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "unique"
-      },
-      "2039": {
-        "tokens": [
-          "TEER"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "integritee-parachain"
-      },
-      "2043": {
-        "tokens": [
-          "OTP"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "origintrail-parachain",
-        "xcAssetsData": [
-          {
-            "paraID": 2043,
-            "symbol": "TRAC",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2043},{\"generalIndex\":1}]}}}",
-            "asset": "1"
-          }
-        ]
-      },
-      "2046": {
-        "tokens": [
-          "RING"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "Darwinia2"
-      },
-      "2048": {
-        "tokens": [
-          "BBB"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bitgreen-parachain"
-      },
-      "2051": {
-        "tokens": [
-          "AJUN"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "ajuna"
-      },
-      "2056": {
-        "tokens": [
-          "AVT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "avn-parachain"
-      },
-      "2086": {
-        "tokens": [
-          "KILT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "kilt-spiritnet"
-      },
-      "2091": {
-        "tokens": [
-          "FRQCY"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "frequency"
-      },
-      "2092": {
-        "tokens": [
-          "ZTG"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "zeitgeist"
-      },
-      "2093": {
-        "tokens": [
-          "HASH"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "luhn"
-      },
-      "2094": {
-        "tokens": [
-          "PEN"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "pendulum"
-      },
-      "2101": {
-        "tokens": [
-          "SUB"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "subsocial-parachain"
-      },
-      "2104": {
-        "tokens": [
-          "MANTA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "manta"
-      },
-      "3333": {
-        "tokens": [
-          "TRN"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "t3rn"
-      }
-    },
-    "kusama": {
-      "0": {
-        "tokens": [
-          "KSM"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "kusama"
-      },
-      "1000": {
-        "tokens": [
-          "KSM"
-        ],
-        "assetsInfo": {
-          "0": "DOG",
-          "1": "L T",
-          "2": "PNN",
-          "3": "Meow",
-          "4": "HAPPY",
-          "5": "BEER",
-          "6": "ZKPD",
-          "7": "DOS",
-          "8": "RMRK",
-          "9": "TOT",
-          "10": "USDC",
-          "11": "USDT",
-          "12": "BUSD",
-          "13": "LN",
-          "14": "DOT",
-          "15": "Web3",
-          "16": "ARIS",
-          "17": "MEME",
-          "18": "HEI",
-          "19": "SHOT",
-          "20": "BFKK",
-          "21": "ELEV",
-          "22": "STH",
-          "23": "KOJO",
-          "24": "test",
-          "25": "BABE",
-          "26": "BUNGA",
-          "27": "RUNE",
-          "28": "LAC",
-          "29": "CODES",
-          "30": "GOL",
-          "31": "ki",
-          "32": "FAV",
-          "33": "BUSSY",
-          "34": "PLX",
-          "35": "LUCKY",
-          "36": "RRT",
-          "37": "MNCH",
-          "38": "ENT",
-          "39": "DSCAN",
-          "40": "ERIC",
-          "41": "GOOSE",
-          "42": "NRNF",
-          "43": "TTT",
-          "44": "ADVNCE",
-          "45": "CRIB",
-          "46": "FAN",
-          "47": "EUR",
-          "49": "DIAN",
-          "50": "PROMO",
-          "55": "MTS",
-          "60": "GAV",
-          "61": "CRY",
-          "64": "oh!",
-          "66": "DAI",
-          "68": "ADVERT",
-          "69": "NICE",
-          "70": "MAR",
-          "71": "OAK",
-          "75": "cipher",
-          "77": "Crypto",
-          "87": "XEXR",
-          "88": "BTC",
-          "90": "SATS",
-          "91": "TMJ",
-          "99": "BITCOIN",
-          "100": "Chralt",
-          "101": "---",
-          "102": "DRX",
-          "111": "NO1",
-          "117": "TNKR",
-          "123": "NFT",
-          "138": "Abc",
-          "168": "Tokens",
-          "188": "ZLK",
-          "200": "SIX",
-          "214": "LOVE",
-          "222": "PNEO",
-          "223": "BILL",
-          "224": "SIK",
-          "300": "PWS",
-          "333": "Token",
-          "345": "345",
-          "360": "uni",
-          "365": "time",
-          "374": "wETH",
-          "377": "KAA",
-          "383": "KODA",
-          "404": "MAXI",
-          "420": "BLAZE",
-          "520": "0xe299a5e299a5e299a5",
-          "555": "GAME",
-          "567": "CHRWNA",
-          "569": "KUSA",
-          "598": "EREN",
-          "666": "BAD",
-          "677": "GRB",
-          "759": "bLd",
-          "777": "GOD",
-          "813": "TBUX",
-          "841": "YAYOI",
-          "888": "LUCK",
-          "911": "911",
-          "969": "WGTL",
-          "999": "CBDC",
-          "1000": "SPARK",
-          "1107": "HOLIC",
-          "1111": "MTVD",
-          "1123": "XEN",
-          "1155": "WITEK",
-          "1225": "GOD",
-          "1234": "KSM",
-          "1313": "TACP",
-          "1337": "TIP",
-          "1420": "HYDR",
-          "1441": "SPOT",
-          "1526": "bcd",
-          "1607": "STRGZN",
-          "1688": "ali",
-          "1984": "USDt",
-          "1999": "ADVERT2",
-          "2021": "WAVE",
-          "2048": "RWS",
-          "2049": "Android",
-          "2050": "CUT",
-          "2077": "XRT",
-          "3000": "GRAIN",
-          "3001": "DUCK",
-          "3077": "ACT",
-          "3721": "fast",
-          "3943": "GMK",
-          "6789": "VHM",
-          "6967": "CHAOS",
-          "7777": "lucky7",
-          "8848": "top",
-          "9000": "KPOTS",
-          "9999": "BTC",
-          "11111": "KVC",
-          "12345": "DREX",
-          "19840": "USDt",
-          "42069": "INTRN",
-          "69420": "CHAOS",
-          "80815": "KSMFS",
-          "80816": "RUEPP",
-          "80817": "FRALEY",
-          "88888": "BAILEGO",
-          "95834": "LUL",
-          "220204": "STM",
-          "314159": "RTT",
-          "777777": "DEFI",
-          "862812": "CUBO",
-          "863012": "VCOP",
-          "4206969": "SHIB",
-          "5201314": "belove",
-          "5797867": "TAKE",
-          "7777777": "king",
-          "4294967291": "PRIME"
-        },
-        "foreignAssetsInfo": {
-          "0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a22506f6c6b61646f74227d7d7d": {
-            "symbol": "",
-            "name": "",
-            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}"
-          },
-          "TNKR": {
-            "symbol": "TNKR",
-            "name": "Tinkernet",
-            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X2\":[{\"Parachain\":\"2125\"},{\"GeneralIndex\":\"0\"}]}}"
-          }
-        },
-        "poolPairsInfo": {
-          "0": {
-            "lpToken": "0",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"5797867\"}]}}]]"
-          },
-          "1": {
-            "lpToken": "1",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1984\"}]}}]]"
-          },
-          "2": {
-            "lpToken": "2",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1313\"}]}}]]"
-          }
-        },
-        "specName": "statemine"
-      },
-      "1001": {
-        "tokens": [
-          "KSM"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "encointer-parachain"
-      },
-      "1002": {
-        "tokens": [
-          "KSM"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bridge-hub-kusama"
-      },
-      "2000": {
-        "tokens": [
-          "KAR",
-          "KUSD",
-          "KSM",
-          "LKSM",
-          "BNC",
-          "VSKSM",
-          "PHA",
-          "KINT",
-          "KBTC",
-          "TAI"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "karura",
-        "xcAssetsData": [
-          {
-            "paraID": 1000,
-            "symbol": "RMRK",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
-            "asset": {
-              "ForeignAsset": "0"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "ForeignAsset": "7"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "ARIS",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":16}]}}}",
-            "asset": {
-              "ForeignAsset": "1"
-            }
-          },
-          {
-            "paraID": 2007,
-            "symbol": "SDN",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
-            "asset": {
-              "ForeignAsset": "18"
-            }
-          },
-          {
-            "paraID": 2012,
-            "symbol": "CSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
-            "asset": {
-              "ForeignAsset": "5"
-            }
-          },
-          {
-            "paraID": 2015,
-            "symbol": "TEER",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2015},{\"generalKey\":\"0x54454552\"}]}}}",
-            "asset": {
-              "ForeignAsset": "8"
-            }
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "ForeignAsset": "3"
-            }
-          },
-          {
-            "paraID": 2024,
-            "symbol": "GENS",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2024}}}}",
-            "asset": {
-              "ForeignAsset": "14"
-            }
-          },
-          {
-            "paraID": 2024,
-            "symbol": "EQD",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2024},{\"generalKey\":\"0x657164\"}]}}}",
-            "asset": {
-              "ForeignAsset": "15"
-            }
-          },
-          {
-            "paraID": 2084,
-            "symbol": "KMA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
-            "asset": {
-              "ForeignAsset": "10"
-            }
-          },
-          {
-            "paraID": 2085,
-            "symbol": "HKO",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
-            "asset": {
-              "ForeignAsset": "4"
-            }
-          },
-          {
-            "paraID": 2088,
-            "symbol": "AIR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2088},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": {
-              "ForeignAsset": "12"
-            }
-          },
-          {
-            "paraID": 2090,
-            "symbol": "BSX",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalIndex\":0}]}}}",
-            "asset": {
-              "ForeignAsset": "11"
-            }
-          },
-          {
-            "paraID": 2095,
-            "symbol": "QTZ",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2095}}}}",
-            "asset": {
-              "ForeignAsset": "2"
-            }
-          },
-          {
-            "paraID": 2096,
-            "symbol": "NEER",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
-            "asset": {
-              "ForeignAsset": "9"
-            }
-          },
-          {
-            "paraID": 2102,
-            "symbol": "PCHU",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2102},{\"generalKey\":\"0x50434855\"}]}}}",
-            "asset": {
-              "ForeignAsset": "17"
-            }
-          },
-          {
-            "paraID": 2105,
-            "symbol": "CRAB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
-            "asset": {
-              "ForeignAsset": "13"
-            }
-          },
-          {
-            "paraID": 2106,
-            "symbol": "LIT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2106},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "ForeignAsset": "20"
-            }
-          },
-          {
-            "paraID": 2107,
-            "symbol": "KICO",
-            "decimals": 14,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2107},{\"generalKey\":\"0x4b49434f\"}]}}}",
-            "asset": {
-              "ForeignAsset": "6"
-            }
-          },
-          {
-            "paraID": 2114,
-            "symbol": "TUR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
-            "asset": {
-              "ForeignAsset": "16"
-            }
-          },
-          {
-            "paraID": 2118,
-            "symbol": "LT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2118},{\"generalKey\":\"0x4c54\"}]}}}",
-            "asset": {
-              "ForeignAsset": "19"
-            }
-          }
-        ]
-      },
-      "2001": {
-        "tokens": [
-          "BNC",
-          "KUSD",
-          "DOT",
-          "KSM",
-          "KAR",
-          "ZLK",
-          "PHA",
-          "RMRK",
-          "MOVR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bifrost",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": {
-              "Token": "KSM"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "RMRK",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
-            "asset": {
-              "Token": "RMRK"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "Token2": "0"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": {
-              "Stable": "KUSD"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": {
-              "Token": "KAR"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vBNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
-            "asset": {
-              "VToken": "BNC"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vMOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x010a\"}]}}}",
-            "asset": {
-              "VToken": "MOVR"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
-            "asset": {
-              "VToken": "KSM"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "ZLK",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
-            "asset": {
-              "Token": "ZLK"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "VSvsKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
-            "asset": {
-              "VSToken": "KSM"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": {
-              "Native": "BNC"
-            }
-          },
-          {
-            "paraID": 2004,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
-            "asset": {
-              "Token": "PHA"
-            }
-          },
-          {
-            "paraID": 2007,
-            "symbol": "SDN",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
-            "asset": {
-              "Token2": "3"
-            }
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "Token": "MOVR"
-            }
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
-            "asset": {
-              "Token2": "2"
-            }
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KINT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
-            "asset": {
-              "Token2": "1"
-            }
-          },
-          {
-            "paraID": 2110,
-            "symbol": "MGX",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2110},{\"generalKey\":\"0x00000000\"}]}}}",
-            "asset": {
-              "Token2": "4"
-            }
-          }
-        ]
-      },
-      "2004": {
-        "tokens": [
-          "PHA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "khala",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "0"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "1"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "4"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "2"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "ZLK",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
-            "asset": "3"
-          },
-          {
-            "paraID": 2007,
-            "symbol": "SDN",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
-            "asset": "12"
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": "6"
-          },
-          {
-            "paraID": 2084,
-            "symbol": "KMA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
-            "asset": "8"
-          },
-          {
-            "paraID": 2085,
-            "symbol": "HKO",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
-            "asset": "7"
-          },
-          {
-            "paraID": 2087,
-            "symbol": "PICA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2087}}}}",
-            "asset": "15"
-          },
-          {
-            "paraID": 2090,
-            "symbol": "BSX",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalKey\":\"0x00000000\"}]}}}",
-            "asset": "5"
-          },
-          {
-            "paraID": 2090,
-            "symbol": "BSX",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalIndex\":0}]}}}",
-            "asset": "9"
-          },
-          {
-            "paraID": 2096,
-            "symbol": "NEER",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
-            "asset": "13"
-          },
-          {
-            "paraID": 2096,
-            "symbol": "BIT",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x020000000000000000\"}]}}}",
-            "asset": "14"
-          },
-          {
-            "paraID": 2105,
-            "symbol": "CRAB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
-            "asset": "11"
-          },
-          {
-            "paraID": 2114,
-            "symbol": "TUR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
-            "asset": "10"
-          }
-        ]
-      },
-      "2007": {
-        "tokens": [
-          "SDN"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "shiden",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "340282366920938463463374607431768211455"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "4294969280"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "18446744073709551618"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
-            "asset": "18446744073709551619"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aSEED",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "18446744073709551616"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "18446744073709551627"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vsKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
-            "asset": "18446744073709551629"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
-            "asset": "18446744073709551628"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
-            "asset": "18446744073709551623"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "CSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
-            "asset": "18446744073709551624"
-          },
-          {
-            "paraID": 2016,
-            "symbol": "SKU",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2016}}}}",
-            "asset": "18446744073709551626"
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": "18446744073709551620"
-          },
-          {
-            "paraID": 2024,
-            "symbol": "GENS",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2024}}}}",
-            "asset": "18446744073709551630"
-          },
-          {
-            "paraID": 2024,
-            "symbol": "EQD",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2024},{\"generalKey\":\"0x657164\"}]}}}",
-            "asset": "18446744073709551631"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
-            "asset": "18446744073709551621"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KINT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
-            "asset": "18446744073709551622"
-          },
-          {
-            "paraID": 2095,
-            "symbol": "QTZ",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2095}}}}",
-            "asset": "18446744073709551633"
-          },
-          {
-            "paraID": 2096,
-            "symbol": "NEER",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
-            "asset": "18446744073709551632"
-          },
-          {
-            "paraID": 2105,
-            "symbol": "CRAB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
-            "asset": "18446744073709551625"
-          }
-        ]
-      },
-      "2011": {
-        "tokens": [],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "sora_ksm"
-      },
-      "2012": {
-        "tokens": [
-          "CSM"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "crust-collator",
-        "xcAssetsData": [
-          {
-            "paraID": 2000,
-            "symbol": "AUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "214920334981412447805621250067209749032"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "10810581592933651521121702237638664357"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "319623561105283008236062145480775032445"
-          },
-          {
-            "paraID": 2007,
-            "symbol": "SDN",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
-            "asset": "16797826370226091782818345603793389938"
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": "232263652204149413431520870009560565298"
-          },
-          {
-            "paraID": 2048,
-            "symbol": "XRT",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
-            "asset": "108036400430056508975016746969135344601"
-          },
-          {
-            "paraID": 2105,
-            "symbol": "CRAB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
-            "asset": "173481220575862801646329923366065693029"
-          }
-        ]
-      },
-      "2015": {
-        "tokens": [
-          "TEER"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "integritee-parachain"
-      },
-      "2023": {
-        "tokens": [
-          "MOVR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "moonriver",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "42259045809535163221576417993425387648"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "311091173110107856861649819128533077277"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "RMRK",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
-            "asset": "182365888117048807484804376330534607370"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aSeed",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "214920334981412447805621250067209749032"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "10810581592933651521121702237638664357"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
-            "asset": "264344629840762281112027368930249420542"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vBNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
-            "asset": "72145018963825376852137222787619937732"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vMOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x010a\"}]}}}",
-            "asset": "203223821023327994093278529517083736593"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "319623561105283008236062145480775032445"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
-            "asset": "189307976387032586987344677431204943363"
-          },
-          {
-            "paraID": 2007,
-            "symbol": "SDN",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
-            "asset": "16797826370226091782818345603793389938"
-          },
-          {
-            "paraID": 2012,
-            "symbol": "CSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
-            "asset": "108457044225666871745333730479173774551"
-          },
-          {
-            "paraID": 2015,
-            "symbol": "TEER",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2015},{\"generalKey\":\"0x54454552\"}]}}}",
-            "asset": "105075627293246237499203909093923548958"
-          },
-          {
-            "paraID": 2048,
-            "symbol": "XRT",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
-            "asset": "108036400430056508975016746969135344601"
-          },
-          {
-            "paraID": 2084,
-            "symbol": "KMA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
-            "asset": "213357169630950964874127107356898319277"
-          },
-          {
-            "paraID": 2085,
-            "symbol": "HKO",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
-            "asset": "76100021443485661246318545281171740067"
-          },
-          {
-            "paraID": 2087,
-            "symbol": "PICA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2087}}}}",
-            "asset": "167283995827706324502761431814209211090"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
-            "asset": "328179947973504579459046439826496046832"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KINT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
-            "asset": "175400718394635817552109270754364440562"
-          },
-          {
-            "paraID": 2105,
-            "symbol": "CRAB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
-            "asset": "173481220575862801646329923366065693029"
-          },
-          {
-            "paraID": 2106,
-            "symbol": "LIT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2106},{\"palletInstance\":10}]}}}",
-            "asset": "65216491554813189869575508812319036608"
-          },
-          {
-            "paraID": 2110,
-            "symbol": "MGX",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2110},{\"generalKey\":\"0x00000000\"}]}}}",
-            "asset": "118095707745084482624853002839493125353"
-          },
-          {
-            "paraID": 2114,
-            "symbol": "TUR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
-            "asset": "133300872918374599700079037156071917454"
-          }
-        ]
-      },
-      "2024": {
-        "tokens": [
-          "Unknown",
-          "EQD",
-          "GENS",
-          "ETH",
-          "BTC",
-          "KSM",
-          "CRV"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "Gens-parachain"
-      },
-      "2048": {
-        "tokens": [
-          "XRT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "robonomics"
-      },
-      "2084": {
-        "tokens": [
-          "KMA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "calamari",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "12"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "14"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "BNB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02e278651e8ff8e2efa83d7f84205084ebc90688be\"}]}}}",
-            "asset": "21"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "WBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f\"}]}}}",
-            "asset": "26"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "USDC",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27\"}]}}}",
-            "asset": "16"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "BUSD",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02577f6a0718a468e8a995f6075f2325f86a07c83b\"}]}}}",
-            "asset": "23"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "AUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "9"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LDO",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02b4ce1f6109854243d1af13b8ea34ed28542f31e0\"}]}}}",
-            "asset": "18"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "MATIC",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e\"}]}}}",
-            "asset": "20"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "8"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
-            "asset": "10"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "ARB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02c621abc3afa3f24886ea278fffa7e10e8969d755\"}]}}}",
-            "asset": "17"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "APE",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0230b1f4ba0b07789be9986fa090a57e0fe5631ebb\"}]}}}",
-            "asset": "25"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "UNI",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0277cf14f938cb97308d752647d554439d99b39a3f\"}]}}}",
-            "asset": "22"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LINK",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x022c7de70b32cf5f20e02329a88d2e3b00ef85eb90\"}]}}}",
-            "asset": "24"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "SHIB",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x029759ca009cbcd75a84786ac19bb5d02f8e68bcd9\"}]}}}",
-            "asset": "19"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "WETH",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02ece0cc38021e734bef1d5da071b027ac2f71181f\"}]}}}",
-            "asset": "27"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "DAI",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71\"}]}}}",
-            "asset": "15"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
-            "asset": "13"
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": "11"
-          }
-        ]
-      },
-      "2085": {
-        "tokens": [
-          "HKO"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "heiko",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "100"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "102"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
-            "asset": "109"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "107"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
-            "asset": "115"
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": "113"
-          },
-          {
-            "paraID": 2085,
-            "symbol": "sKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2085},{\"palletInstance\":6},{\"generalIndex\":1000}]}}}",
-            "asset": "1000"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
-            "asset": "121"
-          },
-          {
-            "paraID": 2092,
-            "symbol": "KINT",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
-            "asset": "119"
-          }
-        ]
-      },
-      "2087": {
-        "tokens": [
-          "PICA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "picasso"
-      },
-      "2088": {
-        "tokens": [
-          "AIR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "altair",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": {
-              "ForeignAsset": "3"
-            }
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "ForeignAsset": "1"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": {
-              "ForeignAsset": "2"
-            }
-          },
-          {
-            "paraID": 2088,
-            "symbol": "AIR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2088},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "Native"
-          }
-        ]
-      },
-      "2090": {
-        "tokens": [
-          "BSX"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "basilisk",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "1"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "14"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "DAI",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71\"}]}}}",
-            "asset": "13"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "USDCet",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27\"}]}}}",
-            "asset": "9"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "aUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "2"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "wETH",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02ece0cc38021e734bef1d5da071b027ac2f71181f\"}]}}}",
-            "asset": "10"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "wBTC",
-            "decimals": 8,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f\"}]}}}",
-            "asset": "11"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "wUSDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0254e183e533fd3c6e72debb2d1cab451d017faf72\"}]}}}",
-            "asset": "12"
-          },
-          {
-            "paraID": 2048,
-            "symbol": "XRT",
-            "decimals": 9,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
-            "asset": "16"
-          },
-          {
-            "paraID": 2125,
-            "symbol": "TNKR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2125},{\"generalIndex\":0}]}}}",
-            "asset": "6"
-          }
-        ]
-      },
-      "2092": {
-        "tokens": [
-          "KINT",
-          "KBTC",
-          "KSM",
-          "INTR",
-          "IBTC",
-          "DOT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "kintsugi-parachain",
-        "xcAssetsData": [
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": {
-              "ForeignAsset": "3"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "AUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": {
-              "ForeignAsset": "1"
-            }
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
-            "asset": {
-              "ForeignAsset": "2"
-            }
-          },
-          {
-            "paraID": 2001,
-            "symbol": "VKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
-            "asset": {
-              "ForeignAsset": "5"
-            }
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": {
-              "ForeignAsset": "4"
-            }
-          },
-          {
-            "paraID": 2085,
-            "symbol": "SKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2085},{\"palletInstance\":6},{\"generalIndex\":1000}]}}}",
-            "asset": {
-              "ForeignAsset": "6"
-            }
-          }
-        ]
-      },
-      "2095": {
-        "tokens": [
-          "QTZ"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "quartz"
-      },
-      "2105": {
-        "tokens": [
-          "CRAB"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "Crab2"
-      },
-      "2106": {
-        "tokens": [
-          "LIT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "litmus-parachain"
-      },
-      "2110": {
-        "tokens": [
-          "MGX"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "mangata-parachain",
-        "xcAssetsData": [
-          {
-            "paraID": 1000,
-            "symbol": "USDT",
-            "decimals": 6,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
-            "asset": "30"
-          },
-          {
-            "paraID": 1000,
-            "symbol": "RMRK",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
-            "asset": "31"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "BNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
-            "asset": "14"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vBNC",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
-            "asset": "23"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
-            "asset": "15"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "ZLK",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
-            "asset": "26"
-          },
-          {
-            "paraID": 2001,
-            "symbol": "vsKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
-            "asset": "16"
-          },
-          {
-            "paraID": 2114,
-            "symbol": "TUR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
-            "asset": "7"
-          },
-          {
-            "paraID": 2121,
-            "symbol": "IMBU",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2121},{\"generalKey\":\"0x0096\"}]}}}",
-            "asset": "11"
-          }
-        ]
-      },
-      "2113": {
-        "tokens": [
-          "KAB"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "kabocha-parachain"
-      },
-      "2114": {
-        "tokens": [
-          "TUR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "turing",
-        "xcAssetsData": [
-          {
-            "paraID": 0,
-            "symbol": "KSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
-            "asset": "1"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "AUSD",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
-            "asset": "2"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "KAR",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
-            "asset": "3"
-          },
-          {
-            "paraID": 2000,
-            "symbol": "LKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
-            "asset": "4"
-          },
-          {
-            "paraID": 2004,
-            "symbol": "PHA",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
-            "asset": "7"
-          },
-          {
-            "paraID": 2007,
-            "symbol": "SDN",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
-            "asset": "8"
-          },
-          {
-            "paraID": 2023,
-            "symbol": "MOVR",
-            "decimals": 18,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
-            "asset": "9"
-          },
-          {
-            "paraID": 2085,
-            "symbol": "HKO",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
-            "asset": "5"
-          },
-          {
-            "symbol": "TUR",
-            "decimals": 10,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
-            "asset": "0"
-          },
-          {
-            "paraID": 2085,
-            "symbol": "SKSM",
-            "decimals": 12,
-            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x734b534d\"}]}}}",
-            "asset": "6"
-          }
-        ]
-      },
-      "2119": {
-        "tokens": [
-          "BAJU"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bajun"
-      },
-      "2124": {
-        "tokens": [
-          "AMPE"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "amplitude"
-      },
-      "2222": {
-        "tokens": [
-          "MITO"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "ipci"
-      },
-      "2236": {
-        "tokens": [
-          "ZERO",
-          "PLAY",
-          "GAME",
-          "DOT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "subzero"
-      },
-      "2241": {
-        "tokens": [
-          "KREST"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "peaq-node-krest"
-      }
-    },
-    "westend": {
-      "0": {
-        "tokens": [
-          "WND"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "westend"
-      },
-      "1000": {
-        "tokens": [
-          "WND"
-        ],
-        "assetsInfo": {
-          "0": "OSNT",
-          "1": "CHV TKN",
-          "2": "BIB",
-          "3": "(null)",
-          "4": "0xe282b5414c",
-          "5": "MLK",
-          "6": "BILL",
-          "7": "XAU",
-          "8": "JOE",
-          "9": "xxx",
-          "10": "CAT",
-          "11": "SWD",
-          "13": "RMRK",
-          "14": "NGNC",
-          "15": "JJS",
-          "16": "TEST",
-          "17": "LOL",
-          "19": "TMJ",
-          "20": "WETH",
-          "21": "BETH",
-          "22": "KO",
-          "23": "UDT",
-          "24": "AAA",
-          "25": "BTC",
-          "26": "Tsst",
-          "27": "AMIR",
-          "28": "NSS",
-          "30": "TRTI",
-          "31": "GTT",
-          "32": "TRTO",
-          "42": "HG2G",
-          "46": "RASTA",
-          "47": "MRT",
-          "49": "RAN",
-          "51": "kule",
-          "52": "kule1",
-          "55": "PER",
-          "60": "AAA",
-          "66": "USDT",
-          "67": "USDT",
-          "68": "TTT",
-          "69": "TIDE",
-          "77": "MVP1",
-          "81": "SIRI",
-          "84": "ASTRA",
-          "85": "ITC",
-          "88": "AEC",
-          "91": "stt",
-          "95": "HACK",
-          "99": "hcc",
-          "100": "tlj",
-          "101": "WIL",
-          "102": "cPHP",
-          "103": "cPHP",
-          "104": "NewT",
-          "109": "assetT",
-          "121": "TAL",
-          "122": "TESTC",
-          "123": "INXTSW1",
-          "126": "TAT",
-          "145": "dsu",
-          "146": "FRAC",
-          "168": "NIK",
-          "200": "CRT",
-          "222": "BBB",
-          "223": "BILL",
-          "233": "NTT",
-          "301": "RYUD",
-          "318": "SAT",
-          "368": "KLING",
-          "369": "WIN",
-          "370": "SUM",
-          "381": "ALC",
-          "404": "JET",
-          "420": "SKER",
-          "434": "cool",
-          "482": "PVSE",
-          "535": "KEL",
-          "666": "FTT",
-          "676": "nbnbnbn",
-          "777": "JJD",
-          "887": "TTA",
-          "900": "VOD",
-          "950": "HBCOIN",
-          "987": "JVT",
-          "988": "VTT",
-          "999": "CCW",
-          "1000": "EDU",
-          "1001": "VOW",
-          "1002": "VOW",
-          "1003": "VOW",
-          "1004": "VOW",
-          "1005": "VOW",
-          "1010": "POL",
-          "1021": "NFT",
-          "1022": "nfttst",
-          "1023": "qqnihao",
-          "1024": "qqnihao",
-          "1111": "TESTY",
-          "1113": "JTT",
-          "1114": "USDC",
-          "1122": "dmd",
-          "1233": "QTY",
-          "1234": "TEST",
-          "1309": "KLO",
-          "1312": "NG1312",
-          "1337": "NACHO",
-          "1977": "SQL",
-          "1984": "USDTT",
-          "1988": "HBB",
-          "1994": "SOU",
-          "1995": "LUSD",
-          "2000": "USDT",
-          "2022": "weUSDT",
-          "2023": "DEC",
-          "2048": "CUT",
-          "2122": "SVE",
-          "2131": "Wnd",
-          "2511": "TTY",
-          "3000": "DEV",
-          "4000": "DES",
-          "4123": "DWND2",
-          "4200": "KLM",
-          "6666": "BOB",
-          "8888": "USDT",
-          "8937": "test",
-          "9898": "FTT",
-          "9999": "WND",
-          "10111": "ETH",
-          "12344": "tst",
-          "12345": "DRR2",
-          "13122": "NKL",
-          "13337": "DEV",
-          "15240": "KOKOS",
-          "22061": "RSD",
-          "22062": "BAM",
-          "22063": "PIVO",
-          "22064": "DKT",
-          "31337": "USDC",
-          "54221": "wTEST",
-          "61337": "USDC",
-          "100112": "FLK",
-          "100500": "KEKPEK",
-          "123456": "BATTY",
-          "313370": "WBTC",
-          "313371": "WETH",
-          "321123": "aWNDb",
-          "420420": "KLM2",
-          "793910": "CIDR",
-          "862105": "USDTT",
-          "862812": "CUBOT",
-          "863012": "VCOPT",
-          "1000000": "USDT_B",
-          "19801204": "KHT",
-          "21000000": "PKTB",
-          "21000001": "PKCR",
-          "40000001": "ETH",
-          "123456789": "PUSH",
-          "900990087": "SPOT",
-          "1000000000": "CZX",
-          "1233344433": "BQE",
-          "2000000000": "weUSDT",
-          "3999999999": "BETH",
-          "4000000000": "dde"
-        },
-        "foreignAssetsInfo": {
-          "0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a22506f6c6b61646f74227d7d7d": {
-            "symbol": "",
-            "name": "",
-            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}"
-          },
-          "ROC": {
-            "symbol": "ROC",
-            "name": "Rococo",
-            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Rococo\"}}}"
-          }
-        },
-        "poolPairsInfo": {
-          "0": {
-            "lpToken": "0",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1977\"}]}}]]"
-          },
-          "1": {
-            "lpToken": "1",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"8\"}]}}]]"
-          },
-          "2": {
-            "lpToken": "2",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1114\"}]}}]]"
-          },
-          "3": {
-            "lpToken": "3",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"19801204\"}]}}]]"
-          },
-          "4": {
-            "lpToken": "4",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"2511\"}]}}]]"
-          },
-          "5": {
-            "lpToken": "5",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}]]"
-          },
-          "6": {
-            "lpToken": "6",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"45\"}]}}]]"
-          },
-          "7": {
-            "lpToken": "7",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"4200\"}]}}]]"
-          },
-          "8": {
-            "lpToken": "8",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"32\"}]}}]]"
-          },
-          "9": {
-            "lpToken": "9",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"30\"}]}}]]"
-          },
-          "10": {
-            "lpToken": "10",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"46\"}]}}]]"
-          },
-          "11": {
-            "lpToken": "11",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1\"}]}}]]"
-          },
-          "12": {
-            "lpToken": "12",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"47\"}]}}]]"
-          },
-          "13": {
-            "lpToken": "13",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1312\"}]}}]]"
-          },
-          "14": {
-            "lpToken": "14",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1233\"}]}}]]"
-          },
-          "15": {
-            "lpToken": "15",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"13122\"}]}}]]"
-          },
-          "16": {
-            "lpToken": "16",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"48\"}]}}]]"
-          },
-          "17": {
-            "lpToken": "17",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"49\"}]}}]]"
-          },
-          "18": {
-            "lpToken": "18",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"10111\"}]}}]]"
-          },
-          "19": {
-            "lpToken": "19",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"91\"}]}}]]"
-          },
-          "20": {
-            "lpToken": "20",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"26\"}]}}]]"
-          },
-          "21": {
-            "lpToken": "21",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"28\"}]}}]]"
-          },
-          "22": {
-            "lpToken": "22",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"51\"}]}}]]"
-          },
-          "23": {
-            "lpToken": "23",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1309\"}]}}]]"
-          },
-          "24": {
-            "lpToken": "24",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"122\"}]}}]]"
-          },
-          "25": {
-            "lpToken": "25",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"31\"}]}}]]"
-          },
-          "26": {
-            "lpToken": "26",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"77\"}]}}]]"
-          },
-          "27": {
-            "lpToken": "27",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"381\"}]}}]]"
-          },
-          "28": {
-            "lpToken": "28",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"81\"}]}}]]"
-          },
-          "29": {
-            "lpToken": "29",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"104\"}]}}]]"
-          },
-          "30": {
-            "lpToken": "30",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"121\"}]}}]]"
-          },
-          "31": {
-            "lpToken": "31",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1113\"}]}}]]"
-          },
-          "32": {
-            "lpToken": "32",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"50\"}]}}]]"
-          },
-          "33": {
-            "lpToken": "33",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"777\"}]}}]]"
-          },
-          "34": {
-            "lpToken": "34",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"887\"}]}}]]"
-          },
-          "35": {
-            "lpToken": "35",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"318\"}]}}]]"
-          },
-          "36": {
-            "lpToken": "36",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"120\"}]}}]]"
-          },
-          "37": {
-            "lpToken": "37",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"369\"}]}}]]"
-          },
-          "38": {
-            "lpToken": "38",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"368\"}]}}]]"
-          },
-          "39": {
-            "lpToken": "39",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"370\"}]}}]]"
-          },
-          "40": {
-            "lpToken": "40",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22061\"}]}}]]"
-          },
-          "41": {
-            "lpToken": "41",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22062\"}]}}]]"
-          },
-          "42": {
-            "lpToken": "42",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22064\"}]}}]]"
-          }
-        },
-        "specName": "westmint"
-      },
-      "1001": {
-        "tokens": [
-          "WND"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "collectives"
-      }
-    },
-    "rococo": {
-      "0": {
-        "tokens": [
-          "ROC"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "rococo"
-      },
-      "1000": {
-        "tokens": [
-          "ROC"
-        ],
-        "assetsInfo": {
-          "1": "QQ22",
-          "2": "DDTA",
-          "3": "NGNC",
-          "4": "RMRK",
-          "5": "TROC",
-          "6": "XTS",
-          "7": "CTS",
-          "8": "TCS",
-          "9": "CCoin",
-          "10": "RTST",
-          "11": "SVI",
-          "12": "TST",
-          "13": "dtc",
-          "14": "TTT",
-          "15": "RAT",
-          "16": "LVTAST",
-          "17": "MEW",
-          "18": "HEHE",
-          "19": "ITC",
-          "20": "ICC",
-          "21": "TT21",
-          "22": "SAF",
-          "23": "LART",
-          "24": "SPT",
-          "25": "TAT",
-          "26": "TVP",
-          "27": "MTA",
-          "28": "ZMS",
-          "29": "SAS",
-          "30": "GLT",
-          "31": "FOT",
-          "32": "KVS",
-          "33": "Utoken",
-          "34": "NSV",
-          "39": "KVSS",
-          "40": "RND",
-          "46": "RocRa",
-          "48": "Bal",
-          "49": "Shark",
-          "50": "ZTK",
-          "51": "RCM",
-          "55": "PIZ",
-          "56": "PSP",
-          "66": "BBC",
-          "69": "SRT",
-          "74": "GID",
-          "77": "shicoin",
-          "88": "MEM",
-          "96": "@@@",
-          "99": "PBA",
-          "100": "ACRST",
-          "101": "TTO",
-          "108": "GURU",
-          "111": "PBAC",
-          "112": "TTam",
-          "114": "GOG",
-          "121": "NsNsN",
-          "122": "ttam",
-          "123": "RBT",
-          "124": "BEA",
-          "125": "SDV",
-          "134": "TNG",
-          "139": "PHNX",
-          "140": "USDT",
-          "143": "XIN",
-          "144": "TTT",
-          "145": "UMG",
-          "200": "nUSDT",
-          "201": "VNST",
-          "224": "creagen",
-          "228": "bebra",
-          "233": "NTT",
-          "261": "DOS",
-          "322": "SOLO",
-          "333": "MEM",
-          "377": "KAA",
-          "399": "TTAM",
-          "404": "PDRS",
-          "412": "PML",
-          "420": "SWED",
-          "444": "SASS",
-          "500": "TRN",
-          "555": "bambam",
-          "609": "HMT",
-          "666": "HOGE",
-          "689": "YPT",
-          "777": "FUGA",
-          "786": "AMT",
-          "824": "gbk",
-          "888": "FFF",
-          "988": "BABY",
-          "999": "YAKIO",
-          "1000": "TWC",
-          "1111": "RCL",
-          "1112": "TTam",
-          "1113": "KCT",
-          "1212": "bob",
-          "1231": "123",
-          "1234": "PPV",
-          "1235": "PAV",
-          "1313": "TNA",
-          "1335": "LOT",
-          "1336": "INV",
-          "1337": "rUSD",
-          "1717": "qveex",
-          "1807": "SVO",
-          "1984": "USDt",
-          "1985": "XCMSDK",
-          "2000": "bcdt",
-          "2206": "RSD",
-          "2512": "ARR2",
-          "2727": "PRES",
-          "2984": "RUSD",
-          "3008": "ARR",
-          "4040": "ROSTIK",
-          "4110": "DDA",
-          "5000": "xdtb",
-          "6900": "LSPA",
-          "6969": "STNLY",
-          "7777": "USDT",
-          "9394": "SMEAD",
-          "9991": "SPT",
-          "11111": "RLC",
-          "11123": "AAE",
-          "12345": "USDT",
-          "20001": "TSTT",
-          "20301": "EVM",
-          "22061": "PIVO",
-          "22062": "DEM",
-          "22063": "DKT",
-          "22064": "XPPEN",
-          "26845": "TTT",
-          "41217": "KFTP",
-          "42069": "PEB",
-          "50001": "jelou",
-          "66666": "KST",
-          "69420": "PLONK",
-          "77777": "SHREK",
-          "80085": "NKT",
-          "111111": "11111",
-          "111112": "SQRLTKN",
-          "123456": "LRSKA",
-          "228228": "TEST",
-          "228282": "WTN",
-          "228322": "nzprt",
-          "335277": "PSPV",
-          "411299": "any",
-          "412177": "LKT",
-          "413801": "PPV",
-          "456789": "LDO",
-          "666666": "ISH",
-          "862105": "USDTT",
-          "862812": "CUBOT",
-          "863012": "vCOPT",
-          "1111111": "VVA",
-          "1234567": "TAFK",
-          "12345678": "giraffe",
-          "22332244": "ZoV",
-          "76657621": "gaa",
-          "123456789": "ZeAs",
-          "143228832": "tasset",
-          "1234567890": "giraffe",
-          "2430784328": "TMW"
-        },
-        "foreignAssetsInfo": {
-          "HOP": {
-            "symbol": "HOP",
-            "name": "Trappist Hop",
-            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X1\":{\"Parachain\":\"1836\"}}}"
-          },
-          "WND": {
-            "symbol": "WND",
-            "name": "Westend",
-            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Westend\"}}}"
-          }
-        },
-        "poolPairsInfo": {
-          "0": {
-            "lpToken": "0",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"140\"}]}}]]"
-          },
-          "1": {
-            "lpToken": "1",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"420\"}]}}]]"
-          },
-          "2": {
-            "lpToken": "2",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"47\"}]}}]]"
-          },
-          "3": {
-            "lpToken": "3",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"48\"}]}}]]"
-          },
-          "4": {
-            "lpToken": "4",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"46\"}]}}]]"
-          },
-          "5": {
-            "lpToken": "5",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"49\"}]}}]]"
-          },
-          "6": {
-            "lpToken": "6",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"51\"}]}}]]"
-          },
-          "7": {
-            "lpToken": "7",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"56\"}]}}]]"
-          },
-          "8": {
-            "lpToken": "8",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"11111\"}]}}]]"
-          },
-          "9": {
-            "lpToken": "9",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"101\"}]}}]]"
-          },
-          "10": {
-            "lpToken": "10",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1111\"}]}}]]"
-          },
-          "11": {
-            "lpToken": "11",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"1\",\"interior\":{\"X1\":{\"Parachain\":\"1836\"}}}]]"
-          },
-          "12": {
-            "lpToken": "12",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22062\"}]}}]]"
-          },
-          "13": {
-            "lpToken": "13",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"111111\"}]}}]]"
-          },
-          "14": {
-            "lpToken": "14",
-            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22064\"}]}}]]"
-          }
-        },
-        "specName": "statemine"
-      },
-      "1002": {
-        "tokens": [
-          "ROC"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "contracts-rococo"
-      },
-      "1003": {
-        "tokens": [
-          "ROC"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "encointer-parachain"
-      },
-      "1013": {
-        "tokens": [
-          "ROC"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bridge-hub-rococo"
-      },
-      "2004": {
-        "tokens": [
-          "PHA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "rhala"
-      },
-      "2011": {
-        "tokens": [
-          "RXOR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "sora_ksm"
-      },
-      "2030": {
-        "tokens": [
-          "BNC",
-          "KUSD",
-          "DOT",
-          "KSM",
-          "KAR",
-          "ZLK",
-          "PHA",
-          "RMRK",
-          "MOVR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bifrost_polkadot"
-      },
-      "2031": {
-        "tokens": [
-          "NCFG"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "centrifuge"
-      },
-      "2043": {
-        "tokens": [
-          "OTP"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "origintrail-parachain"
-      },
-      "2056": {
-        "tokens": [
-          "AVT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "avn-parachain"
-      },
-      "2058": {
-        "tokens": [
-          "WATRD"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "watr-devnet"
-      },
-      "2087": {
-        "tokens": [
-          "PICA"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "picasso"
-      },
-      "2090": {
-        "tokens": [
-          "BSX"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "basilisk"
-      },
-      "2093": {
-        "tokens": [
-          "MD5"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "hashed"
-      },
-      "2100": {
-        "tokens": [
-          "SOON"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "soonsocial-parachain"
-      },
-      "2101": {
-        "tokens": [
-          "ZBS"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "zeitgeist"
-      },
-      "2105": {
-        "tokens": [
-          "PRING"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "Pangolin2"
-      },
-      "2106": {
-        "tokens": [
-          "LIT"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "rococo-parachain"
-      },
-      "2114": {
-        "tokens": [
-          "TUR"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "turing"
-      },
-      "2119": {
-        "tokens": [
-          "BAJU"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "bajun"
-      },
-      "2124": {
-        "tokens": [
-          "AMPE"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "foucoco"
-      },
-      "3333": {
-        "tokens": [
-          "T0RN"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "t0rn"
-      },
-      "4044": {
-        "tokens": [
-          "XRQCY"
-        ],
-        "assetsInfo": {},
-        "foreignAssetsInfo": {},
-        "poolPairsInfo": {},
-        "specName": "frequency-rococo"
-      }
-    }
-  } as ChainInfoRegistry;
-  
+	polkadot: {
+		'0': {
+			tokens: ['DOT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'polkadot',
+		},
+		'1000': {
+			tokens: ['DOT'],
+			assetsInfo: {
+				'1': 'no1',
+				'2': 'BTC',
+				'3': 'DOT',
+				'4': 'EFI',
+				'5': 'PLX',
+				'6': 'LPHP',
+				'7': 'lucky7',
+				'8': 'JOE',
+				'9': 'PINT',
+				'10': 'BEAST',
+				'11': 'web3',
+				'12': 'USDcp',
+				'15': 'Meme',
+				'20': 'StabCP',
+				'21': 'WBTC',
+				'23': 'PINK',
+				'77': 'TRQ',
+				'79': 'PGOLD',
+				'99': 'Cypress',
+				'100': 'WETH',
+				'101': 'DOTMA',
+				'123': '123',
+				'256': 'ICE',
+				'666': 'DANGER',
+				'777': '777',
+				'999': 'gold',
+				'1000': 'BRZ',
+				'1337': 'USDC',
+				'1984': 'USDt',
+				'862812': 'CUBO',
+				'868367': 'VSC',
+				'20090103': 'BTC',
+			},
+			foreignAssetsInfo: {
+				EQ: {
+					symbol: 'EQ',
+					name: 'Equilibrium',
+					multiLocation: '{"parents":"1","interior":{"X1":{"Parachain":"2011"}}}',
+				},
+				'0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a224b7573616d61227d7d7d':
+					{
+						symbol: '',
+						name: '',
+						multiLocation: '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Kusama"}}}',
+					},
+				EQD: {
+					symbol: 'EQD',
+					name: 'Equilibrium Dollar',
+					multiLocation:
+						'{"parents":"1","interior":{"X2":[{"Parachain":"2011"},{"GeneralKey":{"length":"3","data":"0x6571640000000000000000000000000000000000000000000000000000000000"}}]}}',
+				},
+			},
+			poolPairsInfo: {},
+			specName: 'statemint',
+		},
+		'1001': {
+			tokens: ['DOT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'collectives',
+		},
+		'1002': {
+			tokens: ['DOT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bridge-hub-polkadot',
+		},
+		'2000': {
+			tokens: ['ACA', 'AUSD', 'DOT', 'LDOT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'acala',
+			xcAssetsData: [
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						ForeignAsset: '12',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'WETH',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":100}]}}}',
+					asset: {
+						ForeignAsset: '6',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'WBTC',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":21}]}}}',
+					asset: {
+						ForeignAsset: '5',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: {
+						ForeignAsset: '0',
+					},
+				},
+				{
+					paraID: 2006,
+					symbol: 'ASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+					asset: {
+						ForeignAsset: '2',
+					},
+				},
+				{
+					paraID: 2008,
+					symbol: 'CRU',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2008}}}}',
+					asset: {
+						ForeignAsset: '11',
+					},
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQD',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
+					asset: {
+						ForeignAsset: '8',
+					},
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQ',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
+					asset: {
+						ForeignAsset: '7',
+					},
+				},
+				{
+					paraID: 2012,
+					symbol: 'PARA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
+					asset: {
+						ForeignAsset: '1',
+					},
+				},
+				{
+					paraID: 2032,
+					symbol: 'IBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+					asset: {
+						ForeignAsset: '3',
+					},
+				},
+				{
+					paraID: 2032,
+					symbol: 'INTR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+					asset: {
+						ForeignAsset: '4',
+					},
+				},
+				{
+					paraID: 2035,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+					asset: {
+						ForeignAsset: '9',
+					},
+				},
+				{
+					paraID: 2037,
+					symbol: 'UNQ',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2037}}}}',
+					asset: {
+						ForeignAsset: '10',
+					},
+				},
+			],
+		},
+		'2004': {
+			tokens: ['GLMR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'moonbeam',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '42259045809535163221576417993425387648',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}',
+					asset: '166377000701797186346254371275954761085',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '311091173110107856861649819128533077277',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0003"}]}}}',
+					asset: '225719522181998468294117309041779353812',
+				},
+				{
+					paraID: 2000,
+					symbol: 'aUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0001"}]}}}',
+					asset: '110021739665376159354538090254163045594',
+				},
+				{
+					paraID: 2000,
+					symbol: 'ACA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0000"}]}}}',
+					asset: '224821240862170613278369189818311486111',
+				},
+				{
+					paraID: 2006,
+					symbol: 'ASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+					asset: '224077081838586484055667086558292981199',
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQD',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
+					asset: '187224307232923873519830480073807488153',
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQ',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
+					asset: '190590555344745888270686124937537713878',
+				},
+				{
+					paraID: 2012,
+					symbol: 'PARA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
+					asset: '32615670524745285411807346420584982855',
+				},
+				{
+					paraID: 2026,
+					symbol: 'NODL',
+					decimals: 11,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2026},{"palletInstance":2}]}}}',
+					asset: '309163521958167876851250718453738106865',
+				},
+				{
+					paraID: 2030,
+					symbol: 'FIL',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0804"}]}}}',
+					asset: '144012926827374458669278577633504620722',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
+					asset: '29085784439601774464560083082574142143',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vGLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0901"}]}}}',
+					asset: '204507659831918931608354793288110796652',
+				},
+				{
+					paraID: 2030,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0001"}]}}}',
+					asset: '165823357460190568952172802245839421906',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vFIL',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0904"}]}}}',
+					asset: '272547899416482196831721420898811311297',
+				},
+				{
+					paraID: 2031,
+					symbol: 'CFG',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2031},{"generalKey":"0x0001"}]}}}',
+					asset: '91372035960551235635465443179559840483',
+				},
+				{
+					paraID: 2032,
+					symbol: 'IBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+					asset: '120637696315203257380661607956669368914',
+				},
+				{
+					paraID: 2032,
+					symbol: 'INTR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+					asset: '101170542313601871197860408087030232491',
+				},
+				{
+					paraID: 2034,
+					symbol: 'HDX',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2034},{"generalIndex":0}]}}}',
+					asset: '69606720909260275826784788104880799692',
+				},
+				{
+					paraID: 2035,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+					asset: '132685552157663328694213725410064821485',
+				},
+				{
+					paraID: 2043,
+					symbol: 'OTP',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2043},{"palletInstance":10}]}}}',
+					asset: '238111524681612888331172110363070489924',
+				},
+				{
+					paraID: 2046,
+					symbol: 'RING',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2046},{"palletInstance":5}]}}}',
+					asset: '125699734534028342599692732320197985871',
+				},
+				{
+					paraID: 2092,
+					symbol: 'ZTG',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x0001"}]}}}',
+					asset: '150874409661081770150564009349448205842',
+				},
+				{
+					paraID: 2101,
+					symbol: 'SUB',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2101}}}}',
+					asset: '89994634370519791027168048838578580624',
+				},
+				{
+					paraID: 2104,
+					symbol: 'MANTA',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2104}}}}',
+					asset: '166446646689194205559791995948102903873',
+				},
+			],
+		},
+		'2006': {
+			tokens: ['ASTR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'astar',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '340282366920938463463374607431768211455',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}',
+					asset: '4294969281',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '4294969280',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0003"}]}}}',
+					asset: '18446744073709551618',
+				},
+				{
+					paraID: 2000,
+					symbol: 'ACA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0000"}]}}}',
+					asset: '18446744073709551616',
+				},
+				{
+					paraID: 2000,
+					symbol: 'aSEED',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0001"}]}}}',
+					asset: '18446744073709551617',
+				},
+				{
+					paraID: 2002,
+					symbol: 'CLV',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2002}}}}',
+					asset: '18446744073709551625',
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: '18446744073709551619',
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQD',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
+					asset: '18446744073709551629',
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQ',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
+					asset: '18446744073709551628',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vsDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0403"}]}}}',
+					asset: '18446744073709551626',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
+					asset: '18446744073709551624',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0903"}]}}}',
+					asset: '18446744073709551632',
+				},
+				{
+					paraID: 2030,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0001"}]}}}',
+					asset: '18446744073709551623',
+				},
+				{
+					paraID: 2032,
+					symbol: 'IBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+					asset: '18446744073709551620',
+				},
+				{
+					paraID: 2032,
+					symbol: 'INTR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+					asset: '18446744073709551621',
+				},
+				{
+					paraID: 2034,
+					symbol: 'HDX',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2034},{"generalIndex":0}]}}}',
+					asset: '18446744073709551630',
+				},
+				{
+					paraID: 2035,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+					asset: '18446744073709551622',
+				},
+				{
+					paraID: 2037,
+					symbol: 'UNQ',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2037}}}}',
+					asset: '18446744073709551631',
+				},
+				{
+					paraID: 2046,
+					symbol: 'RING',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2046},{"palletInstance":5}]}}}',
+					asset: '18446744073709551627',
+				},
+			],
+		},
+		'2007': {
+			tokens: ['KPX'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'totem-parachain',
+		},
+		'2008': {
+			tokens: ['CRU'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'polkadot-crust-parachain',
+		},
+		'2011': {
+			tokens: ['TOKEN'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'Equilibrium-parachain',
+		},
+		'2012': {
+			tokens: ['PARA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'parallel',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '101',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '102',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0003"}]}}}',
+					asset: '110',
+				},
+				{
+					paraID: 2000,
+					symbol: 'ACA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0000"}]}}}',
+					asset: '108',
+				},
+				{
+					paraID: 2000,
+					symbol: 'lcDOT',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x040d000000"}]}}}',
+					asset: '106',
+				},
+				{
+					paraID: 2002,
+					symbol: 'CLV',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2002}}}}',
+					asset: '130',
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: '114',
+				},
+				{
+					paraID: 2012,
+					symbol: 'sDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x73444f54"}]}}}',
+					asset: '1001',
+				},
+				{
+					paraID: 2012,
+					symbol: 'cDOT-7/14',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2012},{"palletInstance":6},{"generalIndex":200070014}]}}}',
+					asset: '200070014',
+				},
+				{
+					paraID: 2012,
+					symbol: 'cDOT-8/15',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2012},{"palletInstance":6},{"generalIndex":200080015}]}}}',
+					asset: '200080015',
+				},
+				{
+					paraID: 2012,
+					symbol: 'cDOT-10/17',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2012},{"palletInstance":6},{"generalIndex":200100017}]}}}',
+					asset: '200100017',
+				},
+				{
+					paraID: 2012,
+					symbol: 'cDOT-6/13',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2012},{"palletInstance":6},{"generalIndex":200060013}]}}}',
+					asset: '200060013',
+				},
+				{
+					paraID: 2012,
+					symbol: 'cDOT-9/16',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2012},{"palletInstance":6},{"generalIndex":200090016}]}}}',
+					asset: '200090016',
+				},
+				{
+					paraID: 2032,
+					symbol: 'INTR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+					asset: '120',
+				},
+				{
+					paraID: 2032,
+					symbol: 'IBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+					asset: '122',
+				},
+				{
+					paraID: 2035,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+					asset: '115',
+				},
+			],
+		},
+		'2013': {
+			tokens: ['LIT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'litentry-parachain',
+		},
+		'2019': {
+			tokens: ['LAYR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'composable',
+		},
+		'2026': {
+			tokens: ['NODL'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'nodle-para',
+		},
+		'2030': {
+			tokens: ['BNC'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bifrost_polkadot',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: {
+						Token2: '0',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						Token2: '2',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}',
+					asset: {
+						Token2: '5',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: {
+						Token2: '1',
+					},
+				},
+				{
+					paraID: 2006,
+					symbol: 'ASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+					asset: {
+						Token2: '3',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'vGLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0901"}]}}}',
+					asset: {
+						VToken2: '1',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'vFIL',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0904"}]}}}',
+					asset: {
+						VToken2: '4',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'FIL',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0804"}]}}}',
+					asset: {
+						Token2: '4',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'vASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0903"}]}}}',
+					asset: {
+						VToken2: '3',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'vDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
+					asset: {
+						VToken2: '0',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'vsDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0403"}]}}}',
+					asset: {
+						VSToken2: '0',
+					},
+				},
+				{
+					paraID: 2032,
+					symbol: 'IBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+					asset: {
+						Token2: '6',
+					},
+				},
+				{
+					paraID: 2032,
+					symbol: 'INTR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+					asset: {
+						Token2: '7',
+					},
+				},
+				{
+					paraID: 2104,
+					symbol: 'MANTA',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2104}}}}',
+					asset: {
+						Token2: '8',
+					},
+				},
+			],
+		},
+		'2031': {
+			tokens: ['CFG'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'centrifuge',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: {
+						ForeignAsset: '5',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}',
+					asset: {
+						ForeignAsset: '6',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						ForeignAsset: '1',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'aUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0001"}]}}}',
+					asset: {
+						ForeignAsset: '3',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: {
+						ForeignAsset: '4',
+					},
+				},
+				{
+					paraID: 2031,
+					symbol: 'LpArbUSDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x4":[{"parachain":2031},{"palletInstance":103},{"globalConsensus":{"ethereum":{"chainId":42161}}},{"accountKey20":{"network":null,"key":"0xaf88d065e77c8cc2239327c5edb3a432268e5831"}}]}}}',
+					asset: {
+						ForeignAsset: '100,003',
+					},
+				},
+				{
+					paraID: 2031,
+					symbol: 'CFG',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2031},{"generalKey":"0x0001"}]}}}',
+					asset: 'Native',
+				},
+				{
+					paraID: 2031,
+					symbol: 'LpBaseUSDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x4":[{"parachain":2031},{"palletInstance":103},{"globalConsensus":{"ethereum":{"chainId":8453}}},{"accountKey20":{"network":null,"key":"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"}}]}}}',
+					asset: {
+						ForeignAsset: '100,002',
+					},
+				},
+				{
+					paraID: 2031,
+					symbol: 'LpEthUSDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x4":[{"parachain":2031},{"palletInstance":103},{"globalConsensus":{"ethereum":{"chainId":1}}},{"accountKey20":{"network":null,"key":"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"}}]}}}',
+					asset: {
+						ForeignAsset: '100,001',
+					},
+				},
+				{
+					paraID: 2031,
+					symbol: 'LpCeloUSDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x4":[{"parachain":2031},{"palletInstance":103},{"globalConsensus":{"ethereum":{"chainId":42220}}},{"accountKey20":{"network":null,"key":"0x37f750b7cc259a2f741af45294f6a16572cf5cad"}}]}}}',
+					asset: {
+						ForeignAsset: '100,004',
+					},
+				},
+			],
+		},
+		'2032': {
+			tokens: ['INTR', 'IBTC', 'DOT', 'KINT', 'KBTC', 'KSM'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'interlay-parachain',
+			xcAssetsData: [
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						ForeignAsset: '2',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'LDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0003"}]}}}',
+					asset: {
+						ForeignAsset: '1',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: {
+						ForeignAsset: '11',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'WBNB.wh',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xe3b841c3f96e647e6dc01b468d6d0ad3562a9eeb"}}]}}}',
+					asset: {
+						ForeignAsset: '7',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'TBTC.wh',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xecd65e4b89495ae63b4f11ca872a23680a7c419c"}}]}}}',
+					asset: {
+						ForeignAsset: '5',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'USDC.wh',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0x931715fee2d06333043d11f658c8ce934ac61d0c"}}]}}}',
+					asset: {
+						ForeignAsset: '8',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'WBTC.wh',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d"}}]}}}',
+					asset: {
+						ForeignAsset: '9',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: {
+						ForeignAsset: '10',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'WETH.wh',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xab3f0245b83feb11d15aaffefd7ad465a59817ed"}}]}}}',
+					asset: {
+						ForeignAsset: '6',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'DAI.wh',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0x06e605775296e851ff43b4daa541bb0984e9d6fd"}}]}}}',
+					asset: {
+						ForeignAsset: '4',
+					},
+				},
+				{
+					paraID: 2030,
+					symbol: 'VDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
+					asset: {
+						ForeignAsset: '3',
+					},
+				},
+			],
+		},
+		'2034': {
+			tokens: ['HDX'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'hydradx',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '5',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1337}]}}}',
+					asset: '22',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '10',
+				},
+				{
+					paraID: 2000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce"}]}}}',
+					asset: '7',
+				},
+				{
+					paraID: 2000,
+					symbol: 'DAI',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae"}]}}}',
+					asset: '2',
+				},
+				{
+					paraID: 2000,
+					symbol: 'APE',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02f4c723e61709d90f89939c1852f516e373d418a8"}]}}}',
+					asset: '6',
+				},
+				{
+					paraID: 2000,
+					symbol: 'WBTC',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02c80084af223c8b598536178d9361dc55bfda6818"}]}}}',
+					asset: '3',
+				},
+				{
+					paraID: 2000,
+					symbol: 'WETH',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x025a4d6acdc4e3e5ab15717f407afe957f7a242578"}]}}}',
+					asset: '4',
+				},
+				{
+					paraID: 2004,
+					symbol: 'WETH',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xab3f0245b83feb11d15aaffefd7ad465a59817ed"}}]}}}',
+					asset: '20',
+				},
+				{
+					paraID: 2004,
+					symbol: 'WBTC',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d"}}]}}}',
+					asset: '19',
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: '16',
+				},
+				{
+					paraID: 2004,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0x931715fee2d06333043d11f658c8ce934ac61d0c"}}]}}}',
+					asset: '21',
+				},
+				{
+					paraID: 2004,
+					symbol: 'DAI',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0x06e605775296e851ff43b4daa541bb0984e9d6fd"}}]}}}',
+					asset: '18',
+				},
+				{
+					paraID: 2004,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2004},{"palletInstance":110},{"accountKey20":{"network":null,"key":"0xc30e9ca94cf52f3bf5692aacf81353a27052c46f"}}]}}}',
+					asset: '23',
+				},
+				{
+					paraID: 2006,
+					symbol: 'ASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+					asset: '9',
+				},
+				{
+					paraID: 2030,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0001"}]}}}',
+					asset: '14',
+				},
+				{
+					paraID: 2030,
+					symbol: 'vDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0900"}]}}}',
+					asset: '15',
+				},
+				{
+					paraID: 2031,
+					symbol: 'CFG',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2031},{"generalKey":"0x0001"}]}}}',
+					asset: '13',
+				},
+				{
+					paraID: 2032,
+					symbol: 'iBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0001"}]}}}',
+					asset: '11',
+				},
+				{
+					paraID: 2032,
+					symbol: 'INTR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2032},{"generalKey":"0x0002"}]}}}',
+					asset: '17',
+				},
+				{
+					paraID: 2035,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2035}}}}',
+					asset: '8',
+				},
+				{
+					paraID: 2092,
+					symbol: 'ZTG',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x0001"}]}}}',
+					asset: '12',
+				},
+				{
+					paraID: 2101,
+					symbol: 'SUB',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2101}}}}',
+					asset: '24',
+				},
+			],
+		},
+		'2035': {
+			tokens: ['PHA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'phala',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'DOT',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '0',
+				},
+				{
+					paraID: 2000,
+					symbol: 'ACA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0000"}]}}}',
+					asset: '5',
+				},
+				{
+					paraID: 2000,
+					symbol: 'AUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0001"}]}}}',
+					asset: '3',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LDOT',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0003"}]}}}',
+					asset: '4',
+				},
+				{
+					paraID: 2004,
+					symbol: 'GLMR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2004},{"palletInstance":10}]}}}',
+					asset: '1',
+				},
+				{
+					paraID: 2006,
+					symbol: 'ASTR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2006}}}}',
+					asset: '6',
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQ',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2011}}}}',
+					asset: '9',
+				},
+				{
+					paraID: 2011,
+					symbol: 'EQD',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2011},{"generalKey":"0x657164"}]}}}',
+					asset: '10',
+				},
+				{
+					paraID: 2012,
+					symbol: 'PARA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2012},{"generalKey":"0x50415241"}]}}}',
+					asset: '2',
+				},
+				{
+					paraID: 2030,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2030},{"generalKey":"0x0001"}]}}}',
+					asset: '8',
+				},
+				{
+					paraID: 2034,
+					symbol: 'HDX',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2034},{"generalIndex":0}]}}}',
+					asset: '11',
+				},
+				{
+					paraID: 2046,
+					symbol: 'RING',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2046},{"palletInstance":5}]}}}',
+					asset: '7',
+				},
+			],
+		},
+		'2037': {
+			tokens: ['UNQ'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'unique',
+		},
+		'2039': {
+			tokens: ['TEER'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'integritee-parachain',
+		},
+		'2043': {
+			tokens: ['OTP'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'origintrail-parachain',
+			xcAssetsData: [
+				{
+					paraID: 2043,
+					symbol: 'TRAC',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2043},{"generalIndex":1}]}}}',
+					asset: '1',
+				},
+			],
+		},
+		'2046': {
+			tokens: ['RING'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'Darwinia2',
+		},
+		'2048': {
+			tokens: ['BBB'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bitgreen-parachain',
+		},
+		'2051': {
+			tokens: ['AJUN'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'ajuna',
+		},
+		'2056': {
+			tokens: ['AVT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'avn-parachain',
+		},
+		'2086': {
+			tokens: ['KILT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'kilt-spiritnet',
+		},
+		'2091': {
+			tokens: ['FRQCY'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'frequency',
+		},
+		'2092': {
+			tokens: ['ZTG'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'zeitgeist',
+		},
+		'2093': {
+			tokens: ['HASH'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'luhn',
+		},
+		'2094': {
+			tokens: ['PEN'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'pendulum',
+		},
+		'2101': {
+			tokens: ['SUB'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'subsocial-parachain',
+		},
+		'2104': {
+			tokens: ['MANTA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'manta',
+		},
+		'3333': {
+			tokens: ['TRN'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 't3rn',
+		},
+	},
+	kusama: {
+		'0': {
+			tokens: ['KSM'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'kusama',
+		},
+		'1000': {
+			tokens: ['KSM'],
+			assetsInfo: {
+				'0': 'DOG',
+				'1': 'L T',
+				'2': 'PNN',
+				'3': 'Meow',
+				'4': 'HAPPY',
+				'5': 'BEER',
+				'6': 'ZKPD',
+				'7': 'DOS',
+				'8': 'RMRK',
+				'9': 'TOT',
+				'10': 'USDC',
+				'11': 'USDT',
+				'12': 'BUSD',
+				'13': 'LN',
+				'14': 'DOT',
+				'15': 'Web3',
+				'16': 'ARIS',
+				'17': 'MEME',
+				'18': 'HEI',
+				'19': 'SHOT',
+				'20': 'BFKK',
+				'21': 'ELEV',
+				'22': 'STH',
+				'23': 'KOJO',
+				'24': 'test',
+				'25': 'BABE',
+				'26': 'BUNGA',
+				'27': 'RUNE',
+				'28': 'LAC',
+				'29': 'CODES',
+				'30': 'GOL',
+				'31': 'ki',
+				'32': 'FAV',
+				'33': 'BUSSY',
+				'34': 'PLX',
+				'35': 'LUCKY',
+				'36': 'RRT',
+				'37': 'MNCH',
+				'38': 'ENT',
+				'39': 'DSCAN',
+				'40': 'ERIC',
+				'41': 'GOOSE',
+				'42': 'NRNF',
+				'43': 'TTT',
+				'44': 'ADVNCE',
+				'45': 'CRIB',
+				'46': 'FAN',
+				'47': 'EUR',
+				'49': 'DIAN',
+				'50': 'PROMO',
+				'55': 'MTS',
+				'60': 'GAV',
+				'61': 'CRY',
+				'64': 'oh!',
+				'66': 'DAI',
+				'68': 'ADVERT',
+				'69': 'NICE',
+				'70': 'MAR',
+				'71': 'OAK',
+				'75': 'cipher',
+				'77': 'Crypto',
+				'87': 'XEXR',
+				'88': 'BTC',
+				'90': 'SATS',
+				'91': 'TMJ',
+				'99': 'BITCOIN',
+				'100': 'Chralt',
+				'101': '---',
+				'102': 'DRX',
+				'111': 'NO1',
+				'117': 'TNKR',
+				'123': 'NFT',
+				'138': 'Abc',
+				'168': 'Tokens',
+				'188': 'ZLK',
+				'200': 'SIX',
+				'214': 'LOVE',
+				'222': 'PNEO',
+				'223': 'BILL',
+				'224': 'SIK',
+				'300': 'PWS',
+				'333': 'Token',
+				'345': '345',
+				'360': 'uni',
+				'365': 'time',
+				'374': 'wETH',
+				'377': 'KAA',
+				'383': 'KODA',
+				'404': 'MAXI',
+				'420': 'BLAZE',
+				'520': '0xe299a5e299a5e299a5',
+				'555': 'GAME',
+				'567': 'CHRWNA',
+				'569': 'KUSA',
+				'598': 'EREN',
+				'666': 'BAD',
+				'677': 'GRB',
+				'759': 'bLd',
+				'777': 'GOD',
+				'813': 'TBUX',
+				'841': 'YAYOI',
+				'888': 'LUCK',
+				'911': '911',
+				'969': 'WGTL',
+				'999': 'CBDC',
+				'1000': 'SPARK',
+				'1107': 'HOLIC',
+				'1111': 'MTVD',
+				'1123': 'XEN',
+				'1155': 'WITEK',
+				'1225': 'GOD',
+				'1234': 'KSM',
+				'1313': 'TACP',
+				'1337': 'TIP',
+				'1420': 'HYDR',
+				'1441': 'SPOT',
+				'1526': 'bcd',
+				'1607': 'STRGZN',
+				'1688': 'ali',
+				'1984': 'USDt',
+				'1999': 'ADVERT2',
+				'2021': 'WAVE',
+				'2048': 'RWS',
+				'2049': 'Android',
+				'2050': 'CUT',
+				'2077': 'XRT',
+				'3000': 'GRAIN',
+				'3001': 'DUCK',
+				'3077': 'ACT',
+				'3721': 'fast',
+				'3943': 'GMK',
+				'6789': 'VHM',
+				'6967': 'CHAOS',
+				'7777': 'lucky7',
+				'8848': 'top',
+				'9000': 'KPOTS',
+				'9999': 'BTC',
+				'11111': 'KVC',
+				'12345': 'DREX',
+				'19840': 'USDt',
+				'42069': 'INTRN',
+				'69420': 'CHAOS',
+				'80815': 'KSMFS',
+				'80816': 'RUEPP',
+				'80817': 'FRALEY',
+				'88888': 'BAILEGO',
+				'95834': 'LUL',
+				'220204': 'STM',
+				'314159': 'RTT',
+				'777777': 'DEFI',
+				'862812': 'CUBO',
+				'863012': 'VCOP',
+				'4206969': 'SHIB',
+				'5201314': 'belove',
+				'5797867': 'TAKE',
+				'7777777': 'king',
+				'4294967291': 'PRIME',
+			},
+			foreignAssetsInfo: {
+				'0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a22506f6c6b61646f74227d7d7d':
+					{
+						symbol: '',
+						name: '',
+						multiLocation: '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}',
+					},
+				TNKR: {
+					symbol: 'TNKR',
+					name: 'Tinkernet',
+					multiLocation: '{"parents":"1","interior":{"X2":[{"Parachain":"2125"},{"GeneralIndex":"0"}]}}',
+				},
+			},
+			poolPairsInfo: {
+				'0': {
+					lpToken: '0',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"5797867"}]}}]]',
+				},
+				'1': {
+					lpToken: '1',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}]]',
+				},
+				'2': {
+					lpToken: '2',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1313"}]}}]]',
+				},
+			},
+			specName: 'statemine',
+		},
+		'1001': {
+			tokens: ['KSM'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'encointer-parachain',
+		},
+		'1002': {
+			tokens: ['KSM'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bridge-hub-kusama',
+		},
+		'2000': {
+			tokens: ['KAR', 'KUSD', 'KSM', 'LKSM', 'BNC', 'VSKSM', 'PHA', 'KINT', 'KBTC', 'TAI'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'karura',
+			xcAssetsData: [
+				{
+					paraID: 1000,
+					symbol: 'RMRK',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":8}]}}}',
+					asset: {
+						ForeignAsset: '0',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						ForeignAsset: '7',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'ARIS',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":16}]}}}',
+					asset: {
+						ForeignAsset: '1',
+					},
+				},
+				{
+					paraID: 2007,
+					symbol: 'SDN',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2007}}}}',
+					asset: {
+						ForeignAsset: '18',
+					},
+				},
+				{
+					paraID: 2012,
+					symbol: 'CSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2012}}}}',
+					asset: {
+						ForeignAsset: '5',
+					},
+				},
+				{
+					paraID: 2015,
+					symbol: 'TEER',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2015},{"generalKey":"0x54454552"}]}}}',
+					asset: {
+						ForeignAsset: '8',
+					},
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: {
+						ForeignAsset: '3',
+					},
+				},
+				{
+					paraID: 2024,
+					symbol: 'GENS',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2024}}}}',
+					asset: {
+						ForeignAsset: '14',
+					},
+				},
+				{
+					paraID: 2024,
+					symbol: 'EQD',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2024},{"generalKey":"0x657164"}]}}}',
+					asset: {
+						ForeignAsset: '15',
+					},
+				},
+				{
+					paraID: 2084,
+					symbol: 'KMA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2084}}}}',
+					asset: {
+						ForeignAsset: '10',
+					},
+				},
+				{
+					paraID: 2085,
+					symbol: 'HKO',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2085},{"generalKey":"0x484b4f"}]}}}',
+					asset: {
+						ForeignAsset: '4',
+					},
+				},
+				{
+					paraID: 2088,
+					symbol: 'AIR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2088},{"generalKey":"0x0001"}]}}}',
+					asset: {
+						ForeignAsset: '12',
+					},
+				},
+				{
+					paraID: 2090,
+					symbol: 'BSX',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2090},{"generalIndex":0}]}}}',
+					asset: {
+						ForeignAsset: '11',
+					},
+				},
+				{
+					paraID: 2095,
+					symbol: 'QTZ',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2095}}}}',
+					asset: {
+						ForeignAsset: '2',
+					},
+				},
+				{
+					paraID: 2096,
+					symbol: 'NEER',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2096},{"generalKey":"0x000000000000000000"}]}}}',
+					asset: {
+						ForeignAsset: '9',
+					},
+				},
+				{
+					paraID: 2102,
+					symbol: 'PCHU',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2102},{"generalKey":"0x50434855"}]}}}',
+					asset: {
+						ForeignAsset: '17',
+					},
+				},
+				{
+					paraID: 2105,
+					symbol: 'CRAB',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2105},{"palletInstance":5}]}}}',
+					asset: {
+						ForeignAsset: '13',
+					},
+				},
+				{
+					paraID: 2106,
+					symbol: 'LIT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2106},{"palletInstance":10}]}}}',
+					asset: {
+						ForeignAsset: '20',
+					},
+				},
+				{
+					paraID: 2107,
+					symbol: 'KICO',
+					decimals: 14,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2107},{"generalKey":"0x4b49434f"}]}}}',
+					asset: {
+						ForeignAsset: '6',
+					},
+				},
+				{
+					paraID: 2114,
+					symbol: 'TUR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2114}}}}',
+					asset: {
+						ForeignAsset: '16',
+					},
+				},
+				{
+					paraID: 2118,
+					symbol: 'LT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2118},{"generalKey":"0x4c54"}]}}}',
+					asset: {
+						ForeignAsset: '19',
+					},
+				},
+			],
+		},
+		'2001': {
+			tokens: ['BNC', 'KUSD', 'DOT', 'KSM', 'KAR', 'ZLK', 'PHA', 'RMRK', 'MOVR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bifrost',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: {
+						Token: 'KSM',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'RMRK',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":8}]}}}',
+					asset: {
+						Token: 'RMRK',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						Token2: '0',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'KUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: {
+						Stable: 'KUSD',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: {
+						Token: 'KAR',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'vBNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0101"}]}}}',
+					asset: {
+						VToken: 'BNC',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'vMOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x010a"}]}}}',
+					asset: {
+						VToken: 'MOVR',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'vKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0104"}]}}}',
+					asset: {
+						VToken: 'KSM',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'ZLK',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0207"}]}}}',
+					asset: {
+						Token: 'ZLK',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'VSvsKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0404"}]}}}',
+					asset: {
+						VSToken: 'KSM',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: {
+						Native: 'BNC',
+					},
+				},
+				{
+					paraID: 2004,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2004}}}}',
+					asset: {
+						Token: 'PHA',
+					},
+				},
+				{
+					paraID: 2007,
+					symbol: 'SDN',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2007}}}}',
+					asset: {
+						Token2: '3',
+					},
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: {
+						Token: 'MOVR',
+					},
+				},
+				{
+					paraID: 2092,
+					symbol: 'KBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000b"}]}}}',
+					asset: {
+						Token2: '2',
+					},
+				},
+				{
+					paraID: 2092,
+					symbol: 'KINT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000c"}]}}}',
+					asset: {
+						Token2: '1',
+					},
+				},
+				{
+					paraID: 2110,
+					symbol: 'MGX',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2110},{"generalKey":"0x00000000"}]}}}',
+					asset: {
+						Token2: '4',
+					},
+				},
+			],
+		},
+		'2004': {
+			tokens: ['PHA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'khala',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '0',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '1',
+				},
+				{
+					paraID: 2000,
+					symbol: 'aUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '4',
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: '2',
+				},
+				{
+					paraID: 2001,
+					symbol: 'ZLK',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0207"}]}}}',
+					asset: '3',
+				},
+				{
+					paraID: 2007,
+					symbol: 'SDN',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2007}}}}',
+					asset: '12',
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: '6',
+				},
+				{
+					paraID: 2084,
+					symbol: 'KMA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2084}}}}',
+					asset: '8',
+				},
+				{
+					paraID: 2085,
+					symbol: 'HKO',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2085},{"generalKey":"0x484b4f"}]}}}',
+					asset: '7',
+				},
+				{
+					paraID: 2087,
+					symbol: 'PICA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2087}}}}',
+					asset: '15',
+				},
+				{
+					paraID: 2090,
+					symbol: 'BSX',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2090},{"generalKey":"0x00000000"}]}}}',
+					asset: '5',
+				},
+				{
+					paraID: 2090,
+					symbol: 'BSX',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2090},{"generalIndex":0}]}}}',
+					asset: '9',
+				},
+				{
+					paraID: 2096,
+					symbol: 'NEER',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2096},{"generalKey":"0x000000000000000000"}]}}}',
+					asset: '13',
+				},
+				{
+					paraID: 2096,
+					symbol: 'BIT',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2096},{"generalKey":"0x020000000000000000"}]}}}',
+					asset: '14',
+				},
+				{
+					paraID: 2105,
+					symbol: 'CRAB',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2105},{"palletInstance":5}]}}}',
+					asset: '11',
+				},
+				{
+					paraID: 2114,
+					symbol: 'TUR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2114}}}}',
+					asset: '10',
+				},
+			],
+		},
+		'2007': {
+			tokens: ['SDN'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'shiden',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '340282366920938463463374607431768211455',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '4294969280',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '18446744073709551618',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0083"}]}}}',
+					asset: '18446744073709551619',
+				},
+				{
+					paraID: 2000,
+					symbol: 'aSEED',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '18446744073709551616',
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: '18446744073709551627',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vsKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0404"}]}}}',
+					asset: '18446744073709551629',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0104"}]}}}',
+					asset: '18446744073709551628',
+				},
+				{
+					paraID: 2004,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2004}}}}',
+					asset: '18446744073709551623',
+				},
+				{
+					paraID: 2012,
+					symbol: 'CSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2012}}}}',
+					asset: '18446744073709551624',
+				},
+				{
+					paraID: 2016,
+					symbol: 'SKU',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2016}}}}',
+					asset: '18446744073709551626',
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: '18446744073709551620',
+				},
+				{
+					paraID: 2024,
+					symbol: 'GENS',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2024}}}}',
+					asset: '18446744073709551630',
+				},
+				{
+					paraID: 2024,
+					symbol: 'EQD',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2024},{"generalKey":"0x657164"}]}}}',
+					asset: '18446744073709551631',
+				},
+				{
+					paraID: 2092,
+					symbol: 'KBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000b"}]}}}',
+					asset: '18446744073709551621',
+				},
+				{
+					paraID: 2092,
+					symbol: 'KINT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000c"}]}}}',
+					asset: '18446744073709551622',
+				},
+				{
+					paraID: 2095,
+					symbol: 'QTZ',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2095}}}}',
+					asset: '18446744073709551633',
+				},
+				{
+					paraID: 2096,
+					symbol: 'NEER',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2096},{"generalKey":"0x000000000000000000"}]}}}',
+					asset: '18446744073709551632',
+				},
+				{
+					paraID: 2105,
+					symbol: 'CRAB',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2105},{"palletInstance":5}]}}}',
+					asset: '18446744073709551625',
+				},
+			],
+		},
+		'2011': {
+			tokens: [],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'sora_ksm',
+		},
+		'2012': {
+			tokens: ['CSM'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'crust-collator',
+			xcAssetsData: [
+				{
+					paraID: 2000,
+					symbol: 'AUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '214920334981412447805621250067209749032',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '10810581592933651521121702237638664357',
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: '319623561105283008236062145480775032445',
+				},
+				{
+					paraID: 2007,
+					symbol: 'SDN',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2007}}}}',
+					asset: '16797826370226091782818345603793389938',
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: '232263652204149413431520870009560565298',
+				},
+				{
+					paraID: 2048,
+					symbol: 'XRT',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2048}}}}',
+					asset: '108036400430056508975016746969135344601',
+				},
+				{
+					paraID: 2105,
+					symbol: 'CRAB',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2105},{"palletInstance":5}]}}}',
+					asset: '173481220575862801646329923366065693029',
+				},
+			],
+		},
+		'2015': {
+			tokens: ['TEER'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'integritee-parachain',
+		},
+		'2023': {
+			tokens: ['MOVR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'moonriver',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '42259045809535163221576417993425387648',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '311091173110107856861649819128533077277',
+				},
+				{
+					paraID: 1000,
+					symbol: 'RMRK',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":8}]}}}',
+					asset: '182365888117048807484804376330534607370',
+				},
+				{
+					paraID: 2000,
+					symbol: 'aSeed',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '214920334981412447805621250067209749032',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '10810581592933651521121702237638664357',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0104"}]}}}',
+					asset: '264344629840762281112027368930249420542',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vBNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0101"}]}}}',
+					asset: '72145018963825376852137222787619937732',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vMOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x010a"}]}}}',
+					asset: '203223821023327994093278529517083736593',
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: '319623561105283008236062145480775032445',
+				},
+				{
+					paraID: 2004,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2004}}}}',
+					asset: '189307976387032586987344677431204943363',
+				},
+				{
+					paraID: 2007,
+					symbol: 'SDN',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2007}}}}',
+					asset: '16797826370226091782818345603793389938',
+				},
+				{
+					paraID: 2012,
+					symbol: 'CSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2012}}}}',
+					asset: '108457044225666871745333730479173774551',
+				},
+				{
+					paraID: 2015,
+					symbol: 'TEER',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2015},{"generalKey":"0x54454552"}]}}}',
+					asset: '105075627293246237499203909093923548958',
+				},
+				{
+					paraID: 2048,
+					symbol: 'XRT',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2048}}}}',
+					asset: '108036400430056508975016746969135344601',
+				},
+				{
+					paraID: 2084,
+					symbol: 'KMA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2084}}}}',
+					asset: '213357169630950964874127107356898319277',
+				},
+				{
+					paraID: 2085,
+					symbol: 'HKO',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2085},{"generalKey":"0x484b4f"}]}}}',
+					asset: '76100021443485661246318545281171740067',
+				},
+				{
+					paraID: 2087,
+					symbol: 'PICA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2087}}}}',
+					asset: '167283995827706324502761431814209211090',
+				},
+				{
+					paraID: 2092,
+					symbol: 'KBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000b"}]}}}',
+					asset: '328179947973504579459046439826496046832',
+				},
+				{
+					paraID: 2092,
+					symbol: 'KINT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000c"}]}}}',
+					asset: '175400718394635817552109270754364440562',
+				},
+				{
+					paraID: 2105,
+					symbol: 'CRAB',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2105},{"palletInstance":5}]}}}',
+					asset: '173481220575862801646329923366065693029',
+				},
+				{
+					paraID: 2106,
+					symbol: 'LIT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2106},{"palletInstance":10}]}}}',
+					asset: '65216491554813189869575508812319036608',
+				},
+				{
+					paraID: 2110,
+					symbol: 'MGX',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2110},{"generalKey":"0x00000000"}]}}}',
+					asset: '118095707745084482624853002839493125353',
+				},
+				{
+					paraID: 2114,
+					symbol: 'TUR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2114}}}}',
+					asset: '133300872918374599700079037156071917454',
+				},
+			],
+		},
+		'2024': {
+			tokens: ['Unknown', 'EQD', 'GENS', 'ETH', 'BTC', 'KSM', 'CRV'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'Gens-parachain',
+		},
+		'2048': {
+			tokens: ['XRT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'robonomics',
+		},
+		'2084': {
+			tokens: ['KMA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'calamari',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '12',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '14',
+				},
+				{
+					paraID: 2000,
+					symbol: 'BNB',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02e278651e8ff8e2efa83d7f84205084ebc90688be"}]}}}',
+					asset: '21',
+				},
+				{
+					paraID: 2000,
+					symbol: 'WBTC',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f"}]}}}',
+					asset: '26',
+				},
+				{
+					paraID: 2000,
+					symbol: 'USDC',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27"}]}}}',
+					asset: '16',
+				},
+				{
+					paraID: 2000,
+					symbol: 'BUSD',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02577f6a0718a468e8a995f6075f2325f86a07c83b"}]}}}',
+					asset: '23',
+				},
+				{
+					paraID: 2000,
+					symbol: 'AUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '9',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LDO',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02b4ce1f6109854243d1af13b8ea34ed28542f31e0"}]}}}',
+					asset: '18',
+				},
+				{
+					paraID: 2000,
+					symbol: 'MATIC',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e"}]}}}',
+					asset: '20',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '8',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0083"}]}}}',
+					asset: '10',
+				},
+				{
+					paraID: 2000,
+					symbol: 'ARB',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02c621abc3afa3f24886ea278fffa7e10e8969d755"}]}}}',
+					asset: '17',
+				},
+				{
+					paraID: 2000,
+					symbol: 'APE',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0230b1f4ba0b07789be9986fa090a57e0fe5631ebb"}]}}}',
+					asset: '25',
+				},
+				{
+					paraID: 2000,
+					symbol: 'UNI',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0277cf14f938cb97308d752647d554439d99b39a3f"}]}}}',
+					asset: '22',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LINK',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x022c7de70b32cf5f20e02329a88d2e3b00ef85eb90"}]}}}',
+					asset: '24',
+				},
+				{
+					paraID: 2000,
+					symbol: 'SHIB',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x029759ca009cbcd75a84786ac19bb5d02f8e68bcd9"}]}}}',
+					asset: '19',
+				},
+				{
+					paraID: 2000,
+					symbol: 'WETH',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02ece0cc38021e734bef1d5da071b027ac2f71181f"}]}}}',
+					asset: '27',
+				},
+				{
+					paraID: 2000,
+					symbol: 'DAI',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71"}]}}}',
+					asset: '15',
+				},
+				{
+					paraID: 2004,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2004}}}}',
+					asset: '13',
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: '11',
+				},
+			],
+		},
+		'2085': {
+			tokens: ['HKO'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'heiko',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '100',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '102',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0083"}]}}}',
+					asset: '109',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '107',
+				},
+				{
+					paraID: 2004,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2004}}}}',
+					asset: '115',
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: '113',
+				},
+				{
+					paraID: 2085,
+					symbol: 'sKSM',
+					decimals: 12,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2085},{"palletInstance":6},{"generalIndex":1000}]}}}',
+					asset: '1000',
+				},
+				{
+					paraID: 2092,
+					symbol: 'KBTC',
+					decimals: 8,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000b"}]}}}',
+					asset: '121',
+				},
+				{
+					paraID: 2092,
+					symbol: 'KINT',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2092},{"generalKey":"0x000c"}]}}}',
+					asset: '119',
+				},
+			],
+		},
+		'2087': {
+			tokens: ['PICA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'picasso',
+		},
+		'2088': {
+			tokens: ['AIR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'altair',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: {
+						ForeignAsset: '3',
+					},
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						ForeignAsset: '1',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'aUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: {
+						ForeignAsset: '2',
+					},
+				},
+				{
+					paraID: 2088,
+					symbol: 'AIR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2088},{"generalKey":"0x0001"}]}}}',
+					asset: 'Native',
+				},
+			],
+		},
+		'2090': {
+			tokens: ['BSX'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'basilisk',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '1',
+				},
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '14',
+				},
+				{
+					paraID: 2000,
+					symbol: 'DAI',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71"}]}}}',
+					asset: '13',
+				},
+				{
+					paraID: 2000,
+					symbol: 'USDCet',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27"}]}}}',
+					asset: '9',
+				},
+				{
+					paraID: 2000,
+					symbol: 'aUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '2',
+				},
+				{
+					paraID: 2000,
+					symbol: 'wETH',
+					decimals: 18,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x02ece0cc38021e734bef1d5da071b027ac2f71181f"}]}}}',
+					asset: '10',
+				},
+				{
+					paraID: 2000,
+					symbol: 'wBTC',
+					decimals: 8,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f"}]}}}',
+					asset: '11',
+				},
+				{
+					paraID: 2000,
+					symbol: 'wUSDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0254e183e533fd3c6e72debb2d1cab451d017faf72"}]}}}',
+					asset: '12',
+				},
+				{
+					paraID: 2048,
+					symbol: 'XRT',
+					decimals: 9,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2048}}}}',
+					asset: '16',
+				},
+				{
+					paraID: 2125,
+					symbol: 'TNKR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2125},{"generalIndex":0}]}}}',
+					asset: '6',
+				},
+			],
+		},
+		'2092': {
+			tokens: ['KINT', 'KBTC', 'KSM', 'INTR', 'IBTC', 'DOT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'kintsugi-parachain',
+			xcAssetsData: [
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: {
+						ForeignAsset: '3',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'AUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: {
+						ForeignAsset: '1',
+					},
+				},
+				{
+					paraID: 2000,
+					symbol: 'LKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0083"}]}}}',
+					asset: {
+						ForeignAsset: '2',
+					},
+				},
+				{
+					paraID: 2001,
+					symbol: 'VKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0104"}]}}}',
+					asset: {
+						ForeignAsset: '5',
+					},
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: {
+						ForeignAsset: '4',
+					},
+				},
+				{
+					paraID: 2085,
+					symbol: 'SKSM',
+					decimals: 12,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":2085},{"palletInstance":6},{"generalIndex":1000}]}}}',
+					asset: {
+						ForeignAsset: '6',
+					},
+				},
+			],
+		},
+		'2095': {
+			tokens: ['QTZ'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'quartz',
+		},
+		'2105': {
+			tokens: ['CRAB'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'Crab2',
+		},
+		'2106': {
+			tokens: ['LIT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'litmus-parachain',
+		},
+		'2110': {
+			tokens: ['MGX'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'mangata-parachain',
+			xcAssetsData: [
+				{
+					paraID: 1000,
+					symbol: 'USDT',
+					decimals: 6,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}',
+					asset: '30',
+				},
+				{
+					paraID: 1000,
+					symbol: 'RMRK',
+					decimals: 10,
+					xcmV1MultiLocation:
+						'{"v1":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":8}]}}}',
+					asset: '31',
+				},
+				{
+					paraID: 2001,
+					symbol: 'BNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}}',
+					asset: '14',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vBNC',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0101"}]}}}',
+					asset: '23',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0104"}]}}}',
+					asset: '15',
+				},
+				{
+					paraID: 2001,
+					symbol: 'ZLK',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0207"}]}}}',
+					asset: '26',
+				},
+				{
+					paraID: 2001,
+					symbol: 'vsKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0404"}]}}}',
+					asset: '16',
+				},
+				{
+					paraID: 2114,
+					symbol: 'TUR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2114}}}}',
+					asset: '7',
+				},
+				{
+					paraID: 2121,
+					symbol: 'IMBU',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2121},{"generalKey":"0x0096"}]}}}',
+					asset: '11',
+				},
+			],
+		},
+		'2113': {
+			tokens: ['KAB'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'kabocha-parachain',
+		},
+		'2114': {
+			tokens: ['TUR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'turing',
+			xcAssetsData: [
+				{
+					paraID: 0,
+					symbol: 'KSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"here":null}}}',
+					asset: '1',
+				},
+				{
+					paraID: 2000,
+					symbol: 'AUSD',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0081"}]}}}',
+					asset: '2',
+				},
+				{
+					paraID: 2000,
+					symbol: 'KAR',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0080"}]}}}',
+					asset: '3',
+				},
+				{
+					paraID: 2000,
+					symbol: 'LKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2000},{"generalKey":"0x0083"}]}}}',
+					asset: '4',
+				},
+				{
+					paraID: 2004,
+					symbol: 'PHA',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2004}}}}',
+					asset: '7',
+				},
+				{
+					paraID: 2007,
+					symbol: 'SDN',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2007}}}}',
+					asset: '8',
+				},
+				{
+					paraID: 2023,
+					symbol: 'MOVR',
+					decimals: 18,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}',
+					asset: '9',
+				},
+				{
+					paraID: 2085,
+					symbol: 'HKO',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2085},{"generalKey":"0x484b4f"}]}}}',
+					asset: '5',
+				},
+				{
+					symbol: 'TUR',
+					decimals: 10,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x1":{"parachain":2114}}}}',
+					asset: '0',
+				},
+				{
+					paraID: 2085,
+					symbol: 'SKSM',
+					decimals: 12,
+					xcmV1MultiLocation: '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2085},{"generalKey":"0x734b534d"}]}}}',
+					asset: '6',
+				},
+			],
+		},
+		'2119': {
+			tokens: ['BAJU'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bajun',
+		},
+		'2124': {
+			tokens: ['AMPE'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'amplitude',
+		},
+		'2125': {
+			tokens: ['TNKR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'tinkernet_node',
+		},
+		'2222': {
+			tokens: ['MITO'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'ipci',
+		},
+		'2236': {
+			tokens: ['ZERO', 'PLAY', 'GAME', 'DOT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'subzero',
+		},
+		'2241': {
+			tokens: ['KREST'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'peaq-node-krest',
+		},
+	},
+	westend: {
+		'0': {
+			tokens: ['WND'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'westend',
+		},
+		'1000': {
+			tokens: ['WND'],
+			assetsInfo: {
+				'0': 'OSNT',
+				'1': 'CHV TKN',
+				'2': 'BIB',
+				'3': '(null)',
+				'4': '0xe282b5414c',
+				'5': 'MLK',
+				'6': 'BILL',
+				'7': 'XAU',
+				'8': 'JOE',
+				'9': 'xxx',
+				'10': 'CAT',
+				'11': 'SWD',
+				'13': 'RMRK',
+				'14': 'NGNC',
+				'15': 'JJS',
+				'16': 'TEST',
+				'17': 'LOL',
+				'19': 'TMJ',
+				'20': 'WETH',
+				'21': 'BETH',
+				'22': 'KO',
+				'23': 'UDT',
+				'24': 'AAA',
+				'25': 'BTC',
+				'26': 'Tsst',
+				'27': 'AMIR',
+				'28': 'NSS',
+				'30': 'TRTI',
+				'31': 'GTT',
+				'32': 'TRTO',
+				'42': 'HG2G',
+				'46': 'RASTA',
+				'47': 'MRT',
+				'49': 'RAN',
+				'51': 'kule',
+				'52': 'kule1',
+				'55': 'PER',
+				'60': 'AAA',
+				'66': 'USDT',
+				'67': 'USDT',
+				'68': 'TTT',
+				'69': 'TIDE',
+				'77': 'MVP1',
+				'81': 'SIRI',
+				'84': 'ASTRA',
+				'85': 'ITC',
+				'88': 'AEC',
+				'91': 'stt',
+				'95': 'HACK',
+				'99': 'hcc',
+				'100': 'tlj',
+				'101': 'WIL',
+				'102': 'cPHP',
+				'103': 'cPHP',
+				'104': 'NewT',
+				'109': 'assetT',
+				'121': 'TAL',
+				'122': 'TESTC',
+				'123': 'INXTSW1',
+				'126': 'TAT',
+				'145': 'dsu',
+				'146': 'FRAC',
+				'168': 'NIK',
+				'200': 'CRT',
+				'222': 'BBB',
+				'223': 'BILL',
+				'233': 'NTT',
+				'301': 'RYUD',
+				'318': 'SAT',
+				'368': 'KLING',
+				'369': 'WIN',
+				'370': 'SUM',
+				'381': 'ALC',
+				'404': 'JET',
+				'420': 'SKER',
+				'434': 'cool',
+				'482': 'PVSE',
+				'535': 'KEL',
+				'666': 'FTT',
+				'676': 'nbnbnbn',
+				'777': 'JJD',
+				'887': 'TTA',
+				'900': 'VOD',
+				'950': 'HBCOIN',
+				'987': 'JVT',
+				'988': 'VTT',
+				'999': 'CCW',
+				'1000': 'EDU',
+				'1001': 'VOW',
+				'1002': 'VOW',
+				'1003': 'VOW',
+				'1004': 'VOW',
+				'1005': 'VOW',
+				'1010': 'POL',
+				'1021': 'NFT',
+				'1022': 'nfttst',
+				'1023': 'qqnihao',
+				'1024': 'qqnihao',
+				'1111': 'TESTY',
+				'1113': 'JTT',
+				'1114': 'USDC',
+				'1122': 'dmd',
+				'1233': 'QTY',
+				'1234': 'TEST',
+				'1309': 'KLO',
+				'1312': 'NG1312',
+				'1337': 'NACHO',
+				'1977': 'SQL',
+				'1984': 'USDTT',
+				'1988': 'HBB',
+				'1994': 'SOU',
+				'1995': 'LUSD',
+				'2000': 'USDT',
+				'2022': 'weUSDT',
+				'2023': 'DEC',
+				'2048': 'CUT',
+				'2122': 'SVE',
+				'2131': 'Wnd',
+				'2511': 'TTY',
+				'3000': 'DEV',
+				'4000': 'DES',
+				'4123': 'DWND2',
+				'4200': 'KLM',
+				'6666': 'BOB',
+				'8888': 'USDT',
+				'8937': 'test',
+				'9898': 'FTT',
+				'9999': 'WND',
+				'10111': 'ETH',
+				'12344': 'tst',
+				'12345': 'DRR2',
+				'13122': 'NKL',
+				'13337': 'DEV',
+				'15240': 'KOKOS',
+				'22061': 'RSD',
+				'22062': 'BAM',
+				'22063': 'PIVO',
+				'22064': 'DKT',
+				'31337': 'USDC',
+				'54221': 'wTEST',
+				'61337': 'USDC',
+				'100112': 'FLK',
+				'100500': 'KEKPEK',
+				'123456': 'BATTY',
+				'313370': 'WBTC',
+				'313371': 'WETH',
+				'321123': 'aWNDb',
+				'420420': 'KLM2',
+				'793910': 'CIDR',
+				'862105': 'USDTT',
+				'862812': 'CUBOT',
+				'863012': 'VCOPT',
+				'1000000': 'USDT_B',
+				'19801204': 'KHT',
+				'21000000': 'PKTB',
+				'21000001': 'PKCR',
+				'40000001': 'ETH',
+				'123456789': 'PUSH',
+				'900990087': 'SPOT',
+				'1000000000': 'CZX',
+				'1233344433': 'BQE',
+				'2000000000': 'weUSDT',
+				'3999999999': 'BETH',
+				'4000000000': 'dde',
+			},
+			foreignAssetsInfo: {
+				'0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a22506f6c6b61646f74227d7d7d':
+					{
+						symbol: '',
+						name: '',
+						multiLocation: '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}',
+					},
+				ROC: {
+					symbol: 'ROC',
+					name: 'Rococo',
+					multiLocation: '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}',
+				},
+			},
+			poolPairsInfo: {
+				'0': {
+					lpToken: '0',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1977"}]}}]]',
+				},
+				'1': {
+					lpToken: '1',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"8"}]}}]]',
+				},
+				'2': {
+					lpToken: '2',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1114"}]}}]]',
+				},
+				'3': {
+					lpToken: '3',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"19801204"}]}}]]',
+				},
+				'4': {
+					lpToken: '4',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"2511"}]}}]]',
+				},
+				'5': {
+					lpToken: '5',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}]]',
+				},
+				'6': {
+					lpToken: '6',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"45"}]}}]]',
+				},
+				'7': {
+					lpToken: '7',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"4200"}]}}]]',
+				},
+				'8': {
+					lpToken: '8',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"32"}]}}]]',
+				},
+				'9': {
+					lpToken: '9',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"30"}]}}]]',
+				},
+				'10': {
+					lpToken: '10',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"46"}]}}]]',
+				},
+				'11': {
+					lpToken: '11',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1"}]}}]]',
+				},
+				'12': {
+					lpToken: '12',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"47"}]}}]]',
+				},
+				'13': {
+					lpToken: '13',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1312"}]}}]]',
+				},
+				'14': {
+					lpToken: '14',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1233"}]}}]]',
+				},
+				'15': {
+					lpToken: '15',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"13122"}]}}]]',
+				},
+				'16': {
+					lpToken: '16',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"48"}]}}]]',
+				},
+				'17': {
+					lpToken: '17',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"49"}]}}]]',
+				},
+				'18': {
+					lpToken: '18',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"10111"}]}}]]',
+				},
+				'19': {
+					lpToken: '19',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"91"}]}}]]',
+				},
+				'20': {
+					lpToken: '20',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"26"}]}}]]',
+				},
+				'21': {
+					lpToken: '21',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"28"}]}}]]',
+				},
+				'22': {
+					lpToken: '22',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"51"}]}}]]',
+				},
+				'23': {
+					lpToken: '23',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1309"}]}}]]',
+				},
+				'24': {
+					lpToken: '24',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"122"}]}}]]',
+				},
+				'25': {
+					lpToken: '25',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"31"}]}}]]',
+				},
+				'26': {
+					lpToken: '26',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"77"}]}}]]',
+				},
+				'27': {
+					lpToken: '27',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"381"}]}}]]',
+				},
+				'28': {
+					lpToken: '28',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"81"}]}}]]',
+				},
+				'29': {
+					lpToken: '29',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"104"}]}}]]',
+				},
+				'30': {
+					lpToken: '30',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"121"}]}}]]',
+				},
+				'31': {
+					lpToken: '31',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1113"}]}}]]',
+				},
+				'32': {
+					lpToken: '32',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"50"}]}}]]',
+				},
+				'33': {
+					lpToken: '33',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"777"}]}}]]',
+				},
+				'34': {
+					lpToken: '34',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"887"}]}}]]',
+				},
+				'35': {
+					lpToken: '35',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"318"}]}}]]',
+				},
+				'36': {
+					lpToken: '36',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"120"}]}}]]',
+				},
+				'37': {
+					lpToken: '37',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"369"}]}}]]',
+				},
+				'38': {
+					lpToken: '38',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"368"}]}}]]',
+				},
+				'39': {
+					lpToken: '39',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"370"}]}}]]',
+				},
+				'40': {
+					lpToken: '40',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"22061"}]}}]]',
+				},
+				'41': {
+					lpToken: '41',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"22062"}]}}]]',
+				},
+				'42': {
+					lpToken: '42',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"22064"}]}}]]',
+				},
+			},
+			specName: 'westmint',
+		},
+		'1001': {
+			tokens: ['WND'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'collectives',
+		},
+	},
+	rococo: {
+		'0': {
+			tokens: ['ROC'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'rococo',
+		},
+		'1000': {
+			tokens: ['ROC'],
+			assetsInfo: {
+				'1': 'QQ22',
+				'2': 'DDTA',
+				'3': 'NGNC',
+				'4': 'RMRK',
+				'5': 'TROC',
+				'6': 'XTS',
+				'7': 'CTS',
+				'8': 'TCS',
+				'9': 'CCoin',
+				'10': 'RTST',
+				'11': 'SVI',
+				'12': 'TST',
+				'13': 'dtc',
+				'14': 'TTT',
+				'15': 'RAT',
+				'16': 'LVTAST',
+				'17': 'MEW',
+				'18': 'HEHE',
+				'19': 'ITC',
+				'20': 'ICC',
+				'21': 'TT21',
+				'22': 'SAF',
+				'23': 'LART',
+				'24': 'SPT',
+				'25': 'TAT',
+				'26': 'TVP',
+				'27': 'MTA',
+				'28': 'ZMS',
+				'29': 'SAS',
+				'30': 'GLT',
+				'31': 'FOT',
+				'32': 'KVS',
+				'33': 'Utoken',
+				'34': 'NSV',
+				'39': 'KVSS',
+				'40': 'RND',
+				'46': 'RocRa',
+				'48': 'Bal',
+				'49': 'Shark',
+				'50': 'ZTK',
+				'51': 'RCM',
+				'55': 'PIZ',
+				'56': 'PSP',
+				'66': 'BBC',
+				'69': 'SRT',
+				'74': 'GID',
+				'77': 'shicoin',
+				'88': 'MEM',
+				'96': '@@@',
+				'99': 'PBA',
+				'100': 'ACRST',
+				'101': 'TTO',
+				'108': 'GURU',
+				'111': 'PBAC',
+				'112': 'TTam',
+				'114': 'GOG',
+				'121': 'NsNsN',
+				'122': 'ttam',
+				'123': 'RBT',
+				'124': 'BEA',
+				'125': 'SDV',
+				'134': 'TNG',
+				'139': 'PHNX',
+				'140': 'USDT',
+				'143': 'XIN',
+				'144': 'TTT',
+				'145': 'UMG',
+				'200': 'nUSDT',
+				'201': 'VNST',
+				'224': 'creagen',
+				'228': 'bebra',
+				'233': 'NTT',
+				'261': 'DOS',
+				'322': 'SOLO',
+				'333': 'MEM',
+				'377': 'KAA',
+				'399': 'TTAM',
+				'404': 'PDRS',
+				'412': 'PML',
+				'420': 'SWED',
+				'444': 'SASS',
+				'500': 'TRN',
+				'555': 'bambam',
+				'609': 'HMT',
+				'666': 'HOGE',
+				'689': 'YPT',
+				'777': 'FUGA',
+				'786': 'AMT',
+				'824': 'gbk',
+				'888': 'FFF',
+				'988': 'BABY',
+				'999': 'YAKIO',
+				'1000': 'TWC',
+				'1111': 'RCL',
+				'1112': 'TTam',
+				'1113': 'KCT',
+				'1212': 'bob',
+				'1231': '123',
+				'1234': 'PPV',
+				'1235': 'PAV',
+				'1313': 'TNA',
+				'1335': 'LOT',
+				'1336': 'INV',
+				'1337': 'rUSD',
+				'1717': 'qveex',
+				'1807': 'SVO',
+				'1984': 'USDt',
+				'1985': 'XCMSDK',
+				'2000': 'bcdt',
+				'2206': 'RSD',
+				'2512': 'ARR2',
+				'2727': 'PRES',
+				'2984': 'RUSD',
+				'3008': 'ARR',
+				'4040': 'ROSTIK',
+				'4110': 'DDA',
+				'5000': 'xdtb',
+				'6900': 'LSPA',
+				'6969': 'STNLY',
+				'7777': 'USDT',
+				'9394': 'SMEAD',
+				'9991': 'SPT',
+				'11111': 'RLC',
+				'11123': 'AAE',
+				'12345': 'USDT',
+				'20001': 'TSTT',
+				'20301': 'EVM',
+				'22061': 'PIVO',
+				'22062': 'DEM',
+				'22063': 'DKT',
+				'22064': 'XPPEN',
+				'26845': 'TTT',
+				'41217': 'KFTP',
+				'42069': 'PEB',
+				'50001': 'jelou',
+				'66666': 'KST',
+				'69420': 'PLONK',
+				'77777': 'SHREK',
+				'80085': 'NKT',
+				'111111': '11111',
+				'111112': 'SQRLTKN',
+				'123456': 'LRSKA',
+				'228228': 'TEST',
+				'228282': 'WTN',
+				'228322': 'nzprt',
+				'335277': 'PSPV',
+				'411299': 'any',
+				'412177': 'LKT',
+				'413801': 'PPV',
+				'456789': 'LDO',
+				'666666': 'ISH',
+				'862105': 'USDTT',
+				'862812': 'CUBOT',
+				'863012': 'vCOPT',
+				'1111111': 'VVA',
+				'1234567': 'TAFK',
+				'12345678': 'giraffe',
+				'22332244': 'ZoV',
+				'76657621': 'gaa',
+				'123456789': 'ZeAs',
+				'143228832': 'tasset',
+				'1234567890': 'giraffe',
+				'2430784328': 'TMW',
+			},
+			foreignAssetsInfo: {
+				HOP: {
+					symbol: 'HOP',
+					name: 'Trappist Hop',
+					multiLocation: '{"parents":"1","interior":{"X1":{"Parachain":"1836"}}}',
+				},
+				WND: {
+					symbol: 'WND',
+					name: 'Westend',
+					multiLocation: '{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}',
+				},
+			},
+			poolPairsInfo: {
+				'0': {
+					lpToken: '0',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"140"}]}}]]',
+				},
+				'1': {
+					lpToken: '1',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"420"}]}}]]',
+				},
+				'2': {
+					lpToken: '2',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"47"}]}}]]',
+				},
+				'3': {
+					lpToken: '3',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"48"}]}}]]',
+				},
+				'4': {
+					lpToken: '4',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"46"}]}}]]',
+				},
+				'5': {
+					lpToken: '5',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"49"}]}}]]',
+				},
+				'6': {
+					lpToken: '6',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"51"}]}}]]',
+				},
+				'7': {
+					lpToken: '7',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"56"}]}}]]',
+				},
+				'8': {
+					lpToken: '8',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"11111"}]}}]]',
+				},
+				'9': {
+					lpToken: '9',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"101"}]}}]]',
+				},
+				'10': {
+					lpToken: '10',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1111"}]}}]]',
+				},
+				'11': {
+					lpToken: '11',
+					pairInfo: '[[{"parents":"1","interior":"Here"},{"parents":"1","interior":{"X1":{"Parachain":"1836"}}}]]',
+				},
+				'12': {
+					lpToken: '12',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"22062"}]}}]]',
+				},
+				'13': {
+					lpToken: '13',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"111111"}]}}]]',
+				},
+				'14': {
+					lpToken: '14',
+					pairInfo:
+						'[[{"parents":"1","interior":"Here"},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"22064"}]}}]]',
+				},
+			},
+			specName: 'statemine',
+		},
+		'1002': {
+			tokens: ['ROC'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'contracts-rococo',
+		},
+		'1003': {
+			tokens: ['ROC'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'encointer-parachain',
+		},
+		'1013': {
+			tokens: ['ROC'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bridge-hub-rococo',
+		},
+		'2004': {
+			tokens: ['PHA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'rhala',
+		},
+		'2011': {
+			tokens: ['RXOR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'sora_ksm',
+		},
+		'2030': {
+			tokens: ['BNC', 'KUSD', 'DOT', 'KSM', 'KAR', 'ZLK', 'PHA', 'RMRK', 'MOVR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bifrost_polkadot',
+		},
+		'2031': {
+			tokens: ['NCFG'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'centrifuge',
+		},
+		'2043': {
+			tokens: ['OTP'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'origintrail-parachain',
+		},
+		'2056': {
+			tokens: ['AVT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'avn-parachain',
+		},
+		'2058': {
+			tokens: ['WATRD'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'watr-devnet',
+		},
+		'2087': {
+			tokens: ['PICA'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'picasso',
+		},
+		'2090': {
+			tokens: ['BSX'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'basilisk',
+		},
+		'2093': {
+			tokens: ['MD5'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'hashed',
+		},
+		'2100': {
+			tokens: ['SOON'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'soonsocial-parachain',
+		},
+		'2101': {
+			tokens: ['ZBS'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'zeitgeist',
+		},
+		'2105': {
+			tokens: ['PRING'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'Pangolin2',
+		},
+		'2106': {
+			tokens: ['LIT'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'rococo-parachain',
+		},
+		'2114': {
+			tokens: ['TUR'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'turing',
+		},
+		'2119': {
+			tokens: ['BAJU'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'bajun',
+		},
+		'2124': {
+			tokens: ['AMPE'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'foucoco',
+		},
+		'3333': {
+			tokens: ['T0RN'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 't0rn',
+		},
+		'4044': {
+			tokens: ['XRQCY'],
+			assetsInfo: {},
+			foreignAssetsInfo: {},
+			poolPairsInfo: {},
+			specName: 'frequency-rococo',
+		},
+	},
+} as ChainInfoRegistry;

--- a/src/testHelpers/mockAssetRegistry.ts
+++ b/src/testHelpers/mockAssetRegistry.ts
@@ -1,0 +1,4154 @@
+import { ChainInfoRegistry } from "../registry/types";
+
+export const mockAssetRegistry = {
+    "polkadot": {
+      "0": {
+        "tokens": [
+          "DOT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "polkadot"
+      },
+      "1000": {
+        "tokens": [
+          "DOT"
+        ],
+        "assetsInfo": {
+          "1": "no1",
+          "2": "BTC",
+          "3": "DOT",
+          "4": "EFI",
+          "5": "PLX",
+          "6": "LPHP",
+          "7": "lucky7",
+          "8": "JOE",
+          "9": "PINT",
+          "10": "BEAST",
+          "11": "web3",
+          "12": "USDcp",
+          "15": "Meme",
+          "20": "StabCP",
+          "21": "WBTC",
+          "23": "PINK",
+          "77": "TRQ",
+          "79": "PGOLD",
+          "99": "Cypress",
+          "100": "WETH",
+          "101": "DOTMA",
+          "123": "123",
+          "256": "ICE",
+          "666": "DANGER",
+          "777": "777",
+          "999": "gold",
+          "1000": "BRZ",
+          "1337": "USDC",
+          "1984": "USDt",
+          "862812": "CUBO",
+          "868367": "VSC",
+          "20090103": "BTC"
+        },
+        "foreignAssetsInfo": {
+          "EQ": {
+            "symbol": "EQ",
+            "name": "Equilibrium",
+            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X1\":{\"Parachain\":\"2011\"}}}"
+          },
+          "0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a224b7573616d61227d7d7d": {
+            "symbol": "",
+            "name": "",
+            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Kusama\"}}}"
+          },
+          "EQD": {
+            "symbol": "EQD",
+            "name": "Equilibrium Dollar",
+            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X2\":[{\"Parachain\":\"2011\"},{\"GeneralKey\":{\"length\":\"3\",\"data\":\"0x6571640000000000000000000000000000000000000000000000000000000000\"}}]}}"
+          }
+        },
+        "poolPairsInfo": {},
+        "specName": "statemint"
+      },
+      "1001": {
+        "tokens": [
+          "DOT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "collectives"
+      },
+      "1002": {
+        "tokens": [
+          "DOT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bridge-hub-polkadot"
+      },
+      "2000": {
+        "tokens": [
+          "ACA",
+          "AUSD",
+          "DOT",
+          "LDOT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "acala",
+        "xcAssetsData": [
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "ForeignAsset": "12"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "WETH",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":100}]}}}",
+            "asset": {
+              "ForeignAsset": "6"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "WBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":21}]}}}",
+            "asset": {
+              "ForeignAsset": "5"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "ForeignAsset": "0"
+            }
+          },
+          {
+            "paraID": 2006,
+            "symbol": "ASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+            "asset": {
+              "ForeignAsset": "2"
+            }
+          },
+          {
+            "paraID": 2008,
+            "symbol": "CRU",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2008}}}}",
+            "asset": {
+              "ForeignAsset": "11"
+            }
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQD",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+            "asset": {
+              "ForeignAsset": "8"
+            }
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQ",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+            "asset": {
+              "ForeignAsset": "7"
+            }
+          },
+          {
+            "paraID": 2012,
+            "symbol": "PARA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+            "asset": {
+              "ForeignAsset": "1"
+            }
+          },
+          {
+            "paraID": 2032,
+            "symbol": "IBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": {
+              "ForeignAsset": "3"
+            }
+          },
+          {
+            "paraID": 2032,
+            "symbol": "INTR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+            "asset": {
+              "ForeignAsset": "4"
+            }
+          },
+          {
+            "paraID": 2035,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+            "asset": {
+              "ForeignAsset": "9"
+            }
+          },
+          {
+            "paraID": 2037,
+            "symbol": "UNQ",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2037}}}}",
+            "asset": {
+              "ForeignAsset": "10"
+            }
+          }
+        ]
+      },
+      "2004": {
+        "tokens": [
+          "GLMR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "moonbeam",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "42259045809535163221576417993425387648"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
+            "asset": "166377000701797186346254371275954761085"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "311091173110107856861649819128533077277"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+            "asset": "225719522181998468294117309041779353812"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "110021739665376159354538090254163045594"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "ACA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+            "asset": "224821240862170613278369189818311486111"
+          },
+          {
+            "paraID": 2006,
+            "symbol": "ASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+            "asset": "224077081838586484055667086558292981199"
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQD",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+            "asset": "187224307232923873519830480073807488153"
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQ",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+            "asset": "190590555344745888270686124937537713878"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "PARA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+            "asset": "32615670524745285411807346420584982855"
+          },
+          {
+            "paraID": 2026,
+            "symbol": "NODL",
+            "decimals": 11,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2026},{\"palletInstance\":2}]}}}",
+            "asset": "309163521958167876851250718453738106865"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "FIL",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0804\"}]}}}",
+            "asset": "144012926827374458669278577633504620722"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+            "asset": "29085784439601774464560083082574142143"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vGLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0901\"}]}}}",
+            "asset": "204507659831918931608354793288110796652"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "165823357460190568952172802245839421906"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vFIL",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0904\"}]}}}",
+            "asset": "272547899416482196831721420898811311297"
+          },
+          {
+            "paraID": 2031,
+            "symbol": "CFG",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "91372035960551235635465443179559840483"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "IBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "120637696315203257380661607956669368914"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "INTR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+            "asset": "101170542313601871197860408087030232491"
+          },
+          {
+            "paraID": 2034,
+            "symbol": "HDX",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
+            "asset": "69606720909260275826784788104880799692"
+          },
+          {
+            "paraID": 2035,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+            "asset": "132685552157663328694213725410064821485"
+          },
+          {
+            "paraID": 2043,
+            "symbol": "OTP",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2043},{\"palletInstance\":10}]}}}",
+            "asset": "238111524681612888331172110363070489924"
+          },
+          {
+            "paraID": 2046,
+            "symbol": "RING",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
+            "asset": "125699734534028342599692732320197985871"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "ZTG",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "150874409661081770150564009349448205842"
+          },
+          {
+            "paraID": 2101,
+            "symbol": "SUB",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2101}}}}",
+            "asset": "89994634370519791027168048838578580624"
+          },
+          {
+            "paraID": 2104,
+            "symbol": "MANTA",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2104}}}}",
+            "asset": "166446646689194205559791995948102903873"
+          }
+        ]
+      },
+      "2006": {
+        "tokens": [
+          "ASTR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "astar",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "340282366920938463463374607431768211455"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
+            "asset": "4294969281"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "4294969280"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+            "asset": "18446744073709551618"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "ACA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+            "asset": "18446744073709551616"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aSEED",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "18446744073709551617"
+          },
+          {
+            "paraID": 2002,
+            "symbol": "CLV",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2002}}}}",
+            "asset": "18446744073709551625"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": "18446744073709551619"
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQD",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+            "asset": "18446744073709551629"
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQ",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+            "asset": "18446744073709551628"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vsDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0403\"}]}}}",
+            "asset": "18446744073709551626"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+            "asset": "18446744073709551624"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0903\"}]}}}",
+            "asset": "18446744073709551632"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "18446744073709551623"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "IBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "18446744073709551620"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "INTR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+            "asset": "18446744073709551621"
+          },
+          {
+            "paraID": 2034,
+            "symbol": "HDX",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
+            "asset": "18446744073709551630"
+          },
+          {
+            "paraID": 2035,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+            "asset": "18446744073709551622"
+          },
+          {
+            "paraID": 2037,
+            "symbol": "UNQ",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2037}}}}",
+            "asset": "18446744073709551631"
+          },
+          {
+            "paraID": 2046,
+            "symbol": "RING",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
+            "asset": "18446744073709551627"
+          }
+        ]
+      },
+      "2007": {
+        "tokens": [
+          "KPX"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "totem-parachain"
+      },
+      "2008": {
+        "tokens": [
+          "CRU"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "polkadot-crust-parachain"
+      },
+      "2011": {
+        "tokens": [
+          "TOKEN"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "Equilibrium-parachain"
+      },
+      "2012": {
+        "tokens": [
+          "PARA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "parallel",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "101"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "102"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+            "asset": "110"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "ACA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+            "asset": "108"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "lcDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x040d000000\"}]}}}",
+            "asset": "106"
+          },
+          {
+            "paraID": 2002,
+            "symbol": "CLV",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2002}}}}",
+            "asset": "130"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": "114"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "sDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x73444f54\"}]}}}",
+            "asset": "1001"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "cDOT-7/14",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200070014}]}}}",
+            "asset": "200070014"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "cDOT-8/15",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200080015}]}}}",
+            "asset": "200080015"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "cDOT-10/17",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200100017}]}}}",
+            "asset": "200100017"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "cDOT-6/13",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200060013}]}}}",
+            "asset": "200060013"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "cDOT-9/16",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2012},{\"palletInstance\":6},{\"generalIndex\":200090016}]}}}",
+            "asset": "200090016"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "INTR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+            "asset": "120"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "IBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "122"
+          },
+          {
+            "paraID": 2035,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+            "asset": "115"
+          }
+        ]
+      },
+      "2013": {
+        "tokens": [
+          "LIT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "litentry-parachain"
+      },
+      "2019": {
+        "tokens": [
+          "LAYR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "composable"
+      },
+      "2026": {
+        "tokens": [
+          "NODL"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "nodle-para"
+      },
+      "2030": {
+        "tokens": [
+          "BNC"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bifrost_polkadot",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": {
+              "Token2": "0"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "Token2": "2"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
+            "asset": {
+              "Token2": "5"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "Token2": "1"
+            }
+          },
+          {
+            "paraID": 2006,
+            "symbol": "ASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+            "asset": {
+              "Token2": "3"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vGLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0901\"}]}}}",
+            "asset": {
+              "VToken2": "1"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vFIL",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0904\"}]}}}",
+            "asset": {
+              "VToken2": "4"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "FIL",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0804\"}]}}}",
+            "asset": {
+              "Token2": "4"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0903\"}]}}}",
+            "asset": {
+              "VToken2": "3"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+            "asset": {
+              "VToken2": "0"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vsDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0403\"}]}}}",
+            "asset": {
+              "VSToken2": "0"
+            }
+          },
+          {
+            "paraID": 2032,
+            "symbol": "IBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": {
+              "Token2": "6"
+            }
+          },
+          {
+            "paraID": 2032,
+            "symbol": "INTR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+            "asset": {
+              "Token2": "7"
+            }
+          },
+          {
+            "paraID": 2104,
+            "symbol": "MANTA",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2104}}}}",
+            "asset": {
+              "Token2": "8"
+            }
+          }
+        ]
+      },
+      "2031": {
+        "tokens": [
+          "CFG"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "centrifuge",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": {
+              "ForeignAsset": "5"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
+            "asset": {
+              "ForeignAsset": "6"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "ForeignAsset": "1"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": {
+              "ForeignAsset": "3"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "ForeignAsset": "4"
+            }
+          },
+          {
+            "paraID": 2031,
+            "symbol": "LpArbUSDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":42161}}},{\"accountKey20\":{\"network\":null,\"key\":\"0xaf88d065e77c8cc2239327c5edb3a432268e5831\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "100,003"
+            }
+          },
+          {
+            "paraID": 2031,
+            "symbol": "CFG",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "Native"
+          },
+          {
+            "paraID": 2031,
+            "symbol": "LpBaseUSDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":8453}}},{\"accountKey20\":{\"network\":null,\"key\":\"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "100,002"
+            }
+          },
+          {
+            "paraID": 2031,
+            "symbol": "LpEthUSDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":1}}},{\"accountKey20\":{\"network\":null,\"key\":\"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "100,001"
+            }
+          },
+          {
+            "paraID": 2031,
+            "symbol": "LpCeloUSDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x4\":[{\"parachain\":2031},{\"palletInstance\":103},{\"globalConsensus\":{\"ethereum\":{\"chainId\":42220}}},{\"accountKey20\":{\"network\":null,\"key\":\"0x37f750b7cc259a2f741af45294f6a16572cf5cad\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "100,004"
+            }
+          }
+        ]
+      },
+      "2032": {
+        "tokens": [
+          "INTR",
+          "IBTC",
+          "DOT",
+          "KINT",
+          "KBTC",
+          "KSM"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "interlay-parachain",
+        "xcAssetsData": [
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "ForeignAsset": "2"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+            "asset": {
+              "ForeignAsset": "1"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": {
+              "ForeignAsset": "11"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "WBNB.wh",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe3b841c3f96e647e6dc01b468d6d0ad3562a9eeb\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "7"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "TBTC.wh",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xecd65e4b89495ae63b4f11ca872a23680a7c419c\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "5"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "USDC.wh",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x931715fee2d06333043d11f658c8ce934ac61d0c\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "8"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "WBTC.wh",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "9"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "ForeignAsset": "10"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "WETH.wh",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xab3f0245b83feb11d15aaffefd7ad465a59817ed\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "6"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "DAI.wh",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x06e605775296e851ff43b4daa541bb0984e9d6fd\"}}]}}}",
+            "asset": {
+              "ForeignAsset": "4"
+            }
+          },
+          {
+            "paraID": 2030,
+            "symbol": "VDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+            "asset": {
+              "ForeignAsset": "3"
+            }
+          }
+        ]
+      },
+      "2034": {
+        "tokens": [
+          "HDX"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "hydradx",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "5"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1337}]}}}",
+            "asset": "22"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "10"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0207df96d1341a7d16ba1ad431e2c847d978bc2bce\"}]}}}",
+            "asset": "7"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "DAI",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae\"}]}}}",
+            "asset": "2"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "APE",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02f4c723e61709d90f89939c1852f516e373d418a8\"}]}}}",
+            "asset": "6"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "WBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02c80084af223c8b598536178d9361dc55bfda6818\"}]}}}",
+            "asset": "3"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "WETH",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x025a4d6acdc4e3e5ab15717f407afe957f7a242578\"}]}}}",
+            "asset": "4"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "WETH",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xab3f0245b83feb11d15aaffefd7ad465a59817ed\"}}]}}}",
+            "asset": "20"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "WBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xe57ebd2d67b462e9926e04a8e33f01cd0d64346d\"}}]}}}",
+            "asset": "19"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": "16"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x931715fee2d06333043d11f658c8ce934ac61d0c\"}}]}}}",
+            "asset": "21"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "DAI",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0x06e605775296e851ff43b4daa541bb0984e9d6fd\"}}]}}}",
+            "asset": "18"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2004},{\"palletInstance\":110},{\"accountKey20\":{\"network\":null,\"key\":\"0xc30e9ca94cf52f3bf5692aacf81353a27052c46f\"}}]}}}",
+            "asset": "23"
+          },
+          {
+            "paraID": 2006,
+            "symbol": "ASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+            "asset": "9"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "14"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "vDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0900\"}]}}}",
+            "asset": "15"
+          },
+          {
+            "paraID": 2031,
+            "symbol": "CFG",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2031},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "13"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "iBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "11"
+          },
+          {
+            "paraID": 2032,
+            "symbol": "INTR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2032},{\"generalKey\":\"0x0002\"}]}}}",
+            "asset": "17"
+          },
+          {
+            "paraID": 2035,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2035}}}}",
+            "asset": "8"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "ZTG",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "12"
+          },
+          {
+            "paraID": 2101,
+            "symbol": "SUB",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2101}}}}",
+            "asset": "24"
+          }
+        ]
+      },
+      "2035": {
+        "tokens": [
+          "PHA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "phala",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "DOT",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "0"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "ACA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0000\"}]}}}",
+            "asset": "5"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "AUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "3"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LDOT",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0003\"}]}}}",
+            "asset": "4"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "GLMR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2004},{\"palletInstance\":10}]}}}",
+            "asset": "1"
+          },
+          {
+            "paraID": 2006,
+            "symbol": "ASTR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2006}}}}",
+            "asset": "6"
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQ",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2011}}}}",
+            "asset": "9"
+          },
+          {
+            "paraID": 2011,
+            "symbol": "EQD",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2011},{\"generalKey\":\"0x657164\"}]}}}",
+            "asset": "10"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "PARA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2012},{\"generalKey\":\"0x50415241\"}]}}}",
+            "asset": "2"
+          },
+          {
+            "paraID": 2030,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2030},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "8"
+          },
+          {
+            "paraID": 2034,
+            "symbol": "HDX",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2034},{\"generalIndex\":0}]}}}",
+            "asset": "11"
+          },
+          {
+            "paraID": 2046,
+            "symbol": "RING",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2046},{\"palletInstance\":5}]}}}",
+            "asset": "7"
+          }
+        ]
+      },
+      "2037": {
+        "tokens": [
+          "UNQ"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "unique"
+      },
+      "2039": {
+        "tokens": [
+          "TEER"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "integritee-parachain"
+      },
+      "2043": {
+        "tokens": [
+          "OTP"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "origintrail-parachain",
+        "xcAssetsData": [
+          {
+            "paraID": 2043,
+            "symbol": "TRAC",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2043},{\"generalIndex\":1}]}}}",
+            "asset": "1"
+          }
+        ]
+      },
+      "2046": {
+        "tokens": [
+          "RING"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "Darwinia2"
+      },
+      "2048": {
+        "tokens": [
+          "BBB"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bitgreen-parachain"
+      },
+      "2051": {
+        "tokens": [
+          "AJUN"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "ajuna"
+      },
+      "2056": {
+        "tokens": [
+          "AVT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "avn-parachain"
+      },
+      "2086": {
+        "tokens": [
+          "KILT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "kilt-spiritnet"
+      },
+      "2091": {
+        "tokens": [
+          "FRQCY"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "frequency"
+      },
+      "2092": {
+        "tokens": [
+          "ZTG"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "zeitgeist"
+      },
+      "2093": {
+        "tokens": [
+          "HASH"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "luhn"
+      },
+      "2094": {
+        "tokens": [
+          "PEN"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "pendulum"
+      },
+      "2101": {
+        "tokens": [
+          "SUB"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "subsocial-parachain"
+      },
+      "2104": {
+        "tokens": [
+          "MANTA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "manta"
+      },
+      "3333": {
+        "tokens": [
+          "TRN"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "t3rn"
+      }
+    },
+    "kusama": {
+      "0": {
+        "tokens": [
+          "KSM"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "kusama"
+      },
+      "1000": {
+        "tokens": [
+          "KSM"
+        ],
+        "assetsInfo": {
+          "0": "DOG",
+          "1": "L T",
+          "2": "PNN",
+          "3": "Meow",
+          "4": "HAPPY",
+          "5": "BEER",
+          "6": "ZKPD",
+          "7": "DOS",
+          "8": "RMRK",
+          "9": "TOT",
+          "10": "USDC",
+          "11": "USDT",
+          "12": "BUSD",
+          "13": "LN",
+          "14": "DOT",
+          "15": "Web3",
+          "16": "ARIS",
+          "17": "MEME",
+          "18": "HEI",
+          "19": "SHOT",
+          "20": "BFKK",
+          "21": "ELEV",
+          "22": "STH",
+          "23": "KOJO",
+          "24": "test",
+          "25": "BABE",
+          "26": "BUNGA",
+          "27": "RUNE",
+          "28": "LAC",
+          "29": "CODES",
+          "30": "GOL",
+          "31": "ki",
+          "32": "FAV",
+          "33": "BUSSY",
+          "34": "PLX",
+          "35": "LUCKY",
+          "36": "RRT",
+          "37": "MNCH",
+          "38": "ENT",
+          "39": "DSCAN",
+          "40": "ERIC",
+          "41": "GOOSE",
+          "42": "NRNF",
+          "43": "TTT",
+          "44": "ADVNCE",
+          "45": "CRIB",
+          "46": "FAN",
+          "47": "EUR",
+          "49": "DIAN",
+          "50": "PROMO",
+          "55": "MTS",
+          "60": "GAV",
+          "61": "CRY",
+          "64": "oh!",
+          "66": "DAI",
+          "68": "ADVERT",
+          "69": "NICE",
+          "70": "MAR",
+          "71": "OAK",
+          "75": "cipher",
+          "77": "Crypto",
+          "87": "XEXR",
+          "88": "BTC",
+          "90": "SATS",
+          "91": "TMJ",
+          "99": "BITCOIN",
+          "100": "Chralt",
+          "101": "---",
+          "102": "DRX",
+          "111": "NO1",
+          "117": "TNKR",
+          "123": "NFT",
+          "138": "Abc",
+          "168": "Tokens",
+          "188": "ZLK",
+          "200": "SIX",
+          "214": "LOVE",
+          "222": "PNEO",
+          "223": "BILL",
+          "224": "SIK",
+          "300": "PWS",
+          "333": "Token",
+          "345": "345",
+          "360": "uni",
+          "365": "time",
+          "374": "wETH",
+          "377": "KAA",
+          "383": "KODA",
+          "404": "MAXI",
+          "420": "BLAZE",
+          "520": "0xe299a5e299a5e299a5",
+          "555": "GAME",
+          "567": "CHRWNA",
+          "569": "KUSA",
+          "598": "EREN",
+          "666": "BAD",
+          "677": "GRB",
+          "759": "bLd",
+          "777": "GOD",
+          "813": "TBUX",
+          "841": "YAYOI",
+          "888": "LUCK",
+          "911": "911",
+          "969": "WGTL",
+          "999": "CBDC",
+          "1000": "SPARK",
+          "1107": "HOLIC",
+          "1111": "MTVD",
+          "1123": "XEN",
+          "1155": "WITEK",
+          "1225": "GOD",
+          "1234": "KSM",
+          "1313": "TACP",
+          "1337": "TIP",
+          "1420": "HYDR",
+          "1441": "SPOT",
+          "1526": "bcd",
+          "1607": "STRGZN",
+          "1688": "ali",
+          "1984": "USDt",
+          "1999": "ADVERT2",
+          "2021": "WAVE",
+          "2048": "RWS",
+          "2049": "Android",
+          "2050": "CUT",
+          "2077": "XRT",
+          "3000": "GRAIN",
+          "3001": "DUCK",
+          "3077": "ACT",
+          "3721": "fast",
+          "3943": "GMK",
+          "6789": "VHM",
+          "6967": "CHAOS",
+          "7777": "lucky7",
+          "8848": "top",
+          "9000": "KPOTS",
+          "9999": "BTC",
+          "11111": "KVC",
+          "12345": "DREX",
+          "19840": "USDt",
+          "42069": "INTRN",
+          "69420": "CHAOS",
+          "80815": "KSMFS",
+          "80816": "RUEPP",
+          "80817": "FRALEY",
+          "88888": "BAILEGO",
+          "95834": "LUL",
+          "220204": "STM",
+          "314159": "RTT",
+          "777777": "DEFI",
+          "862812": "CUBO",
+          "863012": "VCOP",
+          "4206969": "SHIB",
+          "5201314": "belove",
+          "5797867": "TAKE",
+          "7777777": "king",
+          "4294967291": "PRIME"
+        },
+        "foreignAssetsInfo": {
+          "0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a22506f6c6b61646f74227d7d7d": {
+            "symbol": "",
+            "name": "",
+            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}"
+          },
+          "TNKR": {
+            "symbol": "TNKR",
+            "name": "Tinkernet",
+            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X2\":[{\"Parachain\":\"2125\"},{\"GeneralIndex\":\"0\"}]}}"
+          }
+        },
+        "poolPairsInfo": {
+          "0": {
+            "lpToken": "0",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"5797867\"}]}}]]"
+          },
+          "1": {
+            "lpToken": "1",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1984\"}]}}]]"
+          },
+          "2": {
+            "lpToken": "2",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1313\"}]}}]]"
+          }
+        },
+        "specName": "statemine"
+      },
+      "1001": {
+        "tokens": [
+          "KSM"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "encointer-parachain"
+      },
+      "1002": {
+        "tokens": [
+          "KSM"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bridge-hub-kusama"
+      },
+      "2000": {
+        "tokens": [
+          "KAR",
+          "KUSD",
+          "KSM",
+          "LKSM",
+          "BNC",
+          "VSKSM",
+          "PHA",
+          "KINT",
+          "KBTC",
+          "TAI"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "karura",
+        "xcAssetsData": [
+          {
+            "paraID": 1000,
+            "symbol": "RMRK",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+            "asset": {
+              "ForeignAsset": "0"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "ForeignAsset": "7"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "ARIS",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":16}]}}}",
+            "asset": {
+              "ForeignAsset": "1"
+            }
+          },
+          {
+            "paraID": 2007,
+            "symbol": "SDN",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+            "asset": {
+              "ForeignAsset": "18"
+            }
+          },
+          {
+            "paraID": 2012,
+            "symbol": "CSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
+            "asset": {
+              "ForeignAsset": "5"
+            }
+          },
+          {
+            "paraID": 2015,
+            "symbol": "TEER",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2015},{\"generalKey\":\"0x54454552\"}]}}}",
+            "asset": {
+              "ForeignAsset": "8"
+            }
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "ForeignAsset": "3"
+            }
+          },
+          {
+            "paraID": 2024,
+            "symbol": "GENS",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2024}}}}",
+            "asset": {
+              "ForeignAsset": "14"
+            }
+          },
+          {
+            "paraID": 2024,
+            "symbol": "EQD",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2024},{\"generalKey\":\"0x657164\"}]}}}",
+            "asset": {
+              "ForeignAsset": "15"
+            }
+          },
+          {
+            "paraID": 2084,
+            "symbol": "KMA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
+            "asset": {
+              "ForeignAsset": "10"
+            }
+          },
+          {
+            "paraID": 2085,
+            "symbol": "HKO",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+            "asset": {
+              "ForeignAsset": "4"
+            }
+          },
+          {
+            "paraID": 2088,
+            "symbol": "AIR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2088},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": {
+              "ForeignAsset": "12"
+            }
+          },
+          {
+            "paraID": 2090,
+            "symbol": "BSX",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalIndex\":0}]}}}",
+            "asset": {
+              "ForeignAsset": "11"
+            }
+          },
+          {
+            "paraID": 2095,
+            "symbol": "QTZ",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2095}}}}",
+            "asset": {
+              "ForeignAsset": "2"
+            }
+          },
+          {
+            "paraID": 2096,
+            "symbol": "NEER",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
+            "asset": {
+              "ForeignAsset": "9"
+            }
+          },
+          {
+            "paraID": 2102,
+            "symbol": "PCHU",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2102},{\"generalKey\":\"0x50434855\"}]}}}",
+            "asset": {
+              "ForeignAsset": "17"
+            }
+          },
+          {
+            "paraID": 2105,
+            "symbol": "CRAB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+            "asset": {
+              "ForeignAsset": "13"
+            }
+          },
+          {
+            "paraID": 2106,
+            "symbol": "LIT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2106},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "ForeignAsset": "20"
+            }
+          },
+          {
+            "paraID": 2107,
+            "symbol": "KICO",
+            "decimals": 14,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2107},{\"generalKey\":\"0x4b49434f\"}]}}}",
+            "asset": {
+              "ForeignAsset": "6"
+            }
+          },
+          {
+            "paraID": 2114,
+            "symbol": "TUR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+            "asset": {
+              "ForeignAsset": "16"
+            }
+          },
+          {
+            "paraID": 2118,
+            "symbol": "LT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2118},{\"generalKey\":\"0x4c54\"}]}}}",
+            "asset": {
+              "ForeignAsset": "19"
+            }
+          }
+        ]
+      },
+      "2001": {
+        "tokens": [
+          "BNC",
+          "KUSD",
+          "DOT",
+          "KSM",
+          "KAR",
+          "ZLK",
+          "PHA",
+          "RMRK",
+          "MOVR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bifrost",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": {
+              "Token": "KSM"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "RMRK",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+            "asset": {
+              "Token": "RMRK"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "Token2": "0"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": {
+              "Stable": "KUSD"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": {
+              "Token": "KAR"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vBNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
+            "asset": {
+              "VToken": "BNC"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vMOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x010a\"}]}}}",
+            "asset": {
+              "VToken": "MOVR"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+            "asset": {
+              "VToken": "KSM"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "ZLK",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
+            "asset": {
+              "Token": "ZLK"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "VSvsKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
+            "asset": {
+              "VSToken": "KSM"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": {
+              "Native": "BNC"
+            }
+          },
+          {
+            "paraID": 2004,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+            "asset": {
+              "Token": "PHA"
+            }
+          },
+          {
+            "paraID": 2007,
+            "symbol": "SDN",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+            "asset": {
+              "Token2": "3"
+            }
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "Token": "MOVR"
+            }
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+            "asset": {
+              "Token2": "2"
+            }
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KINT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+            "asset": {
+              "Token2": "1"
+            }
+          },
+          {
+            "paraID": 2110,
+            "symbol": "MGX",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2110},{\"generalKey\":\"0x00000000\"}]}}}",
+            "asset": {
+              "Token2": "4"
+            }
+          }
+        ]
+      },
+      "2004": {
+        "tokens": [
+          "PHA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "khala",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "0"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "1"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "4"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "2"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "ZLK",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
+            "asset": "3"
+          },
+          {
+            "paraID": 2007,
+            "symbol": "SDN",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+            "asset": "12"
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": "6"
+          },
+          {
+            "paraID": 2084,
+            "symbol": "KMA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
+            "asset": "8"
+          },
+          {
+            "paraID": 2085,
+            "symbol": "HKO",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+            "asset": "7"
+          },
+          {
+            "paraID": 2087,
+            "symbol": "PICA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2087}}}}",
+            "asset": "15"
+          },
+          {
+            "paraID": 2090,
+            "symbol": "BSX",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalKey\":\"0x00000000\"}]}}}",
+            "asset": "5"
+          },
+          {
+            "paraID": 2090,
+            "symbol": "BSX",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2090},{\"generalIndex\":0}]}}}",
+            "asset": "9"
+          },
+          {
+            "paraID": 2096,
+            "symbol": "NEER",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
+            "asset": "13"
+          },
+          {
+            "paraID": 2096,
+            "symbol": "BIT",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x020000000000000000\"}]}}}",
+            "asset": "14"
+          },
+          {
+            "paraID": 2105,
+            "symbol": "CRAB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+            "asset": "11"
+          },
+          {
+            "paraID": 2114,
+            "symbol": "TUR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+            "asset": "10"
+          }
+        ]
+      },
+      "2007": {
+        "tokens": [
+          "SDN"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "shiden",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "340282366920938463463374607431768211455"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "4294969280"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "18446744073709551618"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+            "asset": "18446744073709551619"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aSEED",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "18446744073709551616"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "18446744073709551627"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vsKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
+            "asset": "18446744073709551629"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+            "asset": "18446744073709551628"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+            "asset": "18446744073709551623"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "CSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
+            "asset": "18446744073709551624"
+          },
+          {
+            "paraID": 2016,
+            "symbol": "SKU",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2016}}}}",
+            "asset": "18446744073709551626"
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": "18446744073709551620"
+          },
+          {
+            "paraID": 2024,
+            "symbol": "GENS",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2024}}}}",
+            "asset": "18446744073709551630"
+          },
+          {
+            "paraID": 2024,
+            "symbol": "EQD",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2024},{\"generalKey\":\"0x657164\"}]}}}",
+            "asset": "18446744073709551631"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+            "asset": "18446744073709551621"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KINT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+            "asset": "18446744073709551622"
+          },
+          {
+            "paraID": 2095,
+            "symbol": "QTZ",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2095}}}}",
+            "asset": "18446744073709551633"
+          },
+          {
+            "paraID": 2096,
+            "symbol": "NEER",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2096},{\"generalKey\":\"0x000000000000000000\"}]}}}",
+            "asset": "18446744073709551632"
+          },
+          {
+            "paraID": 2105,
+            "symbol": "CRAB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+            "asset": "18446744073709551625"
+          }
+        ]
+      },
+      "2011": {
+        "tokens": [],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "sora_ksm"
+      },
+      "2012": {
+        "tokens": [
+          "CSM"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "crust-collator",
+        "xcAssetsData": [
+          {
+            "paraID": 2000,
+            "symbol": "AUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "214920334981412447805621250067209749032"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "10810581592933651521121702237638664357"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "319623561105283008236062145480775032445"
+          },
+          {
+            "paraID": 2007,
+            "symbol": "SDN",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+            "asset": "16797826370226091782818345603793389938"
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": "232263652204149413431520870009560565298"
+          },
+          {
+            "paraID": 2048,
+            "symbol": "XRT",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
+            "asset": "108036400430056508975016746969135344601"
+          },
+          {
+            "paraID": 2105,
+            "symbol": "CRAB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+            "asset": "173481220575862801646329923366065693029"
+          }
+        ]
+      },
+      "2015": {
+        "tokens": [
+          "TEER"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "integritee-parachain"
+      },
+      "2023": {
+        "tokens": [
+          "MOVR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "moonriver",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "42259045809535163221576417993425387648"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "311091173110107856861649819128533077277"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "RMRK",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+            "asset": "182365888117048807484804376330534607370"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aSeed",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "214920334981412447805621250067209749032"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "10810581592933651521121702237638664357"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+            "asset": "264344629840762281112027368930249420542"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vBNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
+            "asset": "72145018963825376852137222787619937732"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vMOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x010a\"}]}}}",
+            "asset": "203223821023327994093278529517083736593"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "319623561105283008236062145480775032445"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+            "asset": "189307976387032586987344677431204943363"
+          },
+          {
+            "paraID": 2007,
+            "symbol": "SDN",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+            "asset": "16797826370226091782818345603793389938"
+          },
+          {
+            "paraID": 2012,
+            "symbol": "CSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2012}}}}",
+            "asset": "108457044225666871745333730479173774551"
+          },
+          {
+            "paraID": 2015,
+            "symbol": "TEER",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2015},{\"generalKey\":\"0x54454552\"}]}}}",
+            "asset": "105075627293246237499203909093923548958"
+          },
+          {
+            "paraID": 2048,
+            "symbol": "XRT",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
+            "asset": "108036400430056508975016746969135344601"
+          },
+          {
+            "paraID": 2084,
+            "symbol": "KMA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2084}}}}",
+            "asset": "213357169630950964874127107356898319277"
+          },
+          {
+            "paraID": 2085,
+            "symbol": "HKO",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+            "asset": "76100021443485661246318545281171740067"
+          },
+          {
+            "paraID": 2087,
+            "symbol": "PICA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2087}}}}",
+            "asset": "167283995827706324502761431814209211090"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+            "asset": "328179947973504579459046439826496046832"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KINT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+            "asset": "175400718394635817552109270754364440562"
+          },
+          {
+            "paraID": 2105,
+            "symbol": "CRAB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2105},{\"palletInstance\":5}]}}}",
+            "asset": "173481220575862801646329923366065693029"
+          },
+          {
+            "paraID": 2106,
+            "symbol": "LIT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2106},{\"palletInstance\":10}]}}}",
+            "asset": "65216491554813189869575508812319036608"
+          },
+          {
+            "paraID": 2110,
+            "symbol": "MGX",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2110},{\"generalKey\":\"0x00000000\"}]}}}",
+            "asset": "118095707745084482624853002839493125353"
+          },
+          {
+            "paraID": 2114,
+            "symbol": "TUR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+            "asset": "133300872918374599700079037156071917454"
+          }
+        ]
+      },
+      "2024": {
+        "tokens": [
+          "Unknown",
+          "EQD",
+          "GENS",
+          "ETH",
+          "BTC",
+          "KSM",
+          "CRV"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "Gens-parachain"
+      },
+      "2048": {
+        "tokens": [
+          "XRT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "robonomics"
+      },
+      "2084": {
+        "tokens": [
+          "KMA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "calamari",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "12"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "14"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "BNB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02e278651e8ff8e2efa83d7f84205084ebc90688be\"}]}}}",
+            "asset": "21"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "WBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f\"}]}}}",
+            "asset": "26"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "USDC",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27\"}]}}}",
+            "asset": "16"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "BUSD",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02577f6a0718a468e8a995f6075f2325f86a07c83b\"}]}}}",
+            "asset": "23"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "AUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "9"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LDO",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02b4ce1f6109854243d1af13b8ea34ed28542f31e0\"}]}}}",
+            "asset": "18"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "MATIC",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02a2a37aaf4730aeedada5aa8ee20a4451cb8b1c4e\"}]}}}",
+            "asset": "20"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "8"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+            "asset": "10"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "ARB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02c621abc3afa3f24886ea278fffa7e10e8969d755\"}]}}}",
+            "asset": "17"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "APE",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0230b1f4ba0b07789be9986fa090a57e0fe5631ebb\"}]}}}",
+            "asset": "25"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "UNI",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0277cf14f938cb97308d752647d554439d99b39a3f\"}]}}}",
+            "asset": "22"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LINK",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x022c7de70b32cf5f20e02329a88d2e3b00ef85eb90\"}]}}}",
+            "asset": "24"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "SHIB",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x029759ca009cbcd75a84786ac19bb5d02f8e68bcd9\"}]}}}",
+            "asset": "19"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "WETH",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02ece0cc38021e734bef1d5da071b027ac2f71181f\"}]}}}",
+            "asset": "27"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "DAI",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71\"}]}}}",
+            "asset": "15"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+            "asset": "13"
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": "11"
+          }
+        ]
+      },
+      "2085": {
+        "tokens": [
+          "HKO"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "heiko",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "100"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "102"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+            "asset": "109"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "107"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+            "asset": "115"
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": "113"
+          },
+          {
+            "paraID": 2085,
+            "symbol": "sKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2085},{\"palletInstance\":6},{\"generalIndex\":1000}]}}}",
+            "asset": "1000"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000b\"}]}}}",
+            "asset": "121"
+          },
+          {
+            "paraID": 2092,
+            "symbol": "KINT",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2092},{\"generalKey\":\"0x000c\"}]}}}",
+            "asset": "119"
+          }
+        ]
+      },
+      "2087": {
+        "tokens": [
+          "PICA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "picasso"
+      },
+      "2088": {
+        "tokens": [
+          "AIR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "altair",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": {
+              "ForeignAsset": "3"
+            }
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "ForeignAsset": "1"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": {
+              "ForeignAsset": "2"
+            }
+          },
+          {
+            "paraID": 2088,
+            "symbol": "AIR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2088},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "Native"
+          }
+        ]
+      },
+      "2090": {
+        "tokens": [
+          "BSX"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "basilisk",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "1"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "14"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "DAI",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x024bb6afb5fa2b07a5d1c499e1c3ddb5a15e709a71\"}]}}}",
+            "asset": "13"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "USDCet",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x021f3a10587a20114ea25ba1b388ee2dd4a337ce27\"}]}}}",
+            "asset": "9"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "aUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "2"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "wETH",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x02ece0cc38021e734bef1d5da071b027ac2f71181f\"}]}}}",
+            "asset": "10"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "wBTC",
+            "decimals": 8,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0266291c7d88d2ed9a708147bae4e0814a76705e2f\"}]}}}",
+            "asset": "11"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "wUSDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0254e183e533fd3c6e72debb2d1cab451d017faf72\"}]}}}",
+            "asset": "12"
+          },
+          {
+            "paraID": 2048,
+            "symbol": "XRT",
+            "decimals": 9,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2048}}}}",
+            "asset": "16"
+          },
+          {
+            "paraID": 2125,
+            "symbol": "TNKR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2125},{\"generalIndex\":0}]}}}",
+            "asset": "6"
+          }
+        ]
+      },
+      "2092": {
+        "tokens": [
+          "KINT",
+          "KBTC",
+          "KSM",
+          "INTR",
+          "IBTC",
+          "DOT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "kintsugi-parachain",
+        "xcAssetsData": [
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": {
+              "ForeignAsset": "3"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "AUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": {
+              "ForeignAsset": "1"
+            }
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+            "asset": {
+              "ForeignAsset": "2"
+            }
+          },
+          {
+            "paraID": 2001,
+            "symbol": "VKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+            "asset": {
+              "ForeignAsset": "5"
+            }
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": {
+              "ForeignAsset": "4"
+            }
+          },
+          {
+            "paraID": 2085,
+            "symbol": "SKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":2085},{\"palletInstance\":6},{\"generalIndex\":1000}]}}}",
+            "asset": {
+              "ForeignAsset": "6"
+            }
+          }
+        ]
+      },
+      "2095": {
+        "tokens": [
+          "QTZ"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "quartz"
+      },
+      "2105": {
+        "tokens": [
+          "CRAB"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "Crab2"
+      },
+      "2106": {
+        "tokens": [
+          "LIT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "litmus-parachain"
+      },
+      "2110": {
+        "tokens": [
+          "MGX"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "mangata-parachain",
+        "xcAssetsData": [
+          {
+            "paraID": 1000,
+            "symbol": "USDT",
+            "decimals": 6,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":1984}]}}}",
+            "asset": "30"
+          },
+          {
+            "paraID": 1000,
+            "symbol": "RMRK",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x3\":[{\"parachain\":1000},{\"palletInstance\":50},{\"generalIndex\":8}]}}}",
+            "asset": "31"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "BNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0001\"}]}}}",
+            "asset": "14"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vBNC",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0101\"}]}}}",
+            "asset": "23"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0104\"}]}}}",
+            "asset": "15"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "ZLK",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0207\"}]}}}",
+            "asset": "26"
+          },
+          {
+            "paraID": 2001,
+            "symbol": "vsKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2001},{\"generalKey\":\"0x0404\"}]}}}",
+            "asset": "16"
+          },
+          {
+            "paraID": 2114,
+            "symbol": "TUR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+            "asset": "7"
+          },
+          {
+            "paraID": 2121,
+            "symbol": "IMBU",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2121},{\"generalKey\":\"0x0096\"}]}}}",
+            "asset": "11"
+          }
+        ]
+      },
+      "2113": {
+        "tokens": [
+          "KAB"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "kabocha-parachain"
+      },
+      "2114": {
+        "tokens": [
+          "TUR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "turing",
+        "xcAssetsData": [
+          {
+            "paraID": 0,
+            "symbol": "KSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"here\":null}}}",
+            "asset": "1"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "AUSD",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0081\"}]}}}",
+            "asset": "2"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "KAR",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0080\"}]}}}",
+            "asset": "3"
+          },
+          {
+            "paraID": 2000,
+            "symbol": "LKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2000},{\"generalKey\":\"0x0083\"}]}}}",
+            "asset": "4"
+          },
+          {
+            "paraID": 2004,
+            "symbol": "PHA",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2004}}}}",
+            "asset": "7"
+          },
+          {
+            "paraID": 2007,
+            "symbol": "SDN",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2007}}}}",
+            "asset": "8"
+          },
+          {
+            "paraID": 2023,
+            "symbol": "MOVR",
+            "decimals": 18,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2023},{\"palletInstance\":10}]}}}",
+            "asset": "9"
+          },
+          {
+            "paraID": 2085,
+            "symbol": "HKO",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x484b4f\"}]}}}",
+            "asset": "5"
+          },
+          {
+            "symbol": "TUR",
+            "decimals": 10,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x1\":{\"parachain\":2114}}}}",
+            "asset": "0"
+          },
+          {
+            "paraID": 2085,
+            "symbol": "SKSM",
+            "decimals": 12,
+            "xcmV1MultiLocation": "{\"v1\":{\"parents\":1,\"interior\":{\"x2\":[{\"parachain\":2085},{\"generalKey\":\"0x734b534d\"}]}}}",
+            "asset": "6"
+          }
+        ]
+      },
+      "2119": {
+        "tokens": [
+          "BAJU"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bajun"
+      },
+      "2124": {
+        "tokens": [
+          "AMPE"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "amplitude"
+      },
+      "2222": {
+        "tokens": [
+          "MITO"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "ipci"
+      },
+      "2236": {
+        "tokens": [
+          "ZERO",
+          "PLAY",
+          "GAME",
+          "DOT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "subzero"
+      },
+      "2241": {
+        "tokens": [
+          "KREST"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "peaq-node-krest"
+      }
+    },
+    "westend": {
+      "0": {
+        "tokens": [
+          "WND"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "westend"
+      },
+      "1000": {
+        "tokens": [
+          "WND"
+        ],
+        "assetsInfo": {
+          "0": "OSNT",
+          "1": "CHV TKN",
+          "2": "BIB",
+          "3": "(null)",
+          "4": "0xe282b5414c",
+          "5": "MLK",
+          "6": "BILL",
+          "7": "XAU",
+          "8": "JOE",
+          "9": "xxx",
+          "10": "CAT",
+          "11": "SWD",
+          "13": "RMRK",
+          "14": "NGNC",
+          "15": "JJS",
+          "16": "TEST",
+          "17": "LOL",
+          "19": "TMJ",
+          "20": "WETH",
+          "21": "BETH",
+          "22": "KO",
+          "23": "UDT",
+          "24": "AAA",
+          "25": "BTC",
+          "26": "Tsst",
+          "27": "AMIR",
+          "28": "NSS",
+          "30": "TRTI",
+          "31": "GTT",
+          "32": "TRTO",
+          "42": "HG2G",
+          "46": "RASTA",
+          "47": "MRT",
+          "49": "RAN",
+          "51": "kule",
+          "52": "kule1",
+          "55": "PER",
+          "60": "AAA",
+          "66": "USDT",
+          "67": "USDT",
+          "68": "TTT",
+          "69": "TIDE",
+          "77": "MVP1",
+          "81": "SIRI",
+          "84": "ASTRA",
+          "85": "ITC",
+          "88": "AEC",
+          "91": "stt",
+          "95": "HACK",
+          "99": "hcc",
+          "100": "tlj",
+          "101": "WIL",
+          "102": "cPHP",
+          "103": "cPHP",
+          "104": "NewT",
+          "109": "assetT",
+          "121": "TAL",
+          "122": "TESTC",
+          "123": "INXTSW1",
+          "126": "TAT",
+          "145": "dsu",
+          "146": "FRAC",
+          "168": "NIK",
+          "200": "CRT",
+          "222": "BBB",
+          "223": "BILL",
+          "233": "NTT",
+          "301": "RYUD",
+          "318": "SAT",
+          "368": "KLING",
+          "369": "WIN",
+          "370": "SUM",
+          "381": "ALC",
+          "404": "JET",
+          "420": "SKER",
+          "434": "cool",
+          "482": "PVSE",
+          "535": "KEL",
+          "666": "FTT",
+          "676": "nbnbnbn",
+          "777": "JJD",
+          "887": "TTA",
+          "900": "VOD",
+          "950": "HBCOIN",
+          "987": "JVT",
+          "988": "VTT",
+          "999": "CCW",
+          "1000": "EDU",
+          "1001": "VOW",
+          "1002": "VOW",
+          "1003": "VOW",
+          "1004": "VOW",
+          "1005": "VOW",
+          "1010": "POL",
+          "1021": "NFT",
+          "1022": "nfttst",
+          "1023": "qqnihao",
+          "1024": "qqnihao",
+          "1111": "TESTY",
+          "1113": "JTT",
+          "1114": "USDC",
+          "1122": "dmd",
+          "1233": "QTY",
+          "1234": "TEST",
+          "1309": "KLO",
+          "1312": "NG1312",
+          "1337": "NACHO",
+          "1977": "SQL",
+          "1984": "USDTT",
+          "1988": "HBB",
+          "1994": "SOU",
+          "1995": "LUSD",
+          "2000": "USDT",
+          "2022": "weUSDT",
+          "2023": "DEC",
+          "2048": "CUT",
+          "2122": "SVE",
+          "2131": "Wnd",
+          "2511": "TTY",
+          "3000": "DEV",
+          "4000": "DES",
+          "4123": "DWND2",
+          "4200": "KLM",
+          "6666": "BOB",
+          "8888": "USDT",
+          "8937": "test",
+          "9898": "FTT",
+          "9999": "WND",
+          "10111": "ETH",
+          "12344": "tst",
+          "12345": "DRR2",
+          "13122": "NKL",
+          "13337": "DEV",
+          "15240": "KOKOS",
+          "22061": "RSD",
+          "22062": "BAM",
+          "22063": "PIVO",
+          "22064": "DKT",
+          "31337": "USDC",
+          "54221": "wTEST",
+          "61337": "USDC",
+          "100112": "FLK",
+          "100500": "KEKPEK",
+          "123456": "BATTY",
+          "313370": "WBTC",
+          "313371": "WETH",
+          "321123": "aWNDb",
+          "420420": "KLM2",
+          "793910": "CIDR",
+          "862105": "USDTT",
+          "862812": "CUBOT",
+          "863012": "VCOPT",
+          "1000000": "USDT_B",
+          "19801204": "KHT",
+          "21000000": "PKTB",
+          "21000001": "PKCR",
+          "40000001": "ETH",
+          "123456789": "PUSH",
+          "900990087": "SPOT",
+          "1000000000": "CZX",
+          "1233344433": "BQE",
+          "2000000000": "weUSDT",
+          "3999999999": "BETH",
+          "4000000000": "dde"
+        },
+        "foreignAssetsInfo": {
+          "0x7b22706172656e7473223a2232222c22696e746572696f72223a7b225831223a7b22476c6f62616c436f6e73656e737573223a22506f6c6b61646f74227d7d7d": {
+            "symbol": "",
+            "name": "",
+            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}"
+          },
+          "ROC": {
+            "symbol": "ROC",
+            "name": "Rococo",
+            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Rococo\"}}}"
+          }
+        },
+        "poolPairsInfo": {
+          "0": {
+            "lpToken": "0",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1977\"}]}}]]"
+          },
+          "1": {
+            "lpToken": "1",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"8\"}]}}]]"
+          },
+          "2": {
+            "lpToken": "2",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1114\"}]}}]]"
+          },
+          "3": {
+            "lpToken": "3",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"19801204\"}]}}]]"
+          },
+          "4": {
+            "lpToken": "4",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"2511\"}]}}]]"
+          },
+          "5": {
+            "lpToken": "5",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Polkadot\"}}}]]"
+          },
+          "6": {
+            "lpToken": "6",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"45\"}]}}]]"
+          },
+          "7": {
+            "lpToken": "7",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"4200\"}]}}]]"
+          },
+          "8": {
+            "lpToken": "8",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"32\"}]}}]]"
+          },
+          "9": {
+            "lpToken": "9",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"30\"}]}}]]"
+          },
+          "10": {
+            "lpToken": "10",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"46\"}]}}]]"
+          },
+          "11": {
+            "lpToken": "11",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1\"}]}}]]"
+          },
+          "12": {
+            "lpToken": "12",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"47\"}]}}]]"
+          },
+          "13": {
+            "lpToken": "13",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1312\"}]}}]]"
+          },
+          "14": {
+            "lpToken": "14",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1233\"}]}}]]"
+          },
+          "15": {
+            "lpToken": "15",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"13122\"}]}}]]"
+          },
+          "16": {
+            "lpToken": "16",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"48\"}]}}]]"
+          },
+          "17": {
+            "lpToken": "17",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"49\"}]}}]]"
+          },
+          "18": {
+            "lpToken": "18",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"10111\"}]}}]]"
+          },
+          "19": {
+            "lpToken": "19",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"91\"}]}}]]"
+          },
+          "20": {
+            "lpToken": "20",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"26\"}]}}]]"
+          },
+          "21": {
+            "lpToken": "21",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"28\"}]}}]]"
+          },
+          "22": {
+            "lpToken": "22",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"51\"}]}}]]"
+          },
+          "23": {
+            "lpToken": "23",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1309\"}]}}]]"
+          },
+          "24": {
+            "lpToken": "24",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"122\"}]}}]]"
+          },
+          "25": {
+            "lpToken": "25",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"31\"}]}}]]"
+          },
+          "26": {
+            "lpToken": "26",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"77\"}]}}]]"
+          },
+          "27": {
+            "lpToken": "27",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"381\"}]}}]]"
+          },
+          "28": {
+            "lpToken": "28",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"81\"}]}}]]"
+          },
+          "29": {
+            "lpToken": "29",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"104\"}]}}]]"
+          },
+          "30": {
+            "lpToken": "30",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"121\"}]}}]]"
+          },
+          "31": {
+            "lpToken": "31",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1113\"}]}}]]"
+          },
+          "32": {
+            "lpToken": "32",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"50\"}]}}]]"
+          },
+          "33": {
+            "lpToken": "33",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"777\"}]}}]]"
+          },
+          "34": {
+            "lpToken": "34",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"887\"}]}}]]"
+          },
+          "35": {
+            "lpToken": "35",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"318\"}]}}]]"
+          },
+          "36": {
+            "lpToken": "36",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"120\"}]}}]]"
+          },
+          "37": {
+            "lpToken": "37",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"369\"}]}}]]"
+          },
+          "38": {
+            "lpToken": "38",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"368\"}]}}]]"
+          },
+          "39": {
+            "lpToken": "39",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"370\"}]}}]]"
+          },
+          "40": {
+            "lpToken": "40",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22061\"}]}}]]"
+          },
+          "41": {
+            "lpToken": "41",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22062\"}]}}]]"
+          },
+          "42": {
+            "lpToken": "42",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22064\"}]}}]]"
+          }
+        },
+        "specName": "westmint"
+      },
+      "1001": {
+        "tokens": [
+          "WND"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "collectives"
+      }
+    },
+    "rococo": {
+      "0": {
+        "tokens": [
+          "ROC"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "rococo"
+      },
+      "1000": {
+        "tokens": [
+          "ROC"
+        ],
+        "assetsInfo": {
+          "1": "QQ22",
+          "2": "DDTA",
+          "3": "NGNC",
+          "4": "RMRK",
+          "5": "TROC",
+          "6": "XTS",
+          "7": "CTS",
+          "8": "TCS",
+          "9": "CCoin",
+          "10": "RTST",
+          "11": "SVI",
+          "12": "TST",
+          "13": "dtc",
+          "14": "TTT",
+          "15": "RAT",
+          "16": "LVTAST",
+          "17": "MEW",
+          "18": "HEHE",
+          "19": "ITC",
+          "20": "ICC",
+          "21": "TT21",
+          "22": "SAF",
+          "23": "LART",
+          "24": "SPT",
+          "25": "TAT",
+          "26": "TVP",
+          "27": "MTA",
+          "28": "ZMS",
+          "29": "SAS",
+          "30": "GLT",
+          "31": "FOT",
+          "32": "KVS",
+          "33": "Utoken",
+          "34": "NSV",
+          "39": "KVSS",
+          "40": "RND",
+          "46": "RocRa",
+          "48": "Bal",
+          "49": "Shark",
+          "50": "ZTK",
+          "51": "RCM",
+          "55": "PIZ",
+          "56": "PSP",
+          "66": "BBC",
+          "69": "SRT",
+          "74": "GID",
+          "77": "shicoin",
+          "88": "MEM",
+          "96": "@@@",
+          "99": "PBA",
+          "100": "ACRST",
+          "101": "TTO",
+          "108": "GURU",
+          "111": "PBAC",
+          "112": "TTam",
+          "114": "GOG",
+          "121": "NsNsN",
+          "122": "ttam",
+          "123": "RBT",
+          "124": "BEA",
+          "125": "SDV",
+          "134": "TNG",
+          "139": "PHNX",
+          "140": "USDT",
+          "143": "XIN",
+          "144": "TTT",
+          "145": "UMG",
+          "200": "nUSDT",
+          "201": "VNST",
+          "224": "creagen",
+          "228": "bebra",
+          "233": "NTT",
+          "261": "DOS",
+          "322": "SOLO",
+          "333": "MEM",
+          "377": "KAA",
+          "399": "TTAM",
+          "404": "PDRS",
+          "412": "PML",
+          "420": "SWED",
+          "444": "SASS",
+          "500": "TRN",
+          "555": "bambam",
+          "609": "HMT",
+          "666": "HOGE",
+          "689": "YPT",
+          "777": "FUGA",
+          "786": "AMT",
+          "824": "gbk",
+          "888": "FFF",
+          "988": "BABY",
+          "999": "YAKIO",
+          "1000": "TWC",
+          "1111": "RCL",
+          "1112": "TTam",
+          "1113": "KCT",
+          "1212": "bob",
+          "1231": "123",
+          "1234": "PPV",
+          "1235": "PAV",
+          "1313": "TNA",
+          "1335": "LOT",
+          "1336": "INV",
+          "1337": "rUSD",
+          "1717": "qveex",
+          "1807": "SVO",
+          "1984": "USDt",
+          "1985": "XCMSDK",
+          "2000": "bcdt",
+          "2206": "RSD",
+          "2512": "ARR2",
+          "2727": "PRES",
+          "2984": "RUSD",
+          "3008": "ARR",
+          "4040": "ROSTIK",
+          "4110": "DDA",
+          "5000": "xdtb",
+          "6900": "LSPA",
+          "6969": "STNLY",
+          "7777": "USDT",
+          "9394": "SMEAD",
+          "9991": "SPT",
+          "11111": "RLC",
+          "11123": "AAE",
+          "12345": "USDT",
+          "20001": "TSTT",
+          "20301": "EVM",
+          "22061": "PIVO",
+          "22062": "DEM",
+          "22063": "DKT",
+          "22064": "XPPEN",
+          "26845": "TTT",
+          "41217": "KFTP",
+          "42069": "PEB",
+          "50001": "jelou",
+          "66666": "KST",
+          "69420": "PLONK",
+          "77777": "SHREK",
+          "80085": "NKT",
+          "111111": "11111",
+          "111112": "SQRLTKN",
+          "123456": "LRSKA",
+          "228228": "TEST",
+          "228282": "WTN",
+          "228322": "nzprt",
+          "335277": "PSPV",
+          "411299": "any",
+          "412177": "LKT",
+          "413801": "PPV",
+          "456789": "LDO",
+          "666666": "ISH",
+          "862105": "USDTT",
+          "862812": "CUBOT",
+          "863012": "vCOPT",
+          "1111111": "VVA",
+          "1234567": "TAFK",
+          "12345678": "giraffe",
+          "22332244": "ZoV",
+          "76657621": "gaa",
+          "123456789": "ZeAs",
+          "143228832": "tasset",
+          "1234567890": "giraffe",
+          "2430784328": "TMW"
+        },
+        "foreignAssetsInfo": {
+          "HOP": {
+            "symbol": "HOP",
+            "name": "Trappist Hop",
+            "multiLocation": "{\"parents\":\"1\",\"interior\":{\"X1\":{\"Parachain\":\"1836\"}}}"
+          },
+          "WND": {
+            "symbol": "WND",
+            "name": "Westend",
+            "multiLocation": "{\"parents\":\"2\",\"interior\":{\"X1\":{\"GlobalConsensus\":\"Westend\"}}}"
+          }
+        },
+        "poolPairsInfo": {
+          "0": {
+            "lpToken": "0",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"140\"}]}}]]"
+          },
+          "1": {
+            "lpToken": "1",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"420\"}]}}]]"
+          },
+          "2": {
+            "lpToken": "2",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"47\"}]}}]]"
+          },
+          "3": {
+            "lpToken": "3",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"48\"}]}}]]"
+          },
+          "4": {
+            "lpToken": "4",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"46\"}]}}]]"
+          },
+          "5": {
+            "lpToken": "5",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"49\"}]}}]]"
+          },
+          "6": {
+            "lpToken": "6",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"51\"}]}}]]"
+          },
+          "7": {
+            "lpToken": "7",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"56\"}]}}]]"
+          },
+          "8": {
+            "lpToken": "8",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"11111\"}]}}]]"
+          },
+          "9": {
+            "lpToken": "9",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"101\"}]}}]]"
+          },
+          "10": {
+            "lpToken": "10",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"1111\"}]}}]]"
+          },
+          "11": {
+            "lpToken": "11",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"1\",\"interior\":{\"X1\":{\"Parachain\":\"1836\"}}}]]"
+          },
+          "12": {
+            "lpToken": "12",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22062\"}]}}]]"
+          },
+          "13": {
+            "lpToken": "13",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"111111\"}]}}]]"
+          },
+          "14": {
+            "lpToken": "14",
+            "pairInfo": "[[{\"parents\":\"1\",\"interior\":\"Here\"},{\"parents\":\"0\",\"interior\":{\"X2\":[{\"PalletInstance\":\"50\"},{\"GeneralIndex\":\"22064\"}]}}]]"
+          }
+        },
+        "specName": "statemine"
+      },
+      "1002": {
+        "tokens": [
+          "ROC"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "contracts-rococo"
+      },
+      "1003": {
+        "tokens": [
+          "ROC"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "encointer-parachain"
+      },
+      "1013": {
+        "tokens": [
+          "ROC"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bridge-hub-rococo"
+      },
+      "2004": {
+        "tokens": [
+          "PHA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "rhala"
+      },
+      "2011": {
+        "tokens": [
+          "RXOR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "sora_ksm"
+      },
+      "2030": {
+        "tokens": [
+          "BNC",
+          "KUSD",
+          "DOT",
+          "KSM",
+          "KAR",
+          "ZLK",
+          "PHA",
+          "RMRK",
+          "MOVR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bifrost_polkadot"
+      },
+      "2031": {
+        "tokens": [
+          "NCFG"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "centrifuge"
+      },
+      "2043": {
+        "tokens": [
+          "OTP"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "origintrail-parachain"
+      },
+      "2056": {
+        "tokens": [
+          "AVT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "avn-parachain"
+      },
+      "2058": {
+        "tokens": [
+          "WATRD"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "watr-devnet"
+      },
+      "2087": {
+        "tokens": [
+          "PICA"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "picasso"
+      },
+      "2090": {
+        "tokens": [
+          "BSX"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "basilisk"
+      },
+      "2093": {
+        "tokens": [
+          "MD5"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "hashed"
+      },
+      "2100": {
+        "tokens": [
+          "SOON"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "soonsocial-parachain"
+      },
+      "2101": {
+        "tokens": [
+          "ZBS"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "zeitgeist"
+      },
+      "2105": {
+        "tokens": [
+          "PRING"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "Pangolin2"
+      },
+      "2106": {
+        "tokens": [
+          "LIT"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "rococo-parachain"
+      },
+      "2114": {
+        "tokens": [
+          "TUR"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "turing"
+      },
+      "2119": {
+        "tokens": [
+          "BAJU"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "bajun"
+      },
+      "2124": {
+        "tokens": [
+          "AMPE"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "foucoco"
+      },
+      "3333": {
+        "tokens": [
+          "T0RN"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "t0rn"
+      },
+      "4044": {
+        "tokens": [
+          "XRQCY"
+        ],
+        "assetsInfo": {},
+        "foreignAssetsInfo": {},
+        "poolPairsInfo": {},
+        "specName": "frequency-rococo"
+      }
+    }
+  } as ChainInfoRegistry;
+  

--- a/src/util/getFeeAssetItemIndex.spec.ts
+++ b/src/util/getFeeAssetItemIndex.spec.ts
@@ -5,9 +5,9 @@ import { ApiPromise } from '@polkadot/api';
 import { AssetTransferApi } from '../AssetTransferApi';
 import { FungibleStrMultiAsset } from '../createXcmTypes/types';
 import { Registry } from '../registry';
-import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { adjustedMockRelayApi } from '../testHelpers/adjustedMockRelayApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { getFeeAssetItemIndex } from './getFeeAssetItemIndex';
 
 type Test = [

--- a/src/util/getFeeAssetItemIndex.spec.ts
+++ b/src/util/getFeeAssetItemIndex.spec.ts
@@ -5,6 +5,7 @@ import { ApiPromise } from '@polkadot/api';
 import { AssetTransferApi } from '../AssetTransferApi';
 import { FungibleStrMultiAsset } from '../createXcmTypes/types';
 import { Registry } from '../registry';
+import { mockAssetRegistry } from '../testHelpers/mockAssetRegistry';
 import { adjustedMockRelayApi } from '../testHelpers/adjustedMockRelayApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
 import { getFeeAssetItemIndex } from './getFeeAssetItemIndex';
@@ -18,9 +19,11 @@ type Test = [
 ];
 
 describe('getFeeAssetItemIndex', () => {
-	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
-	const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2);
-	const registry = new Registry('statemine', {});
+	const registry = new Registry('statemine', mockAssetRegistry);
+	const kusamaRegistry = new Registry('kusama', mockAssetRegistry);
+
+	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, registry);
+	const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, kusamaRegistry);
 
 	it('Should select and return the index of the correct multiassets when given their token symbols', async () => {
 		const tests: Test[] = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,19 +1294,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/asset-transfer-api-registry@npm:^0.2.11":
-  version: 0.2.11
-  resolution: "@substrate/asset-transfer-api-registry@npm:0.2.11"
-  checksum: 9fb315e9a4511146d8ea3b10982ff149c2f3f76c2063e3d48c7ab07d2453320684625f70935ef453f18b1b993765b397747a813b9e86eb916bb88873f4866a3d
-  languageName: node
-  linkType: hard
-
 "@substrate/asset-transfer-api@workspace:.":
   version: 0.0.0-use.local
   resolution: "@substrate/asset-transfer-api@workspace:."
   dependencies:
     "@polkadot/api": ^10.9.1
-    "@substrate/asset-transfer-api-registry": ^0.2.11
     "@substrate/dev": ^0.6.7
     chalk: 4.1.2
     node-fetch: 2.6.7

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@aashutoshrathi/word-wrap@npm:^1.2.3":
+  version: 1.2.6
+  resolution: "@aashutoshrathi/word-wrap@npm:1.2.6"
+  checksum: ada901b9e7c680d190f1d012c84217ce0063d8f5c5a7725bb91ec3c5ed99bb7572680eb2d2938a531ccbaec39a95422fcd8a6b4a13110c7d98dd75402f66a0cd
+  languageName: node
+  linkType: hard
+
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.2.1
   resolution: "@ampproject/remapping@npm:2.2.1"
@@ -15,197 +22,195 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.18.6, @babel/code-frame@npm:^7.21.4":
-  version: 7.21.4
-  resolution: "@babel/code-frame@npm:7.21.4"
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.13":
+  version: 7.22.13
+  resolution: "@babel/code-frame@npm:7.22.13"
   dependencies:
-    "@babel/highlight": ^7.18.6
-  checksum: e5390e6ec1ac58dcef01d4f18eaf1fd2f1325528661ff6d4a5de8979588b9f5a8e852a54a91b923846f7a5c681b217f0a45c2524eb9560553160cd963b7d592c
+    "@babel/highlight": ^7.22.13
+    chalk: ^2.4.2
+  checksum: 22e342c8077c8b77eeb11f554ecca2ba14153f707b85294fcf6070b6f6150aae88a7b7436dd88d8c9289970585f3fe5b9b941c5aa3aa26a6d5a8ef3f292da058
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.21.4":
-  version: 7.21.4
-  resolution: "@babel/compat-data@npm:7.21.4"
-  checksum: 5f8b98c66f2ffba9f3c3a82c0cf354c52a0ec5ad4797b370dc32bdcd6e136ac4febe5e93d76ce76e175632e2dbf6ce9f46319aa689fcfafa41b6e49834fa4b66
+"@babel/compat-data@npm:^7.22.9":
+  version: 7.23.3
+  resolution: "@babel/compat-data@npm:7.23.3"
+  checksum: 52fff649d4e25b10e29e8a9b1c9ef117f44d354273c17b5ef056555f8e5db2429b35df4c38bdfb6865d23133e0fba92e558d31be87bb8457db4ac688646fdbf1
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3":
-  version: 7.21.4
-  resolution: "@babel/core@npm:7.21.4"
+  version: 7.23.3
+  resolution: "@babel/core@npm:7.23.3"
   dependencies:
     "@ampproject/remapping": ^2.2.0
-    "@babel/code-frame": ^7.21.4
-    "@babel/generator": ^7.21.4
-    "@babel/helper-compilation-targets": ^7.21.4
-    "@babel/helper-module-transforms": ^7.21.2
-    "@babel/helpers": ^7.21.0
-    "@babel/parser": ^7.21.4
-    "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.21.4
-    "@babel/types": ^7.21.4
-    convert-source-map: ^1.7.0
+    "@babel/code-frame": ^7.22.13
+    "@babel/generator": ^7.23.3
+    "@babel/helper-compilation-targets": ^7.22.15
+    "@babel/helper-module-transforms": ^7.23.3
+    "@babel/helpers": ^7.23.2
+    "@babel/parser": ^7.23.3
+    "@babel/template": ^7.22.15
+    "@babel/traverse": ^7.23.3
+    "@babel/types": ^7.23.3
+    convert-source-map: ^2.0.0
     debug: ^4.1.0
     gensync: ^1.0.0-beta.2
-    json5: ^2.2.2
-    semver: ^6.3.0
-  checksum: a3beebb2cc79908a02f27a07dc381bcb34e8ecc58fa99f568ad0934c49e12111fc977ee9c5b51eb7ea2da66f63155d37c4dd96b6472eaeecfc35843ccb56bf3d
+    json5: ^2.2.3
+    semver: ^6.3.1
+  checksum: d306c1fa68972f4e085e9e7ad165aee80eb801ef331f6f07808c86309f03534d638b82ad00a3bc08f4d3de4860ccd38512b2790a39e6acc2caf9ea21e526afe7
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.21.4, @babel/generator@npm:^7.7.2":
-  version: 7.21.4
-  resolution: "@babel/generator@npm:7.21.4"
+"@babel/generator@npm:^7.23.3, @babel/generator@npm:^7.7.2":
+  version: 7.23.3
+  resolution: "@babel/generator@npm:7.23.3"
   dependencies:
-    "@babel/types": ^7.21.4
+    "@babel/types": ^7.23.3
     "@jridgewell/gen-mapping": ^0.3.2
     "@jridgewell/trace-mapping": ^0.3.17
     jsesc: ^2.5.1
-  checksum: 9ffbb526a53bb8469b5402f7b5feac93809b09b2a9f82fcbfcdc5916268a65dae746a1f2479e03ba4fb0776facd7c892191f63baa61ab69b2cfdb24f7b92424d
+  checksum: b6e71cca852d4e1aa01a28a30b8c74ffc3b8d56ccb7ae3ee783028ee015f63ad861a2e386c3eb490a9a8634db485a503a33521680f4af510151e90346c46da17
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.21.4":
-  version: 7.21.4
-  resolution: "@babel/helper-compilation-targets@npm:7.21.4"
+"@babel/helper-compilation-targets@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-compilation-targets@npm:7.22.15"
   dependencies:
-    "@babel/compat-data": ^7.21.4
-    "@babel/helper-validator-option": ^7.21.0
-    browserslist: ^4.21.3
+    "@babel/compat-data": ^7.22.9
+    "@babel/helper-validator-option": ^7.22.15
+    browserslist: ^4.21.9
     lru-cache: ^5.1.1
-    semver: ^6.3.0
+    semver: ^6.3.1
+  checksum: ce85196769e091ae54dd39e4a80c2a9df1793da8588e335c383d536d54f06baf648d0a08fc873044f226398c4ded15c4ae9120ee18e7dfd7c639a68e3cdc9980
+  languageName: node
+  linkType: hard
+
+"@babel/helper-environment-visitor@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-environment-visitor@npm:7.22.20"
+  checksum: d80ee98ff66f41e233f36ca1921774c37e88a803b2f7dca3db7c057a5fea0473804db9fb6729e5dbfd07f4bed722d60f7852035c2c739382e84c335661590b69
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.23.0":
+  version: 7.23.0
+  resolution: "@babel/helper-function-name@npm:7.23.0"
+  dependencies:
+    "@babel/template": ^7.22.15
+    "@babel/types": ^7.23.0
+  checksum: e44542257b2d4634a1f979244eb2a4ad8e6d75eb6761b4cfceb56b562f7db150d134bc538c8e6adca3783e3bc31be949071527aa8e3aab7867d1ad2d84a26e10
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-hoist-variables@npm:7.22.5"
+  dependencies:
+    "@babel/types": ^7.22.5
+  checksum: 394ca191b4ac908a76e7c50ab52102669efe3a1c277033e49467913c7ed6f7c64d7eacbeabf3bed39ea1f41731e22993f763b1edce0f74ff8563fd1f380d92cc
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-imports@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-module-imports@npm:7.22.15"
+  dependencies:
+    "@babel/types": ^7.22.15
+  checksum: ecd7e457df0a46f889228f943ef9b4a47d485d82e030676767e6a2fdcbdaa63594d8124d4b55fd160b41c201025aec01fc27580352b1c87a37c9c6f33d116702
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.23.3":
+  version: 7.23.3
+  resolution: "@babel/helper-module-transforms@npm:7.23.3"
+  dependencies:
+    "@babel/helper-environment-visitor": ^7.22.20
+    "@babel/helper-module-imports": ^7.22.15
+    "@babel/helper-simple-access": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.6
+    "@babel/helper-validator-identifier": ^7.22.20
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: bf9c7d3e7e6adff9222c05d898724cd4ee91d7eb9d52222c7ad2a22955620c2872cc2d9bdf0e047df8efdb79f4e3af2a06b53f509286145feccc4d10ddc318be
+  checksum: 5d0895cfba0e16ae16f3aa92fee108517023ad89a855289c4eb1d46f7aef4519adf8e6f971e1d55ac20c5461610e17213f1144097a8f932e768a9132e2278d71
   languageName: node
   linkType: hard
 
-"@babel/helper-environment-visitor@npm:^7.18.9":
-  version: 7.18.9
-  resolution: "@babel/helper-environment-visitor@npm:7.18.9"
-  checksum: b25101f6162ddca2d12da73942c08ad203d7668e06663df685634a8fde54a98bc015f6f62938e8554457a592a024108d45b8f3e651fd6dcdb877275b73cc4420
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.22.5, @babel/helper-plugin-utils@npm:^7.8.0":
+  version: 7.22.5
+  resolution: "@babel/helper-plugin-utils@npm:7.22.5"
+  checksum: c0fc7227076b6041acd2f0e818145d2e8c41968cc52fb5ca70eed48e21b8fe6dd88a0a91cbddf4951e33647336eb5ae184747ca706817ca3bef5e9e905151ff5
   languageName: node
   linkType: hard
 
-"@babel/helper-function-name@npm:^7.21.0":
-  version: 7.21.0
-  resolution: "@babel/helper-function-name@npm:7.21.0"
+"@babel/helper-simple-access@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-simple-access@npm:7.22.5"
   dependencies:
-    "@babel/template": ^7.20.7
-    "@babel/types": ^7.21.0
-  checksum: d63e63c3e0e3e8b3138fa47b0cd321148a300ef12b8ee951196994dcd2a492cc708aeda94c2c53759a5c9177fffaac0fd8778791286746f72a000976968daf4e
+    "@babel/types": ^7.22.5
+  checksum: fe9686714caf7d70aedb46c3cce090f8b915b206e09225f1e4dbc416786c2fdbbee40b38b23c268b7ccef749dd2db35f255338fb4f2444429874d900dede5ad2
   languageName: node
   linkType: hard
 
-"@babel/helper-hoist-variables@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-hoist-variables@npm:7.18.6"
+"@babel/helper-split-export-declaration@npm:^7.22.6":
+  version: 7.22.6
+  resolution: "@babel/helper-split-export-declaration@npm:7.22.6"
   dependencies:
-    "@babel/types": ^7.18.6
-  checksum: fd9c35bb435fda802bf9ff7b6f2df06308a21277c6dec2120a35b09f9de68f68a33972e2c15505c1a1a04b36ec64c9ace97d4a9e26d6097b76b4396b7c5fa20f
+    "@babel/types": ^7.22.5
+  checksum: e141cace583b19d9195f9c2b8e17a3ae913b7ee9b8120246d0f9ca349ca6f03cb2c001fd5ec57488c544347c0bb584afec66c936511e447fd20a360e591ac921
   languageName: node
   linkType: hard
 
-"@babel/helper-module-imports@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-module-imports@npm:7.18.6"
+"@babel/helper-string-parser@npm:^7.22.5":
+  version: 7.22.5
+  resolution: "@babel/helper-string-parser@npm:7.22.5"
+  checksum: 836851ca5ec813077bbb303acc992d75a360267aa3b5de7134d220411c852a6f17de7c0d0b8c8dcc0f567f67874c00f4528672b2a4f1bc978a3ada64c8c78467
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.22.20":
+  version: 7.22.20
+  resolution: "@babel/helper-validator-identifier@npm:7.22.20"
+  checksum: 136412784d9428266bcdd4d91c32bcf9ff0e8d25534a9d94b044f77fe76bc50f941a90319b05aafd1ec04f7d127cd57a179a3716009ff7f3412ef835ada95bdc
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.22.15":
+  version: 7.22.15
+  resolution: "@babel/helper-validator-option@npm:7.22.15"
+  checksum: 68da52b1e10002a543161494c4bc0f4d0398c8fdf361d5f7f4272e95c45d5b32d974896d44f6a0ea7378c9204988879d73613ca683e13bd1304e46d25ff67a8d
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.23.2":
+  version: 7.23.2
+  resolution: "@babel/helpers@npm:7.23.2"
   dependencies:
-    "@babel/types": ^7.18.6
-  checksum: f393f8a3b3304b1b7a288a38c10989de754f01d29caf62ce7c4e5835daf0a27b81f3ac687d9d2780d39685aae7b55267324b512150e7b2be967b0c493b6a1def
+    "@babel/template": ^7.22.15
+    "@babel/traverse": ^7.23.2
+    "@babel/types": ^7.23.0
+  checksum: aaf4828df75ec460eaa70e5c9f66e6dadc28dae3728ddb7f6c13187dbf38030e142194b83d81aa8a31bbc35a5529a5d7d3f3cf59d5d0b595f5dd7f9d8f1ced8e
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.21.2":
-  version: 7.21.2
-  resolution: "@babel/helper-module-transforms@npm:7.21.2"
+"@babel/highlight@npm:^7.22.13":
+  version: 7.22.20
+  resolution: "@babel/highlight@npm:7.22.20"
   dependencies:
-    "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-module-imports": ^7.18.6
-    "@babel/helper-simple-access": ^7.20.2
-    "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/helper-validator-identifier": ^7.19.1
-    "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.21.2
-    "@babel/types": ^7.21.2
-  checksum: 8a1c129a4f90bdf97d8b6e7861732c9580f48f877aaaafbc376ce2482febebcb8daaa1de8bc91676d12886487603f8c62a44f9e90ee76d6cac7f9225b26a49e1
-  languageName: node
-  linkType: hard
-
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.19.0, @babel/helper-plugin-utils@npm:^7.20.2, @babel/helper-plugin-utils@npm:^7.8.0":
-  version: 7.20.2
-  resolution: "@babel/helper-plugin-utils@npm:7.20.2"
-  checksum: f6cae53b7fdb1bf3abd50fa61b10b4470985b400cc794d92635da1e7077bb19729f626adc0741b69403d9b6e411cddddb9c0157a709cc7c4eeb41e663be5d74b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-simple-access@npm:^7.20.2":
-  version: 7.20.2
-  resolution: "@babel/helper-simple-access@npm:7.20.2"
-  dependencies:
-    "@babel/types": ^7.20.2
-  checksum: ad1e96ee2e5f654ffee2369a586e5e8d2722bf2d8b028a121b4c33ebae47253f64d420157b9f0a8927aea3a9e0f18c0103e74fdd531815cf3650a0a4adca11a1
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/helper-split-export-declaration@npm:7.18.6"
-  dependencies:
-    "@babel/types": ^7.18.6
-  checksum: c6d3dede53878f6be1d869e03e9ffbbb36f4897c7cc1527dc96c56d127d834ffe4520a6f7e467f5b6f3c2843ea0e81a7819d66ae02f707f6ac057f3d57943a2b
-  languageName: node
-  linkType: hard
-
-"@babel/helper-string-parser@npm:^7.19.4":
-  version: 7.19.4
-  resolution: "@babel/helper-string-parser@npm:7.19.4"
-  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.19.1":
-  version: 7.19.1
-  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
-  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
-  languageName: node
-  linkType: hard
-
-"@babel/helper-validator-option@npm:^7.21.0":
-  version: 7.21.0
-  resolution: "@babel/helper-validator-option@npm:7.21.0"
-  checksum: 8ece4c78ffa5461fd8ab6b6e57cc51afad59df08192ed5d84b475af4a7193fc1cb794b59e3e7be64f3cdc4df7ac78bf3dbb20c129d7757ae078e6279ff8c2f07
-  languageName: node
-  linkType: hard
-
-"@babel/helpers@npm:^7.21.0":
-  version: 7.21.0
-  resolution: "@babel/helpers@npm:7.21.0"
-  dependencies:
-    "@babel/template": ^7.20.7
-    "@babel/traverse": ^7.21.0
-    "@babel/types": ^7.21.0
-  checksum: 9370dad2bb665c551869a08ac87c8bdafad53dbcdce1f5c5d498f51811456a3c005d9857562715151a0f00b2e912ac8d89f56574f837b5689f5f5072221cdf54
-  languageName: node
-  linkType: hard
-
-"@babel/highlight@npm:^7.18.6":
-  version: 7.18.6
-  resolution: "@babel/highlight@npm:7.18.6"
-  dependencies:
-    "@babel/helper-validator-identifier": ^7.18.6
-    chalk: ^2.0.0
+    "@babel/helper-validator-identifier": ^7.22.20
+    chalk: ^2.4.2
     js-tokens: ^4.0.0
-  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
+  checksum: 84bd034dca309a5e680083cd827a766780ca63cef37308404f17653d32366ea76262bd2364b2d38776232f2d01b649f26721417d507e8b4b6da3e4e739f6d134
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.21.4":
-  version: 7.21.4
-  resolution: "@babel/parser@npm:7.21.4"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.22.15, @babel/parser@npm:^7.23.3":
+  version: 7.23.3
+  resolution: "@babel/parser@npm:7.23.3"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: de610ecd1bff331766d0c058023ca11a4f242bfafefc42caf926becccfb6756637d167c001987ca830dd4b34b93c629a4cef63f8c8c864a8564cdfde1989ac77
+  checksum: 4aa7366e401b5467192c1dbf2bef99ac0958c45ef69ed6704abbae68f98fab6409a527b417d1528fddc49d7664450670528adc7f45abb04db5fafca7ed766d57
   languageName: node
   linkType: hard
 
@@ -265,13 +270,13 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-syntax-jsx@npm:^7.7.2":
-  version: 7.21.4
-  resolution: "@babel/plugin-syntax-jsx@npm:7.21.4"
+  version: 7.23.3
+  resolution: "@babel/plugin-syntax-jsx@npm:7.23.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.20.2
+    "@babel/helper-plugin-utils": ^7.22.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: bb7309402a1d4e155f32aa0cf216e1fa8324d6c4cfd248b03280028a015a10e46b6efd6565f515f8913918a3602b39255999c06046f7d4b8a5106be2165d724a
+  checksum: 89037694314a74e7f0e7a9c8d3793af5bf6b23d80950c29b360db1c66859d67f60711ea437e70ad6b5b4b29affe17eababda841b6c01107c2b638e0493bafb4e
   languageName: node
   linkType: hard
 
@@ -353,66 +358,66 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-syntax-typescript@npm:^7.7.2":
-  version: 7.20.0
-  resolution: "@babel/plugin-syntax-typescript@npm:7.20.0"
+  version: 7.23.3
+  resolution: "@babel/plugin-syntax-typescript@npm:7.23.3"
   dependencies:
-    "@babel/helper-plugin-utils": ^7.19.0
+    "@babel/helper-plugin-utils": ^7.22.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 6189c0b5c32ba3c9a80a42338bd50719d783b20ef29b853d4f03929e971913d3cefd80184e924ae98ad6db09080be8fe6f1ffde9a6db8972523234f0274d36f7
+  checksum: abfad3a19290d258b028e285a1f34c9b8a0cbe46ef79eafed4ed7ffce11b5d0720b5e536c82f91cbd8442cde35a3dd8e861fa70366d87ff06fdc0d4756e30876
   languageName: node
   linkType: hard
 
 "@babel/plugin-transform-modules-commonjs@npm:^7.21.2":
-  version: 7.21.2
-  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.21.2"
+  version: 7.23.3
+  resolution: "@babel/plugin-transform-modules-commonjs@npm:7.23.3"
   dependencies:
-    "@babel/helper-module-transforms": ^7.21.2
-    "@babel/helper-plugin-utils": ^7.20.2
-    "@babel/helper-simple-access": ^7.20.2
+    "@babel/helper-module-transforms": ^7.23.3
+    "@babel/helper-plugin-utils": ^7.22.5
+    "@babel/helper-simple-access": ^7.22.5
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 65aa06e3e3792f39b99eb5f807034693ff0ecf80438580f7ae504f4c4448ef04147b1889ea5e6f60f3ad4a12ebbb57c6f1f979a249dadbd8d11fe22f4441918b
+  checksum: 720a231ceade4ae4d2632478db4e7fecf21987d444942b72d523487ac8d715ca97de6c8f415c71e939595e1a4776403e7dc24ed68fe9125ad4acf57753c9bff7
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.20.7, @babel/template@npm:^7.3.3":
-  version: 7.20.7
-  resolution: "@babel/template@npm:7.20.7"
+"@babel/template@npm:^7.22.15, @babel/template@npm:^7.3.3":
+  version: 7.22.15
+  resolution: "@babel/template@npm:7.22.15"
   dependencies:
-    "@babel/code-frame": ^7.18.6
-    "@babel/parser": ^7.20.7
-    "@babel/types": ^7.20.7
-  checksum: 2eb1a0ab8d415078776bceb3473d07ab746e6bb4c2f6ca46ee70efb284d75c4a32bb0cd6f4f4946dec9711f9c0780e8e5d64b743208deac6f8e9858afadc349e
+    "@babel/code-frame": ^7.22.13
+    "@babel/parser": ^7.22.15
+    "@babel/types": ^7.22.15
+  checksum: 1f3e7dcd6c44f5904c184b3f7fe280394b191f2fed819919ffa1e529c259d5b197da8981b6ca491c235aee8dbad4a50b7e31304aa531271cb823a4a24a0dd8fd
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.21.0, @babel/traverse@npm:^7.21.2, @babel/traverse@npm:^7.21.4, @babel/traverse@npm:^7.7.2":
-  version: 7.21.4
-  resolution: "@babel/traverse@npm:7.21.4"
+"@babel/traverse@npm:^7.23.2, @babel/traverse@npm:^7.23.3":
+  version: 7.23.3
+  resolution: "@babel/traverse@npm:7.23.3"
   dependencies:
-    "@babel/code-frame": ^7.21.4
-    "@babel/generator": ^7.21.4
-    "@babel/helper-environment-visitor": ^7.18.9
-    "@babel/helper-function-name": ^7.21.0
-    "@babel/helper-hoist-variables": ^7.18.6
-    "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.21.4
-    "@babel/types": ^7.21.4
+    "@babel/code-frame": ^7.22.13
+    "@babel/generator": ^7.23.3
+    "@babel/helper-environment-visitor": ^7.22.20
+    "@babel/helper-function-name": ^7.23.0
+    "@babel/helper-hoist-variables": ^7.22.5
+    "@babel/helper-split-export-declaration": ^7.22.6
+    "@babel/parser": ^7.23.3
+    "@babel/types": ^7.23.3
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: f22f067c2d9b6497abf3d4e53ea71f3aa82a21f2ed434dd69b8c5767f11f2a4c24c8d2f517d2312c9e5248e5c69395fdca1c95a2b3286122c75f5783ddb6f53c
+  checksum: f4e0c05f2f82368b9be7e1fed38cfcc2e1074967a8b76ac837b89661adbd391e99d0b1fd8c31215ffc3a04d2d5d7ee5e627914a09082db84ec5606769409fe2b
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.6, @babel/types@npm:^7.20.2, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.0, @babel/types@npm:^7.21.2, @babel/types@npm:^7.21.4, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
-  version: 7.21.4
-  resolution: "@babel/types@npm:7.21.4"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.3, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
+  version: 7.23.3
+  resolution: "@babel/types@npm:7.23.3"
   dependencies:
-    "@babel/helper-string-parser": ^7.19.4
-    "@babel/helper-validator-identifier": ^7.19.1
+    "@babel/helper-string-parser": ^7.22.5
+    "@babel/helper-validator-identifier": ^7.22.20
     to-fast-properties: ^2.0.0
-  checksum: 587bc55a91ce003b0f8aa10d70070f8006560d7dc0360dc0406d306a2cb2a10154e2f9080b9c37abec76907a90b330a536406cb75e6bdc905484f37b75c73219
+  checksum: b96f1ec495351aeb2a5f98dd494aafa17df02a351548ae96999460f35c933261c839002a34c1e83552ff0d9f5e94d0b5b8e105d38131c7c9b0f5a6588676f35d
   languageName: node
   linkType: hard
 
@@ -435,26 +440,26 @@ __metadata:
   linkType: hard
 
 "@eslint-community/regexpp@npm:^4.4.0":
-  version: 4.5.0
-  resolution: "@eslint-community/regexpp@npm:4.5.0"
-  checksum: 99c01335947dbd7f2129e954413067e217ccaa4e219fe0917b7d2bd96135789384b8fedbfb8eb09584d5130b27a7b876a7150ab7376f51b3a0c377d5ce026a10
+  version: 4.10.0
+  resolution: "@eslint-community/regexpp@npm:4.10.0"
+  checksum: 2a6e345429ea8382aaaf3a61f865cae16ed44d31ca917910033c02dc00d505d939f10b81e079fa14d43b51499c640138e153b7e40743c4c094d9df97d4e56f7b
   languageName: node
   linkType: hard
 
 "@eslint/eslintrc@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "@eslint/eslintrc@npm:2.0.2"
+  version: 2.1.3
+  resolution: "@eslint/eslintrc@npm:2.1.3"
   dependencies:
     ajv: ^6.12.4
     debug: ^4.3.2
-    espree: ^9.5.1
+    espree: ^9.6.0
     globals: ^13.19.0
     ignore: ^5.2.0
     import-fresh: ^3.2.1
     js-yaml: ^4.1.0
     minimatch: ^3.1.2
     strip-json-comments: ^3.1.1
-  checksum: cfcf5e12c7b2c4476482e7f12434e76eae16fcd163ee627309adb10b761e5caa4a4e52ed7be464423320ff3d11eca5b50de5bf8be3e25834222470835dd5c801
+  checksum: 5c6c3878192fe0ddffa9aff08b4e2f3bcc8f1c10d6449b7295a5f58b662019896deabfc19890455ffd7e60a5bd28d25d0eaefb2f78b2d230aae3879af92b89e5
   languageName: node
   linkType: hard
 
@@ -465,21 +470,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@gar/promisify@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "@gar/promisify@npm:1.1.3"
-  checksum: 4059f790e2d07bf3c3ff3e0fec0daa8144fe35c1f6e0111c9921bd32106adaa97a4ab096ad7dab1e28ee6a9060083c4d1a4ada42a7f5f3f7a96b8812e2b757c1
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/config-array@npm:^0.11.8":
-  version: 0.11.8
-  resolution: "@humanwhocodes/config-array@npm:0.11.8"
+  version: 0.11.13
+  resolution: "@humanwhocodes/config-array@npm:0.11.13"
   dependencies:
-    "@humanwhocodes/object-schema": ^1.2.1
+    "@humanwhocodes/object-schema": ^2.0.1
     debug: ^4.1.1
     minimatch: ^3.0.5
-  checksum: 0fd6b3c54f1674ce0a224df09b9c2f9846d20b9e54fabae1281ecfc04f2e6ad69bf19e1d6af6a28f88e8aa3990168b6cb9e1ef755868c3256a630605ec2cb1d3
+  checksum: f8ea57b0d7ed7f2d64cd3944654976829d9da91c04d9c860e18804729a33f7681f78166ef4c761850b8c324d362f7d53f14c5c44907a6b38b32c703ff85e4805
   languageName: node
   linkType: hard
 
@@ -490,10 +488,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "@humanwhocodes/object-schema@npm:1.2.1"
-  checksum: a824a1ec31591231e4bad5787641f59e9633827d0a2eaae131a288d33c9ef0290bd16fda8da6f7c0fcb014147865d12118df10db57f27f41e20da92369fcb3f1
+"@humanwhocodes/object-schema@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@humanwhocodes/object-schema@npm:2.0.1"
+  checksum: 24929487b1ed48795d2f08346a0116cc5ee4634848bce64161fb947109352c562310fd159fc64dda0e8b853307f5794605191a9547f7341158559ca3c8262a45
+  languageName: node
+  linkType: hard
+
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: ^5.1.2
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: ^7.0.1
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: ^8.1.0
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 4a473b9b32a7d4d3cfb7a614226e555091ff0c5a29a1734c28c72a182c2f6699b26fc6b5c2131dfd841e86b185aea714c72201d7c98c2fba5f17709333a67aeb
   languageName: node
   linkType: hard
 
@@ -517,50 +529,50 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/console@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/console@npm:29.5.0"
+"@jest/console@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/console@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     chalk: ^4.0.0
-    jest-message-util: ^29.5.0
-    jest-util: ^29.5.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
     slash: ^3.0.0
-  checksum: 9f4f4b8fabd1221361b7f2e92d4a90f5f8c2e2b29077249996ab3c8b7f765175ffee795368f8d6b5b2bb3adb32dc09319f7270c7c787b0d259e624e00e0f64a5
+  checksum: 0e3624e32c5a8e7361e889db70b170876401b7d70f509a2538c31d5cd50deb0c1ae4b92dc63fe18a0902e0a48c590c21d53787a0df41a52b34fa7cab96c384d6
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/core@npm:29.5.0"
+"@jest/core@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/core@npm:29.7.0"
   dependencies:
-    "@jest/console": ^29.5.0
-    "@jest/reporters": ^29.5.0
-    "@jest/test-result": ^29.5.0
-    "@jest/transform": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/console": ^29.7.0
+    "@jest/reporters": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     ansi-escapes: ^4.2.1
     chalk: ^4.0.0
     ci-info: ^3.2.0
     exit: ^0.1.2
     graceful-fs: ^4.2.9
-    jest-changed-files: ^29.5.0
-    jest-config: ^29.5.0
-    jest-haste-map: ^29.5.0
-    jest-message-util: ^29.5.0
-    jest-regex-util: ^29.4.3
-    jest-resolve: ^29.5.0
-    jest-resolve-dependencies: ^29.5.0
-    jest-runner: ^29.5.0
-    jest-runtime: ^29.5.0
-    jest-snapshot: ^29.5.0
-    jest-util: ^29.5.0
-    jest-validate: ^29.5.0
-    jest-watcher: ^29.5.0
+    jest-changed-files: ^29.7.0
+    jest-config: ^29.7.0
+    jest-haste-map: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-regex-util: ^29.6.3
+    jest-resolve: ^29.7.0
+    jest-resolve-dependencies: ^29.7.0
+    jest-runner: ^29.7.0
+    jest-runtime: ^29.7.0
+    jest-snapshot: ^29.7.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
+    jest-watcher: ^29.7.0
     micromatch: ^4.0.4
-    pretty-format: ^29.5.0
+    pretty-format: ^29.7.0
     slash: ^3.0.0
     strip-ansi: ^6.0.0
   peerDependencies:
@@ -568,77 +580,77 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 9e8f5243fe82d5a57f3971e1b96f320058df7c315328a3a827263f3b17f64be10c80f4a9c1b1773628b64d2de6d607c70b5b2d5bf13e7f5ad04223e9ef6aac06
+  checksum: af759c9781cfc914553320446ce4e47775ae42779e73621c438feb1e4231a5d4862f84b1d8565926f2d1aab29b3ec3dcfdc84db28608bdf5f29867124ebcfc0d
   languageName: node
   linkType: hard
 
-"@jest/environment@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/environment@npm:29.5.0"
+"@jest/environment@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/environment@npm:29.7.0"
   dependencies:
-    "@jest/fake-timers": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/fake-timers": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
-    jest-mock: ^29.5.0
-  checksum: 921de6325cd4817dec6685e5ff299b499b6379f3f9cf489b4b13588ee1f3820a0c77b49e6a087996b6de8f629f6f5251e636cba08d1bdb97d8071cc7d033c88a
+    jest-mock: ^29.7.0
+  checksum: 6fb398143b2543d4b9b8d1c6dbce83fa5247f84f550330604be744e24c2bd2178bb893657d62d1b97cf2f24baf85c450223f8237cccb71192c36a38ea2272934
   languageName: node
   linkType: hard
 
-"@jest/expect-utils@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/expect-utils@npm:29.5.0"
+"@jest/expect-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect-utils@npm:29.7.0"
   dependencies:
-    jest-get-type: ^29.4.3
-  checksum: c46fb677c88535cf83cf29f0a5b1f376c6a1109ddda266ad7da1a9cbc53cb441fa402dd61fc7b111ffc99603c11a9b3357ee41a1c0e035a58830bcb360871476
+    jest-get-type: ^29.6.3
+  checksum: 75eb177f3d00b6331bcaa057e07c0ccb0733a1d0a1943e1d8db346779039cb7f103789f16e502f888a3096fb58c2300c38d1f3748b36a7fa762eb6f6d1b160ed
   languageName: node
   linkType: hard
 
-"@jest/expect@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/expect@npm:29.5.0"
+"@jest/expect@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/expect@npm:29.7.0"
   dependencies:
-    expect: ^29.5.0
-    jest-snapshot: ^29.5.0
-  checksum: bd10e295111547e6339137107d83986ab48d46561525393834d7d2d8b2ae9d5626653f3f5e48e5c3fa742ac982e97bdf1f541b53b9e1d117a247b08e938527f6
+    expect: ^29.7.0
+    jest-snapshot: ^29.7.0
+  checksum: a01cb85fd9401bab3370618f4b9013b90c93536562222d920e702a0b575d239d74cecfe98010aaec7ad464f67cf534a353d92d181646a4b792acaa7e912ae55e
   languageName: node
   linkType: hard
 
-"@jest/fake-timers@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/fake-timers@npm:29.5.0"
+"@jest/fake-timers@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/fake-timers@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     "@sinonjs/fake-timers": ^10.0.2
     "@types/node": "*"
-    jest-message-util: ^29.5.0
-    jest-mock: ^29.5.0
-    jest-util: ^29.5.0
-  checksum: 69930c6922341f244151ec0d27640852ec96237f730fc024da1f53143d31b43cde75d92f9d8e5937981cdce3b31416abc3a7090a0d22c2377512c4a6613244ee
+    jest-message-util: ^29.7.0
+    jest-mock: ^29.7.0
+    jest-util: ^29.7.0
+  checksum: caf2bbd11f71c9241b458d1b5a66cbe95debc5a15d96442444b5d5c7ba774f523c76627c6931cca5e10e76f0d08761f6f1f01a608898f4751a0eee54fc3d8d00
   languageName: node
   linkType: hard
 
-"@jest/globals@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/globals@npm:29.5.0"
+"@jest/globals@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/globals@npm:29.7.0"
   dependencies:
-    "@jest/environment": ^29.5.0
-    "@jest/expect": ^29.5.0
-    "@jest/types": ^29.5.0
-    jest-mock: ^29.5.0
-  checksum: b309ab8f21b571a7c672608682e84bbdd3d2b554ddf81e4e32617fec0a69094a290ab42e3c8b2c66ba891882bfb1b8b2736720ea1285b3ad646d55c2abefedd9
+    "@jest/environment": ^29.7.0
+    "@jest/expect": ^29.7.0
+    "@jest/types": ^29.6.3
+    jest-mock: ^29.7.0
+  checksum: 97dbb9459135693ad3a422e65ca1c250f03d82b2a77f6207e7fa0edd2c9d2015fbe4346f3dc9ebff1678b9d8da74754d4d440b7837497f8927059c0642a22123
   languageName: node
   linkType: hard
 
-"@jest/reporters@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/reporters@npm:29.5.0"
+"@jest/reporters@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/reporters@npm:29.7.0"
   dependencies:
     "@bcoe/v8-coverage": ^0.2.3
-    "@jest/console": ^29.5.0
-    "@jest/test-result": ^29.5.0
-    "@jest/transform": ^29.5.0
-    "@jest/types": ^29.5.0
-    "@jridgewell/trace-mapping": ^0.3.15
+    "@jest/console": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
+    "@jridgewell/trace-mapping": ^0.3.18
     "@types/node": "*"
     chalk: ^4.0.0
     collect-v8-coverage: ^1.0.0
@@ -646,13 +658,13 @@ __metadata:
     glob: ^7.1.3
     graceful-fs: ^4.2.9
     istanbul-lib-coverage: ^3.0.0
-    istanbul-lib-instrument: ^5.1.0
+    istanbul-lib-instrument: ^6.0.0
     istanbul-lib-report: ^3.0.0
     istanbul-lib-source-maps: ^4.0.0
     istanbul-reports: ^3.1.3
-    jest-message-util: ^29.5.0
-    jest-util: ^29.5.0
-    jest-worker: ^29.5.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
+    jest-worker: ^29.7.0
     slash: ^3.0.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
@@ -662,88 +674,88 @@ __metadata:
   peerDependenciesMeta:
     node-notifier:
       optional: true
-  checksum: 481268aac9a4a75cc49c4df1273d6b111808dec815e9d009dad717c32383ebb0cebac76e820ad1ab44e207540e1c2fe1e640d44c4f262de92ab1933e057fdeeb
+  checksum: 7eadabd62cc344f629024b8a268ecc8367dba756152b761bdcb7b7e570a3864fc51b2a9810cd310d85e0a0173ef002ba4528d5ea0329fbf66ee2a3ada9c40455
   languageName: node
   linkType: hard
 
-"@jest/schemas@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "@jest/schemas@npm:29.4.3"
+"@jest/schemas@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/schemas@npm:29.6.3"
   dependencies:
-    "@sinclair/typebox": ^0.25.16
-  checksum: ac754e245c19dc39e10ebd41dce09040214c96a4cd8efa143b82148e383e45128f24599195ab4f01433adae4ccfbe2db6574c90db2862ccd8551a86704b5bebd
+    "@sinclair/typebox": ^0.27.8
+  checksum: 910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
   languageName: node
   linkType: hard
 
-"@jest/source-map@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "@jest/source-map@npm:29.4.3"
+"@jest/source-map@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/source-map@npm:29.6.3"
   dependencies:
-    "@jridgewell/trace-mapping": ^0.3.15
+    "@jridgewell/trace-mapping": ^0.3.18
     callsites: ^3.0.0
     graceful-fs: ^4.2.9
-  checksum: 2301d225145f8123540c0be073f35a80fd26a2f5e59550fd68525d8cea580fb896d12bf65106591ffb7366a8a19790076dbebc70e0f5e6ceb51f81827ed1f89c
+  checksum: bcc5a8697d471396c0003b0bfa09722c3cd879ad697eb9c431e6164e2ea7008238a01a07193dfe3cbb48b1d258eb7251f6efcea36f64e1ebc464ea3c03ae2deb
   languageName: node
   linkType: hard
 
-"@jest/test-result@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/test-result@npm:29.5.0"
+"@jest/test-result@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-result@npm:29.7.0"
   dependencies:
-    "@jest/console": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/console": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/istanbul-lib-coverage": ^2.0.0
     collect-v8-coverage: ^1.0.0
-  checksum: 2e8ff5242227ab960c520c3ea0f6544c595cc1c42fa3873c158e9f4f685f4ec9670ec08a4af94ae3885c0005a43550a9595191ffbc27a0965df27d9d98bbf901
+  checksum: 67b6317d526e335212e5da0e768e3b8ab8a53df110361b80761353ad23b6aea4432b7c5665bdeb87658ea373b90fb1afe02ed3611ef6c858c7fba377505057fa
   languageName: node
   linkType: hard
 
-"@jest/test-sequencer@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/test-sequencer@npm:29.5.0"
+"@jest/test-sequencer@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/test-sequencer@npm:29.7.0"
   dependencies:
-    "@jest/test-result": ^29.5.0
+    "@jest/test-result": ^29.7.0
     graceful-fs: ^4.2.9
-    jest-haste-map: ^29.5.0
+    jest-haste-map: ^29.7.0
     slash: ^3.0.0
-  checksum: eca34b4aeb2fda6dfb7f9f4b064c858a7adf64ec5c6091b6f4ed9d3c19549177cbadcf1c615c4c182688fa1cf085c8c55c3ca6eea40719a34554b0bf071d842e
+  checksum: 73f43599017946be85c0b6357993b038f875b796e2f0950487a82f4ebcb115fa12131932dd9904026b4ad8be131fe6e28bd8d0aa93b1563705185f9804bff8bd
   languageName: node
   linkType: hard
 
-"@jest/transform@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/transform@npm:29.5.0"
+"@jest/transform@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "@jest/transform@npm:29.7.0"
   dependencies:
     "@babel/core": ^7.11.6
-    "@jest/types": ^29.5.0
-    "@jridgewell/trace-mapping": ^0.3.15
+    "@jest/types": ^29.6.3
+    "@jridgewell/trace-mapping": ^0.3.18
     babel-plugin-istanbul: ^6.1.1
     chalk: ^4.0.0
     convert-source-map: ^2.0.0
     fast-json-stable-stringify: ^2.1.0
     graceful-fs: ^4.2.9
-    jest-haste-map: ^29.5.0
-    jest-regex-util: ^29.4.3
-    jest-util: ^29.5.0
+    jest-haste-map: ^29.7.0
+    jest-regex-util: ^29.6.3
+    jest-util: ^29.7.0
     micromatch: ^4.0.4
     pirates: ^4.0.4
     slash: ^3.0.0
     write-file-atomic: ^4.0.2
-  checksum: d55d604085c157cf5112e165ff5ac1fa788873b3b31265fb4734ca59892ee24e44119964cc47eb6d178dd9512bbb6c576d1e20e51a201ff4e24d31e818a1c92d
+  checksum: 0f8ac9f413903b3cb6d240102db848f2a354f63971ab885833799a9964999dd51c388162106a807f810071f864302cdd8e3f0c241c29ce02d85a36f18f3f40ab
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "@jest/types@npm:29.5.0"
+"@jest/types@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/types@npm:29.6.3"
   dependencies:
-    "@jest/schemas": ^29.4.3
+    "@jest/schemas": ^29.6.3
     "@types/istanbul-lib-coverage": ^2.0.0
     "@types/istanbul-reports": ^3.0.0
     "@types/node": "*"
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
-  checksum: 1811f94b19cf8a9460a289c4f056796cfc373480e0492692a6125a553cd1a63824bd846d7bb78820b7b6f758f6dd3c2d4558293bb676d541b2fa59c70fdf9d39
+  checksum: a0bcf15dbb0eca6bdd8ce61a3fb055349d40268622a7670a3b2eb3c3dbafe9eb26af59938366d520b86907b9505b0f9b29b85cec11579a9e580694b87cd90fcc
   languageName: node
   linkType: hard
 
@@ -758,10 +770,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
-  checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
+"@jridgewell/resolve-uri@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "@jridgewell/resolve-uri@npm:3.1.1"
+  checksum: f5b441fe7900eab4f9155b3b93f9800a916257f4e8563afbcd3b5a5337b55e52bd8ae6735453b1b745457d9f6cdb16d74cd6220bbdd98cf153239e13f6cbb653
   languageName: node
   linkType: hard
 
@@ -772,36 +784,36 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
-  version: 1.4.14
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
-  checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14":
+  version: 1.4.15
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.15"
+  checksum: b881c7e503db3fc7f3c1f35a1dd2655a188cc51a3612d76efc8a6eb74728bef5606e6758ee77423e564092b4a518aba569bbb21c9bac5ab7a35b0c6ae7e344c8
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.15, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.18
-  resolution: "@jridgewell/trace-mapping@npm:0.3.18"
+"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.17, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.9":
+  version: 0.3.20
+  resolution: "@jridgewell/trace-mapping@npm:0.3.20"
   dependencies:
-    "@jridgewell/resolve-uri": 3.1.0
-    "@jridgewell/sourcemap-codec": 1.4.14
-  checksum: 0572669f855260808c16fe8f78f5f1b4356463b11d3f2c7c0b5580c8ba1cbf4ae53efe9f627595830856e57dbac2325ac17eb0c3dd0ec42102e6f227cc289c02
+    "@jridgewell/resolve-uri": ^3.1.0
+    "@jridgewell/sourcemap-codec": ^1.4.14
+  checksum: cd1a7353135f385909468ff0cf20bdd37e59f2ee49a13a966dedf921943e222082c583ade2b579ff6cd0d8faafcb5461f253e1bf2a9f48fec439211fdbe788f5
   languageName: node
   linkType: hard
 
-"@noble/curves@npm:1.1.0":
-  version: 1.1.0
-  resolution: "@noble/curves@npm:1.1.0"
+"@noble/curves@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@noble/curves@npm:1.2.0"
   dependencies:
-    "@noble/hashes": 1.3.1
-  checksum: 2658cdd3f84f71079b4e3516c47559d22cf4b55c23ac8ee9d2b1f8e5b72916d9689e59820e0f9d9cb4a46a8423af5b56dc6bb7782405c88be06a015180508db5
+    "@noble/hashes": 1.3.2
+  checksum: bb798d7a66d8e43789e93bc3c2ddff91a1e19fdb79a99b86cd98f1e5eff0ee2024a2672902c2576ef3577b6f282f3b5c778bebd55761ddbb30e36bf275e83dd0
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:1.3.1":
-  version: 1.3.1
-  resolution: "@noble/hashes@npm:1.3.1"
-  checksum: 7fdefc0f7a0c1ec27acc6ff88841793e3f93ec4ce6b8a6a12bfc0dd70ae6b7c4c82fe305fdfeda1735d5ad4a9eebe761e6693b3d355689c559e91242f4bc95b1
+"@noble/hashes@npm:1.3.2, @noble/hashes@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "@noble/hashes@npm:1.3.2"
+  checksum: fe23536b436539d13f90e4b9be843cc63b1b17666a07634a2b1259dded6f490be3d050249e6af98076ea8f2ea0d56f578773c2197f2aa0eeaa5fba5bc18ba474
   languageName: node
   linkType: hard
 
@@ -832,465 +844,474 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@npmcli/fs@npm:^2.1.0":
-  version: 2.1.2
-  resolution: "@npmcli/fs@npm:2.1.2"
+"@npmcli/agent@npm:^2.0.0":
+  version: 2.2.0
+  resolution: "@npmcli/agent@npm:2.2.0"
   dependencies:
-    "@gar/promisify": ^1.1.3
+    agent-base: ^7.1.0
+    http-proxy-agent: ^7.0.0
+    https-proxy-agent: ^7.0.1
+    lru-cache: ^10.0.1
+    socks-proxy-agent: ^8.0.1
+  checksum: 3b25312edbdfaa4089af28e2d423b6f19838b945e47765b0c8174c1395c79d43c3ad6d23cb364b43f59fd3acb02c93e3b493f72ddbe3dfea04c86843a7311fc4
+  languageName: node
+  linkType: hard
+
+"@npmcli/fs@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@npmcli/fs@npm:3.1.0"
+  dependencies:
     semver: ^7.3.5
-  checksum: 405074965e72d4c9d728931b64d2d38e6ea12066d4fad651ac253d175e413c06fe4350970c783db0d749181da8fe49c42d3880bd1cbc12cd68e3a7964d820225
+  checksum: a50a6818de5fc557d0b0e6f50ec780a7a02ab8ad07e5ac8b16bf519e0ad60a144ac64f97d05c443c3367235d337182e1d012bbac0eb8dbae8dc7b40b193efd0e
   languageName: node
   linkType: hard
 
-"@npmcli/move-file@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@npmcli/move-file@npm:2.0.1"
-  dependencies:
-    mkdirp: ^1.0.4
-    rimraf: ^3.0.2
-  checksum: 52dc02259d98da517fae4cb3a0a3850227bdae4939dda1980b788a7670636ca2b4a01b58df03dd5f65c1e3cb70c50fa8ce5762b582b3f499ec30ee5ce1fd9380
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 6ad6a00fc4f2f2cfc6bff76fb1d88b8ee20bc0601e18ebb01b6d4be583733a860239a521a7fbca73b612e66705078809483549d2b18f370eb346c5155c8e4a0f
   languageName: node
   linkType: hard
 
-"@polkadot/api-augment@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/api-augment@npm:10.9.1"
+"@polkadot/api-augment@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/api-augment@npm:10.10.1"
   dependencies:
-    "@polkadot/api-base": 10.9.1
-    "@polkadot/rpc-augment": 10.9.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-augment": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/util": ^12.3.1
-    tslib: ^2.5.3
-  checksum: b0aeed5ebf640c58a252a29a33f12d4c39d0dcdf10b875501012c3b4b05955ed8be85efbf75e17ad237a561e1171821979ffdddf7e6a64cb0806badb2752c190
+    "@polkadot/api-base": 10.10.1
+    "@polkadot/rpc-augment": 10.10.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-augment": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/util": ^12.5.1
+    tslib: ^2.6.2
+  checksum: 16ca2d71215019faba506b6dc455ef15ea1eec8b97bd146aef49a04ae15dc9246405540219bfbea36027ee50c5dbb15885296c30ee98908afdd7a56626efd06c
   languageName: node
   linkType: hard
 
-"@polkadot/api-base@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/api-base@npm:10.9.1"
+"@polkadot/api-base@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/api-base@npm:10.10.1"
   dependencies:
-    "@polkadot/rpc-core": 10.9.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/util": ^12.3.1
+    "@polkadot/rpc-core": 10.10.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/util": ^12.5.1
     rxjs: ^7.8.1
-    tslib: ^2.5.3
-  checksum: a761f4ade747a295c16b7e6f24c1bb93e1736aa7fa9f1cb3c651c84d02a99cc62658e83326fa339882423966a55bf0046b74a69a1a4e4567c8d6c1c4db4eb306
+    tslib: ^2.6.2
+  checksum: 374a4378484817b29c52908a9dac649b4d4f231db21a0b0b3d3ec3331c7b9b9c374c103b5e64d028c212b8ab3eb98244cd760d20e2fe5f46a8fdc1d923555047
   languageName: node
   linkType: hard
 
-"@polkadot/api-derive@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/api-derive@npm:10.9.1"
+"@polkadot/api-derive@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/api-derive@npm:10.10.1"
   dependencies:
-    "@polkadot/api": 10.9.1
-    "@polkadot/api-augment": 10.9.1
-    "@polkadot/api-base": 10.9.1
-    "@polkadot/rpc-core": 10.9.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/util": ^12.3.1
-    "@polkadot/util-crypto": ^12.3.1
+    "@polkadot/api": 10.10.1
+    "@polkadot/api-augment": 10.10.1
+    "@polkadot/api-base": 10.10.1
+    "@polkadot/rpc-core": 10.10.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/util": ^12.5.1
+    "@polkadot/util-crypto": ^12.5.1
     rxjs: ^7.8.1
-    tslib: ^2.5.3
-  checksum: 072a43bcc55787beb6c29afe0f011c03cdde3a9b6ac38d972d0b13ff93a1e14198d769a926edfd324c3947735dd8c8fcb7a61629409322230fd8559e7c17a1d7
+    tslib: ^2.6.2
+  checksum: ff0f016d39aa73f55a881927e6ae3dd75c2a81fe4095cdda5e558f420d815a12c204e6a2082acbef2c74867b810d41ef349de2b7924d46957be7260b71fb1512
   languageName: node
   linkType: hard
 
-"@polkadot/api@npm:10.9.1, @polkadot/api@npm:^10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/api@npm:10.9.1"
+"@polkadot/api@npm:10.10.1, @polkadot/api@npm:^10.9.1":
+  version: 10.10.1
+  resolution: "@polkadot/api@npm:10.10.1"
   dependencies:
-    "@polkadot/api-augment": 10.9.1
-    "@polkadot/api-base": 10.9.1
-    "@polkadot/api-derive": 10.9.1
-    "@polkadot/keyring": ^12.3.1
-    "@polkadot/rpc-augment": 10.9.1
-    "@polkadot/rpc-core": 10.9.1
-    "@polkadot/rpc-provider": 10.9.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-augment": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/types-create": 10.9.1
-    "@polkadot/types-known": 10.9.1
-    "@polkadot/util": ^12.3.1
-    "@polkadot/util-crypto": ^12.3.1
+    "@polkadot/api-augment": 10.10.1
+    "@polkadot/api-base": 10.10.1
+    "@polkadot/api-derive": 10.10.1
+    "@polkadot/keyring": ^12.5.1
+    "@polkadot/rpc-augment": 10.10.1
+    "@polkadot/rpc-core": 10.10.1
+    "@polkadot/rpc-provider": 10.10.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-augment": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/types-create": 10.10.1
+    "@polkadot/types-known": 10.10.1
+    "@polkadot/util": ^12.5.1
+    "@polkadot/util-crypto": ^12.5.1
     eventemitter3: ^5.0.1
     rxjs: ^7.8.1
-    tslib: ^2.5.3
-  checksum: 6b37d9bacf0599bb7c385ddefca929547299a6f1d242ce3215f8480672297c81ec30c251bc9aac3889c5956bd9ef3918d69364819861eec308f4aa347c08110d
+    tslib: ^2.6.2
+  checksum: de1aa727b63fb921854840fe2d18b55b99f512f4d3e08d3b895fceea7891f6dd0febe6aa5fb7b1778494c78d6a6a7ebd17d426ba2e3df459aa974b7bb8fee19c
   languageName: node
   linkType: hard
 
-"@polkadot/keyring@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/keyring@npm:12.3.2"
+"@polkadot/keyring@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/keyring@npm:12.5.1"
   dependencies:
-    "@polkadot/util": 12.3.2
-    "@polkadot/util-crypto": 12.3.2
-    tslib: ^2.5.3
+    "@polkadot/util": 12.5.1
+    "@polkadot/util-crypto": 12.5.1
+    tslib: ^2.6.2
   peerDependencies:
-    "@polkadot/util": 12.3.2
-    "@polkadot/util-crypto": 12.3.2
-  checksum: fa1238052ab6a93f4d97c0351e908ab866c128eb9089fe8829af4a4603be3d97dd964bb2b95c22248cfd120800bbc37aa93e03221ecca4f97c36818d452b44db
+    "@polkadot/util": 12.5.1
+    "@polkadot/util-crypto": 12.5.1
+  checksum: d659e5980e4cd6b68f91448a817306666530c033410c713854547dbbbecacb7362346c3ada6c5ab9dc71437c3cf002f064d7db40d1588637b96e84ff8f35dcf4
   languageName: node
   linkType: hard
 
-"@polkadot/networks@npm:12.3.2, @polkadot/networks@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/networks@npm:12.3.2"
+"@polkadot/networks@npm:12.5.1, @polkadot/networks@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/networks@npm:12.5.1"
   dependencies:
-    "@polkadot/util": 12.3.2
-    "@substrate/ss58-registry": ^1.40.0
-    tslib: ^2.5.3
-  checksum: 54d5aa2a90b761a200bf0cf492f1c53cbbd555067f9486542997097640b0813e46675837e83225cee8ab4e816bcae12cdc046f07b5869930ab1e694b1e6e3cec
+    "@polkadot/util": 12.5.1
+    "@substrate/ss58-registry": ^1.43.0
+    tslib: ^2.6.2
+  checksum: f8c64684f6806365c1aded6ebca52432050cc8caacd067faf339b2f37497b63b13cebb689f7b0f9c62a890566383cf1931552da82815cc52baa2166fb1772a43
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-augment@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/rpc-augment@npm:10.9.1"
+"@polkadot/rpc-augment@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/rpc-augment@npm:10.10.1"
   dependencies:
-    "@polkadot/rpc-core": 10.9.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/util": ^12.3.1
-    tslib: ^2.5.3
-  checksum: 4f7b090be6d88ef6a56679a80da856bf007994e2142e16fbac6030132789b5a2411421650935ed4b18334afca399edfc0387135731836c6d9f8420acf510f11b
+    "@polkadot/rpc-core": 10.10.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/util": ^12.5.1
+    tslib: ^2.6.2
+  checksum: d19ff447fea298387e8af9b7ac44c8eb8438b0e939608414c0ddc642fbd5c2d657d199a66741d9e330f28aa587486a163238cdf058cc69994178b121a0d26738
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-core@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/rpc-core@npm:10.9.1"
+"@polkadot/rpc-core@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/rpc-core@npm:10.10.1"
   dependencies:
-    "@polkadot/rpc-augment": 10.9.1
-    "@polkadot/rpc-provider": 10.9.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/util": ^12.3.1
+    "@polkadot/rpc-augment": 10.10.1
+    "@polkadot/rpc-provider": 10.10.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/util": ^12.5.1
     rxjs: ^7.8.1
-    tslib: ^2.5.3
-  checksum: 538a207f5d321b4b18b0580da438598dd78e496dbc7069a776abcc39ede36903981ba2b9897eea73ecfe2f48a4d0cbd5b5cd738b3184f5c333709e6f4603f22a
+    tslib: ^2.6.2
+  checksum: 5ab21029fbafa13e50bb48161a82c023f7015b633e258b76c2cff25bf648d7f69baf18efc291ebec8dd635b38da8223e853e15b53478268b1f6b40d2ab0b3e09
   languageName: node
   linkType: hard
 
-"@polkadot/rpc-provider@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/rpc-provider@npm:10.9.1"
+"@polkadot/rpc-provider@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/rpc-provider@npm:10.10.1"
   dependencies:
-    "@polkadot/keyring": ^12.3.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-support": 10.9.1
-    "@polkadot/util": ^12.3.1
-    "@polkadot/util-crypto": ^12.3.1
-    "@polkadot/x-fetch": ^12.3.1
-    "@polkadot/x-global": ^12.3.1
-    "@polkadot/x-ws": ^12.3.1
-    "@substrate/connect": 0.7.26
+    "@polkadot/keyring": ^12.5.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-support": 10.10.1
+    "@polkadot/util": ^12.5.1
+    "@polkadot/util-crypto": ^12.5.1
+    "@polkadot/x-fetch": ^12.5.1
+    "@polkadot/x-global": ^12.5.1
+    "@polkadot/x-ws": ^12.5.1
+    "@substrate/connect": 0.7.33
     eventemitter3: ^5.0.1
-    mock-socket: ^9.2.1
-    nock: ^13.3.1
-    tslib: ^2.5.3
+    mock-socket: ^9.3.1
+    nock: ^13.3.4
+    tslib: ^2.6.2
   dependenciesMeta:
     "@substrate/connect":
       optional: true
-  checksum: 4521ba64a1e69ed323910796a4598755e8101704aae3be33b6c363be4ebb9ea1a99ced17b8cd9fa3ab15abf5900e1055279f532f47b8472e8a143a299bfa046d
+  checksum: 44147ad7ce4bb0fccf5272bbe56b3b65c1e907f02109c8e18a5b5da8c658f84c1d7741c5e6878adacd06514254b0a7fb8254d5a222f55f25f7a573b2ba970449
   languageName: node
   linkType: hard
 
-"@polkadot/types-augment@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/types-augment@npm:10.9.1"
+"@polkadot/types-augment@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/types-augment@npm:10.10.1"
   dependencies:
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/util": ^12.3.1
-    tslib: ^2.5.3
-  checksum: d643f83ab0a9498267037d95b878fa4e3b0087882195c3bd609038e8c934a092d9c82f7164ac97989305805aabe0d9186736c50a372498c81c22b3d7f4cfcccb
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/util": ^12.5.1
+    tslib: ^2.6.2
+  checksum: 40440fc2a9568c9e636f478c4f191cbb38f07256f4db7f1bb9bdbcf0b928280315afee2843090a006a3dfd16e000f22dd6a9bd5687dd6400a1fc3dcd6ee59a25
   languageName: node
   linkType: hard
 
-"@polkadot/types-codec@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/types-codec@npm:10.9.1"
+"@polkadot/types-codec@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/types-codec@npm:10.10.1"
   dependencies:
-    "@polkadot/util": ^12.3.1
-    "@polkadot/x-bigint": ^12.3.1
-    tslib: ^2.5.3
-  checksum: ac11b770fa4328f55daf6dd78fc8fc4d6906fb0d4b2bf92eaece58332c74f2b178d598a310a6dd068c72856acefddf5f7d23cac56991fa12f61d6853fb73d582
+    "@polkadot/util": ^12.5.1
+    "@polkadot/x-bigint": ^12.5.1
+    tslib: ^2.6.2
+  checksum: 17ceb561e6a82784febd5c8b0219050a9b8aeeb766ffbae8255ab586120063ca9fea1c89df776047e861aba87e43048a8060d5c469bcd42c169830a69416d62f
   languageName: node
   linkType: hard
 
-"@polkadot/types-create@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/types-create@npm:10.9.1"
+"@polkadot/types-create@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/types-create@npm:10.10.1"
   dependencies:
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/util": ^12.3.1
-    tslib: ^2.5.3
-  checksum: 43f8fbd70a7891d6b49f1edb00b4a918c21924f2c1e44eb81ef7c9327e1fcc7eac65dbc2a9d0e3ba49079fdddda5498115e47f5fd99ec2a91f79c7f305bf553a
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/util": ^12.5.1
+    tslib: ^2.6.2
+  checksum: 1dedef441218a0786774033c2d587b8ccdf184a72da671c7da70ced9f765073bfec4a15d8937b00d5d50cb0eb1b4bd25886ace3f7e024c95b46f58a1c318efd1
   languageName: node
   linkType: hard
 
-"@polkadot/types-known@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/types-known@npm:10.9.1"
+"@polkadot/types-known@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/types-known@npm:10.10.1"
   dependencies:
-    "@polkadot/networks": ^12.3.1
-    "@polkadot/types": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/types-create": 10.9.1
-    "@polkadot/util": ^12.3.1
-    tslib: ^2.5.3
-  checksum: 8a3dd0dead1759112b9011c5ff47bf9fa0f5a00d0d5cba841d724494a9434a2f565fad8ab654ae8cc3949a10c28f3966034bfc23e493b7cc373d3532de508953
+    "@polkadot/networks": ^12.5.1
+    "@polkadot/types": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/types-create": 10.10.1
+    "@polkadot/util": ^12.5.1
+    tslib: ^2.6.2
+  checksum: 25489967fcd6022f11a64c20884dd1ef49494f3b3e514034a08cc07f61267121adf8b96b307edc3381c445de58842d515aa8440ee888bc37120775deffae671a
   languageName: node
   linkType: hard
 
-"@polkadot/types-support@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/types-support@npm:10.9.1"
+"@polkadot/types-support@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/types-support@npm:10.10.1"
   dependencies:
-    "@polkadot/util": ^12.3.1
-    tslib: ^2.5.3
-  checksum: f5df33f215f529c33d4fd7ad7d6877a4567954488971c2986da416b6578ccb6d5c6eeadab4602abe0e3ce17373cdd6de0ce6f09529852b6e2fd6bc28b9183f9b
+    "@polkadot/util": ^12.5.1
+    tslib: ^2.6.2
+  checksum: 391857f39463fcc9bbc34a6bafd191e12eb3fd28f386d4094cc3cdcbcd0fcc8799c6e99a49b0e634c6a1b78d07188eb6e1e01299f55df2593c3f30fcb241631c
   languageName: node
   linkType: hard
 
-"@polkadot/types@npm:10.9.1":
-  version: 10.9.1
-  resolution: "@polkadot/types@npm:10.9.1"
+"@polkadot/types@npm:10.10.1":
+  version: 10.10.1
+  resolution: "@polkadot/types@npm:10.10.1"
   dependencies:
-    "@polkadot/keyring": ^12.3.1
-    "@polkadot/types-augment": 10.9.1
-    "@polkadot/types-codec": 10.9.1
-    "@polkadot/types-create": 10.9.1
-    "@polkadot/util": ^12.3.1
-    "@polkadot/util-crypto": ^12.3.1
+    "@polkadot/keyring": ^12.5.1
+    "@polkadot/types-augment": 10.10.1
+    "@polkadot/types-codec": 10.10.1
+    "@polkadot/types-create": 10.10.1
+    "@polkadot/util": ^12.5.1
+    "@polkadot/util-crypto": ^12.5.1
     rxjs: ^7.8.1
-    tslib: ^2.5.3
-  checksum: c9b0873b52f33c5d7913bc1e474c67d797411ac592c10af987dfecfee7480aeda02b9fc100ff506bc8af704a7fc239162a8ec7eec580e2e7a62ac7f7b95f3900
+    tslib: ^2.6.2
+  checksum: 58b8b026e25f8156f270bdd240a2e384b64db93a6abe7c15abe9acdc2ce06a724328a8bf4d5b3047f5e398eef3d4961447d8511c52105c082dddd1b9d8fb0cb4
   languageName: node
   linkType: hard
 
-"@polkadot/util-crypto@npm:12.3.2, @polkadot/util-crypto@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/util-crypto@npm:12.3.2"
+"@polkadot/util-crypto@npm:12.5.1, @polkadot/util-crypto@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/util-crypto@npm:12.5.1"
   dependencies:
-    "@noble/curves": 1.1.0
-    "@noble/hashes": 1.3.1
-    "@polkadot/networks": 12.3.2
-    "@polkadot/util": 12.3.2
-    "@polkadot/wasm-crypto": ^7.2.1
-    "@polkadot/wasm-util": ^7.2.1
-    "@polkadot/x-bigint": 12.3.2
-    "@polkadot/x-randomvalues": 12.3.2
-    "@scure/base": 1.1.1
-    tslib: ^2.5.3
+    "@noble/curves": ^1.2.0
+    "@noble/hashes": ^1.3.2
+    "@polkadot/networks": 12.5.1
+    "@polkadot/util": 12.5.1
+    "@polkadot/wasm-crypto": ^7.2.2
+    "@polkadot/wasm-util": ^7.2.2
+    "@polkadot/x-bigint": 12.5.1
+    "@polkadot/x-randomvalues": 12.5.1
+    "@scure/base": ^1.1.3
+    tslib: ^2.6.2
   peerDependencies:
-    "@polkadot/util": 12.3.2
-  checksum: 5c4053b4172ce138b4df5d61dc83905759fde6816ddf1d1aea7389bf4e9bba6d0a110e356eb9a3d76065393b787eb9797428966a1da36bb3b13567bdb67d5671
+    "@polkadot/util": 12.5.1
+  checksum: 4efb5ca6e48f7457d8dcfa02ac9f581ce23a90ba9e72c8f6fd7649296e92dcb3dfa3d2bdd0b5ed68b81bf15e32aabef34f60d47851249d8859dba7ebeb63501f
   languageName: node
   linkType: hard
 
-"@polkadot/util@npm:12.3.2, @polkadot/util@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/util@npm:12.3.2"
+"@polkadot/util@npm:12.5.1, @polkadot/util@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/util@npm:12.5.1"
   dependencies:
-    "@polkadot/x-bigint": 12.3.2
-    "@polkadot/x-global": 12.3.2
-    "@polkadot/x-textdecoder": 12.3.2
-    "@polkadot/x-textencoder": 12.3.2
+    "@polkadot/x-bigint": 12.5.1
+    "@polkadot/x-global": 12.5.1
+    "@polkadot/x-textdecoder": 12.5.1
+    "@polkadot/x-textencoder": 12.5.1
     "@types/bn.js": ^5.1.1
     bn.js: ^5.2.1
-    tslib: ^2.5.3
-  checksum: 53b5ac58bbae5d3aa867e0f1483fc0fd40e811919e573051225ab32e031ab81649be0f969ecb7c7a094c588f381d8ec1fa67160a65e3e2ef2180afe5677136cc
+    tslib: ^2.6.2
+  checksum: 955d41c01cb3c7da72c4f5f8faed13e1af1fa9603a3a1dd9f282eb69b5ebbffb889e76c595d1252ff5f9665cb3c55f1a96f908b020dc79356f92b2d5ce1aa81e
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-bridge@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/wasm-bridge@npm:7.2.1"
+"@polkadot/wasm-bridge@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@polkadot/wasm-bridge@npm:7.3.1"
   dependencies:
-    "@polkadot/wasm-util": 7.2.1
-    tslib: ^2.5.0
+    "@polkadot/wasm-util": 7.3.1
+    tslib: ^2.6.2
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: 6f4d255665f6c1552df9abcf8e99ee36b220c446c74e4da7ac21f3c578c3736695db41e816ef83226d98231c535df8daea6d2266c3090bdd8e7609fa87447de9
+  checksum: 0a0f644fe68ca74f8ba19910f6777870960e64d86c868b438d9bc6bd2ebd78eec0692c1ae096b5a70d2ebf247d414c47e1143a1a7c1a5fcd143ad0c9ed64fe4c
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-asmjs@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/wasm-crypto-asmjs@npm:7.2.1"
+"@polkadot/wasm-crypto-asmjs@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@polkadot/wasm-crypto-asmjs@npm:7.3.1"
   dependencies:
-    tslib: ^2.5.0
+    tslib: ^2.6.2
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 9d7f2ac6f73cc2ed390941a35426763c73e6f20374eb11ed60b880a6f716c2773cb1fe1cddb9416ab669c75b25b7d99be25c8c91886bb676d6faf9b4658f8fd7
+  checksum: c4930ca070bf695dcc341f51861f0c8a5f11c2efdefbc5682b7d7bb3221c4d7b4f4ee26fe4b7b05f7fd344f9d119485e5b4c813dc1b540663fe477317c0616bc
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-crypto-init@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/wasm-crypto-init@npm:7.2.1"
+"@polkadot/wasm-crypto-init@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@polkadot/wasm-crypto-init@npm:7.3.1"
   dependencies:
-    "@polkadot/wasm-bridge": 7.2.1
-    "@polkadot/wasm-crypto-asmjs": 7.2.1
-    "@polkadot/wasm-crypto-wasm": 7.2.1
-    "@polkadot/wasm-util": 7.2.1
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-    "@polkadot/x-randomvalues": "*"
-  checksum: 97105a9e846e97d9d678526e5dd1b491cd71e705c759a8ace9e0e9a54aa045b2b512bdcdd524ea6684963b6cb0fc0a44043d2198bc680c893e1feaaf4d860e76
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto-wasm@npm:7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/wasm-crypto-wasm@npm:7.2.1"
-  dependencies:
-    "@polkadot/wasm-util": 7.2.1
-    tslib: ^2.5.0
-  peerDependencies:
-    "@polkadot/util": "*"
-  checksum: f000fab2fc682a4d4d2029b483701a64091b9be0d75df82f3337a48d65ffdac8d76c828f46810cb5aae6b9ec77bdf3963ae8b8668106ea9e5c0c19f57637655d
-  languageName: node
-  linkType: hard
-
-"@polkadot/wasm-crypto@npm:^7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/wasm-crypto@npm:7.2.1"
-  dependencies:
-    "@polkadot/wasm-bridge": 7.2.1
-    "@polkadot/wasm-crypto-asmjs": 7.2.1
-    "@polkadot/wasm-crypto-init": 7.2.1
-    "@polkadot/wasm-crypto-wasm": 7.2.1
-    "@polkadot/wasm-util": 7.2.1
-    tslib: ^2.5.0
+    "@polkadot/wasm-bridge": 7.3.1
+    "@polkadot/wasm-crypto-asmjs": 7.3.1
+    "@polkadot/wasm-crypto-wasm": 7.3.1
+    "@polkadot/wasm-util": 7.3.1
+    tslib: ^2.6.2
   peerDependencies:
     "@polkadot/util": "*"
     "@polkadot/x-randomvalues": "*"
-  checksum: f42f2bc34cf76d1438893f72a233080196c9a95dd3c53444f582150c7f56b75c80b8b8b9b4a3d9015438a6f7438c6e40def46b1fe7ce3a367bcd280f2bf29c98
+  checksum: 64de1573766c6ccb5a41d0b60c42654ed45ff80ac74742fe75855d37734b6a23a929a7f1c8495e14cabf4626e72500c7ae3e8f22cb5c99372d8866b729d0f189
   languageName: node
   linkType: hard
 
-"@polkadot/wasm-util@npm:7.2.1, @polkadot/wasm-util@npm:^7.2.1":
-  version: 7.2.1
-  resolution: "@polkadot/wasm-util@npm:7.2.1"
+"@polkadot/wasm-crypto-wasm@npm:7.3.1":
+  version: 7.3.1
+  resolution: "@polkadot/wasm-crypto-wasm@npm:7.3.1"
   dependencies:
-    tslib: ^2.5.0
+    "@polkadot/wasm-util": 7.3.1
+    tslib: ^2.6.2
   peerDependencies:
     "@polkadot/util": "*"
-  checksum: 8df30296664807c27b01d37a3e9f124fdc22aef61e633b1a538a7c533f485a2aa756c43e67aac8d0c8383273432783b78e5528c5bc1ffcf508e7faaa5009e618
+  checksum: 265a3260a09271b5a614cfa33f5e70602d36af0e737f1acf595c72867acdf60dc694aad5ae77413af96c801d882932f1da581bda83d2bcbf559f79f04c865009
   languageName: node
   linkType: hard
 
-"@polkadot/x-bigint@npm:12.3.2, @polkadot/x-bigint@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/x-bigint@npm:12.3.2"
+"@polkadot/wasm-crypto@npm:^7.2.2":
+  version: 7.3.1
+  resolution: "@polkadot/wasm-crypto@npm:7.3.1"
   dependencies:
-    "@polkadot/x-global": 12.3.2
-    tslib: ^2.5.3
-  checksum: 0c88e28f1072cd2e5bc0efa3b8ede13f1084c8d56bb78a91f031ee128e572a5f74faa99c22be64182950194647a2081899dcfaa7e7ab16bbb3f9b9761515eb85
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-fetch@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/x-fetch@npm:12.3.2"
-  dependencies:
-    "@polkadot/x-global": 12.3.2
-    node-fetch: ^3.3.1
-    tslib: ^2.5.3
-  checksum: 063bae74b5c197c5b2c603cc761aa830fe96a196d8cc0d9bc428670d1d0fa44d053d96b463783a9d989ec1032bda6397cb4f8772e65fed9d5f1089d04d7b54dc
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-global@npm:12.3.2, @polkadot/x-global@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/x-global@npm:12.3.2"
-  dependencies:
-    tslib: ^2.5.3
-  checksum: 85bd4a3e89bacdf8159fe505b875fad0ce8cfc5ba65377b14981166d973339a2fa3128582112af51dfecea4b68b0501a960056138110195b5bea69c3a8c88e11
-  languageName: node
-  linkType: hard
-
-"@polkadot/x-randomvalues@npm:12.3.2":
-  version: 12.3.2
-  resolution: "@polkadot/x-randomvalues@npm:12.3.2"
-  dependencies:
-    "@polkadot/x-global": 12.3.2
-    tslib: ^2.5.3
+    "@polkadot/wasm-bridge": 7.3.1
+    "@polkadot/wasm-crypto-asmjs": 7.3.1
+    "@polkadot/wasm-crypto-init": 7.3.1
+    "@polkadot/wasm-crypto-wasm": 7.3.1
+    "@polkadot/wasm-util": 7.3.1
+    tslib: ^2.6.2
   peerDependencies:
-    "@polkadot/util": 12.3.2
+    "@polkadot/util": "*"
+    "@polkadot/x-randomvalues": "*"
+  checksum: 704a7d6edc35e5cb0b5bdbbc6e77694690f8a03bef1ad12ffb39e0ea32a2b8edae424745e7b5e4fb8877089425349978306895a01da895e1004a9ea554817710
+  languageName: node
+  linkType: hard
+
+"@polkadot/wasm-util@npm:7.3.1, @polkadot/wasm-util@npm:^7.2.2":
+  version: 7.3.1
+  resolution: "@polkadot/wasm-util@npm:7.3.1"
+  dependencies:
+    tslib: ^2.6.2
+  peerDependencies:
+    "@polkadot/util": "*"
+  checksum: 6c412f9f69ffb6fea24705160567c7f76a3ed90507fd9d432bab1ecf73ec0f25bb5a95474011d894ce269264e9c590b6071e2d8ffb4503a5eb3bbfda954ba374
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-bigint@npm:12.5.1, @polkadot/x-bigint@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-bigint@npm:12.5.1"
+  dependencies:
+    "@polkadot/x-global": 12.5.1
+    tslib: ^2.6.2
+  checksum: 295d00b17860196c43ac4957ffb052ca68bb4319990876238e3f0925ca6ca9106810204136315491116a11a277d8a1e1fae65cc43a168505ee5a69a27404d2e0
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-fetch@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-fetch@npm:12.5.1"
+  dependencies:
+    "@polkadot/x-global": 12.5.1
+    node-fetch: ^3.3.2
+    tslib: ^2.6.2
+  checksum: 26b24b09f9074c181f53f13ea17a1389e823b262a956a28fddf609ba7d177a1cde3cd4db28e8e38320b207adcc675ac868dadfaeafe9cf3998a3861f02ee43d7
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-global@npm:12.5.1, @polkadot/x-global@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-global@npm:12.5.1"
+  dependencies:
+    tslib: ^2.6.2
+  checksum: d45e3d6096674b7495992c6e45cf1a284db545c16107ba9adae241d6aefe13c27adfaf93d58a3079e6a6b63acb221eb3181c7f55dc34124b24b542154724c506
+  languageName: node
+  linkType: hard
+
+"@polkadot/x-randomvalues@npm:12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-randomvalues@npm:12.5.1"
+  dependencies:
+    "@polkadot/x-global": 12.5.1
+    tslib: ^2.6.2
+  peerDependencies:
+    "@polkadot/util": 12.5.1
     "@polkadot/wasm-util": "*"
-  checksum: 809e0429a0e6f285ad0e2bf0b7dbe1f8b05cc3aacb9f7d8593fd0702e2f23ef7e3aab861d1493528670712c03426b36aacecf43b6fc97cc4036ee1ae41fa04dc
+  checksum: 52ee4b4206a98cac9e97e3d194db01fb4a540046672784442926478eaa2b2a74cebae59d10432671f544d72df5d623aedf57c301bcf447a4c72688ec3cb82fd5
   languageName: node
   linkType: hard
 
-"@polkadot/x-textdecoder@npm:12.3.2":
-  version: 12.3.2
-  resolution: "@polkadot/x-textdecoder@npm:12.3.2"
+"@polkadot/x-textdecoder@npm:12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-textdecoder@npm:12.5.1"
   dependencies:
-    "@polkadot/x-global": 12.3.2
-    tslib: ^2.5.3
-  checksum: d5b8810b325bad317e10f631f0d7c9c91e0db92ca37db7935e41569df8c926534aa4668a14b9b12d1d5263569239665bca8ad0089bf3b789a09dbf6f0303108f
+    "@polkadot/x-global": 12.5.1
+    tslib: ^2.6.2
+  checksum: 202a9e216e9b89cc74012fa3f6c96eeb368dc3e6fa3c943f28c37c20941a6c678506cbc136946e9ff100123aa43846eab7765af074de94dfdd23f4ce2242c794
   languageName: node
   linkType: hard
 
-"@polkadot/x-textencoder@npm:12.3.2":
-  version: 12.3.2
-  resolution: "@polkadot/x-textencoder@npm:12.3.2"
+"@polkadot/x-textencoder@npm:12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-textencoder@npm:12.5.1"
   dependencies:
-    "@polkadot/x-global": 12.3.2
-    tslib: ^2.5.3
-  checksum: c383fab93904f6c47f87b1b111a002542c701844c82a62ead6bbbd19f23b58f87ebd47ec8578de7ed18b45668b43491cc60e44c343b9d59e80696e5c9357e962
+    "@polkadot/x-global": 12.5.1
+    tslib: ^2.6.2
+  checksum: 7a8d99d203cbd9537e55405d737667ae8cd9ad40a9e3de52f2ef7580a23d27ebf7f7c52da4e0eca6ca34dc97aae33a97bab36afb54aaa7714f54a31931f94113
   languageName: node
   linkType: hard
 
-"@polkadot/x-ws@npm:^12.3.1":
-  version: 12.3.2
-  resolution: "@polkadot/x-ws@npm:12.3.2"
+"@polkadot/x-ws@npm:^12.5.1":
+  version: 12.5.1
+  resolution: "@polkadot/x-ws@npm:12.5.1"
   dependencies:
-    "@polkadot/x-global": 12.3.2
-    tslib: ^2.5.3
-    ws: ^8.13.0
-  checksum: 7bb18ada56bb7d441c1392ec459959ff7cfc27fd57953898cb19682ea2fd323b68946102e4fe1c5eb1eb89fa62eb2d8ea7be03382ef9a473cd8c74d039b875d1
+    "@polkadot/x-global": 12.5.1
+    tslib: ^2.6.2
+    ws: ^8.14.1
+  checksum: 839e82ab4bf013d17a356e2f10a42ba2ecf88f4e432985241e785416aeb6434c0e7c897b09aeeab23f5d27b27ef0dfe65eda85293c7a08f52d0774bb1b23704b
   languageName: node
   linkType: hard
 
-"@scure/base@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@scure/base@npm:1.1.1"
-  checksum: b4fc810b492693e7e8d0107313ac74c3646970c198bbe26d7332820886fa4f09441991023ec9aa3a2a51246b74409ab5ebae2e8ef148bbc253da79ac49130309
+"@scure/base@npm:^1.1.3":
+  version: 1.1.3
+  resolution: "@scure/base@npm:1.1.3"
+  checksum: 1606ab8a4db898cb3a1ada16c15437c3bce4e25854fadc8eb03ae93cbbbac1ed90655af4b0be3da37e12056fef11c0374499f69b9e658c9e5b7b3e06353c630c
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:^0.25.16":
-  version: 0.25.24
-  resolution: "@sinclair/typebox@npm:0.25.24"
-  checksum: 10219c58f40b8414c50b483b0550445e9710d4fe7b2c4dccb9b66533dd90ba8e024acc776026cebe81e87f06fa24b07fdd7bc30dd277eb9cc386ec50151a3026
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.8
+  resolution: "@sinclair/typebox@npm:0.27.8"
+  checksum: 00bd7362a3439021aa1ea51b0e0d0a0e8ca1351a3d54c606b115fdcc49b51b16db6e5f43b4fe7a28c38688523e22a94d49dd31168868b655f0d4d50f032d07a1
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@sinonjs/commons@npm:2.0.0"
+"@sinonjs/commons@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "@sinonjs/commons@npm:3.0.0"
   dependencies:
     type-detect: 4.0.8
-  checksum: 5023ba17edf2b85ed58262313b8e9b59e23c6860681a9af0200f239fe939e2b79736d04a260e8270ddd57196851dde3ba754d7230be5c5234e777ae2ca8af137
+  checksum: b4b5b73d4df4560fb8c0c7b38c7ad4aeabedd362f3373859d804c988c725889cde33550e4bcc7cd316a30f5152a2d1d43db71b6d0c38f5feef71fd8d016763f8
   languageName: node
   linkType: hard
 
 "@sinonjs/fake-timers@npm:^10.0.2":
-  version: 10.0.2
-  resolution: "@sinonjs/fake-timers@npm:10.0.2"
+  version: 10.3.0
+  resolution: "@sinonjs/fake-timers@npm:10.3.0"
   dependencies:
-    "@sinonjs/commons": ^2.0.0
-  checksum: c62aa98e7cefda8dedc101ce227abc888dc46b8ff9706c5f0a8dfd9c3ada97d0a5611384738d9ba0b26b59f99c2ba24efece8e779bb08329e9e87358fa309824
+    "@sinonjs/commons": ^3.0.0
+  checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
   languageName: node
   linkType: hard
 
@@ -1315,14 +1336,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/connect@npm:0.7.26":
-  version: 0.7.26
-  resolution: "@substrate/connect@npm:0.7.26"
+"@substrate/connect@npm:0.7.33":
+  version: 0.7.33
+  resolution: "@substrate/connect@npm:0.7.33"
   dependencies:
     "@substrate/connect-extension-protocol": ^1.0.1
-    eventemitter3: ^4.0.7
-    smoldot: 1.0.4
-  checksum: 3179d241f073318d5973deb61c9c8d9b89ae28909a594b6b9fbcdfffd030a70ba58e8428eaa9d72484810bad10c93de1ad9c440b878d0fcfaaf4559d2e6f4502
+    smoldot: 2.0.1
+  checksum: b4cfb86bef46450b6635e7dbf1eb133603c6ad8c955046e72fc67aaf36b1fe5f2aeeb521f4b1ea0a1eea9ac4c49b0f6417c24eb1320e8da13cc0d3efd7ee4cd7
   languageName: node
   linkType: hard
 
@@ -1355,175 +1375,163 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@substrate/ss58-registry@npm:^1.40.0":
-  version: 1.40.0
-  resolution: "@substrate/ss58-registry@npm:1.40.0"
-  checksum: 474cb16b350e95fa7ca1020b70c6885c5c3d739472f506d175f24e9fd5a6d337d3c7e7a7fa44962199ed03fffb5d3b44b8af79a9811cb55ec34b3b75bb8e7f97
-  languageName: node
-  linkType: hard
-
-"@tootallnate/once@npm:2":
-  version: 2.0.0
-  resolution: "@tootallnate/once@npm:2.0.0"
-  checksum: ad87447820dd3f24825d2d947ebc03072b20a42bfc96cbafec16bff8bbda6c1a81fcb0be56d5b21968560c5359a0af4038a68ba150c3e1694fe4c109a063bed8
+"@substrate/ss58-registry@npm:^1.43.0":
+  version: 1.44.0
+  resolution: "@substrate/ss58-registry@npm:1.44.0"
+  checksum: 130fafc337a60bf22b1c01b8bd4fdbc2606a00483961bd173224478adb358a17b865d287cf99a2a32cb430d23d3a7969fce0457e8302dc48a98e1f666c7f6e40
   languageName: node
   linkType: hard
 
 "@types/babel__core@npm:^7.1.14":
-  version: 7.1.20
-  resolution: "@types/babel__core@npm:7.1.20"
+  version: 7.20.4
+  resolution: "@types/babel__core@npm:7.20.4"
   dependencies:
-    "@babel/parser": ^7.1.0
-    "@babel/types": ^7.0.0
+    "@babel/parser": ^7.20.7
+    "@babel/types": ^7.20.7
     "@types/babel__generator": "*"
     "@types/babel__template": "*"
     "@types/babel__traverse": "*"
-  checksum: a09c4f0456552547a5b8a5a009a3daec4d362f622168f8e08bda0ded2da0a65ab0b1642e23c433b3616721f5701dc34a996c5bde5baeaea53eda98f438043f2c
+  checksum: 75ed6072213423d2b827740d68bbf96f5a7050ce8bd842dde0ceec8d352d06e847166bac757df4beba55525b65f8727c0432adeb5cb4f83aa42e155ac555767e
   languageName: node
   linkType: hard
 
 "@types/babel__generator@npm:*":
-  version: 7.6.4
-  resolution: "@types/babel__generator@npm:7.6.4"
+  version: 7.6.7
+  resolution: "@types/babel__generator@npm:7.6.7"
   dependencies:
     "@babel/types": ^7.0.0
-  checksum: 20effbbb5f8a3a0211e95959d06ae70c097fb6191011b73b38fe86deebefad8e09ee014605e0fd3cdaedc73d158be555866810e9166e1f09e4cfd880b874dcb0
+  checksum: 03e96ea327a5238f00c38394a05cc01619b9f5f3ea57371419a1c25cf21676a6d327daf802435819f8cb3b8fa10e938a94bcbaf79a38c132068c813a1807ff93
   languageName: node
   linkType: hard
 
 "@types/babel__template@npm:*":
-  version: 7.4.1
-  resolution: "@types/babel__template@npm:7.4.1"
+  version: 7.4.4
+  resolution: "@types/babel__template@npm:7.4.4"
   dependencies:
     "@babel/parser": ^7.1.0
     "@babel/types": ^7.0.0
-  checksum: 649fe8b42c2876be1fd28c6ed9b276f78152d5904ec290b6c861d9ef324206e0a5c242e8305c421ac52ecf6358fa7e32ab7a692f55370484825c1df29b1596ee
+  checksum: d7a02d2a9b67e822694d8e6a7ddb8f2b71a1d6962dfd266554d2513eefbb205b33ca71a0d163b1caea3981ccf849211f9964d8bd0727124d18ace45aa6c9ae29
   languageName: node
   linkType: hard
 
 "@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.6":
-  version: 7.18.3
-  resolution: "@types/babel__traverse@npm:7.18.3"
+  version: 7.20.4
+  resolution: "@types/babel__traverse@npm:7.20.4"
   dependencies:
-    "@babel/types": ^7.3.0
-  checksum: d20953338b2f012ab7750932ece0a78e7d1645b0a6ff42d49be90f55e9998085da1374a9786a7da252df89555c6586695ba4d1d4b4e88ab2b9f306bcd35e00d3
+    "@babel/types": ^7.20.7
+  checksum: f044ba80e00d07e46ee917c44f96cfc268fcf6d3871f7dfb8db8d3c6dab1508302f3e6bc508352a4a3ae627d2522e3fc500fa55907e0410a08e2e0902a8f3576
   languageName: node
   linkType: hard
 
 "@types/bn.js@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@types/bn.js@npm:5.1.1"
+  version: 5.1.5
+  resolution: "@types/bn.js@npm:5.1.5"
   dependencies:
     "@types/node": "*"
-  checksum: e50ed2dd3abe997e047caf90e0352c71e54fc388679735217978b4ceb7e336e51477791b715f49fd77195ac26dd296c7bad08a3be9750e235f9b2e1edb1b51c2
+  checksum: c87b28c4af74545624f8a3dae5294b16aa190c222626e8d4b2e327b33b1a3f1eeb43e7a24d914a9774bca43d8cd6e1cb0325c1f4b3a244af6693a024e1d918e6
   languageName: node
   linkType: hard
 
 "@types/graceful-fs@npm:^4.1.3":
-  version: 4.1.6
-  resolution: "@types/graceful-fs@npm:4.1.6"
+  version: 4.1.9
+  resolution: "@types/graceful-fs@npm:4.1.9"
   dependencies:
     "@types/node": "*"
-  checksum: c3070ccdc9ca0f40df747bced1c96c71a61992d6f7c767e8fd24bb6a3c2de26e8b84135ede000b7e79db530a23e7e88dcd9db60eee6395d0f4ce1dae91369dd4
+  checksum: 79d746a8f053954bba36bd3d94a90c78de995d126289d656fb3271dd9f1229d33f678da04d10bce6be440494a5a73438e2e363e92802d16b8315b051036c5256
   languageName: node
   linkType: hard
 
 "@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
-  version: 2.0.4
-  resolution: "@types/istanbul-lib-coverage@npm:2.0.4"
-  checksum: a25d7589ee65c94d31464c16b72a9dc81dfa0bea9d3e105ae03882d616e2a0712a9c101a599ec482d297c3591e16336962878cb3eb1a0a62d5b76d277a890ce7
+  version: 2.0.6
+  resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
+  checksum: 3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
   languageName: node
   linkType: hard
 
 "@types/istanbul-lib-report@npm:*":
-  version: 3.0.0
-  resolution: "@types/istanbul-lib-report@npm:3.0.0"
+  version: 3.0.3
+  resolution: "@types/istanbul-lib-report@npm:3.0.3"
   dependencies:
     "@types/istanbul-lib-coverage": "*"
-  checksum: 656398b62dc288e1b5226f8880af98087233cdb90100655c989a09f3052b5775bf98ba58a16c5ae642fb66c61aba402e07a9f2bff1d1569e3b306026c59f3f36
+  checksum: b91e9b60f865ff08cb35667a427b70f6c2c63e88105eadd29a112582942af47ed99c60610180aa8dcc22382fa405033f141c119c69b95db78c4c709fbadfeeb4
   languageName: node
   linkType: hard
 
 "@types/istanbul-reports@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@types/istanbul-reports@npm:3.0.1"
+  version: 3.0.4
+  resolution: "@types/istanbul-reports@npm:3.0.4"
   dependencies:
     "@types/istanbul-lib-report": "*"
-  checksum: f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
+  checksum: 93eb18835770b3431f68ae9ac1ca91741ab85f7606f310a34b3586b5a34450ec038c3eed7ab19266635499594de52ff73723a54a72a75b9f7d6a956f01edee95
   languageName: node
   linkType: hard
 
 "@types/jest@npm:^29.5.1":
-  version: 29.5.1
-  resolution: "@types/jest@npm:29.5.1"
+  version: 29.5.8
+  resolution: "@types/jest@npm:29.5.8"
   dependencies:
     expect: ^29.0.0
     pretty-format: ^29.0.0
-  checksum: 0a22491dec86333c0e92b897be2c809c922a7b2b0aa5604ac369810d6b2360908b4a3f2c6892e8a237a54fa1f10ecefe0e823ec5fcb7915195af4dfe88d2197e
+  checksum: ca8438a5b4c098c8c023e9d5b279ea306494a1d0b5291cfb498100fa780377145f068b2a021d545b0398bbe0328dcc37044dd3aaf3c6c0fe9b0bef7b46a63453
   languageName: node
   linkType: hard
 
 "@types/json-schema@npm:^7.0.9":
-  version: 7.0.11
-  resolution: "@types/json-schema@npm:7.0.11"
-  checksum: 527bddfe62db9012fccd7627794bd4c71beb77601861055d87e3ee464f2217c85fca7a4b56ae677478367bbd248dbde13553312b7d4dbc702a2f2bbf60c4018d
+  version: 7.0.15
+  resolution: "@types/json-schema@npm:7.0.15"
+  checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
   languageName: node
   linkType: hard
 
 "@types/node@npm:*":
-  version: 18.11.18
-  resolution: "@types/node@npm:18.11.18"
-  checksum: 03f17f9480f8d775c8a72da5ea7e9383db5f6d85aa5fefde90dd953a1449bd5e4ffde376f139da4f3744b4c83942166d2a7603969a6f8ea826edfb16e6e3b49d
-  languageName: node
-  linkType: hard
-
-"@types/prettier@npm:^2.1.5":
-  version: 2.7.2
-  resolution: "@types/prettier@npm:2.7.2"
-  checksum: b47d76a5252265f8d25dd2fe2a5a61dc43ba0e6a96ffdd00c594cb4fd74c1982c2e346497e3472805d97915407a09423804cc2110a0b8e1b22cffcab246479b7
+  version: 20.9.1
+  resolution: "@types/node@npm:20.9.1"
+  dependencies:
+    undici-types: ~5.26.4
+  checksum: bb893c6790733dac32818c1ca170fa466622dec39a0ade4639463e1358cb811771e242accbd065e7a1bfe59adc989c0ee59be65e462d3a0ab49043426f0b7637
   languageName: node
   linkType: hard
 
 "@types/semver@npm:^7.3.12":
-  version: 7.3.13
-  resolution: "@types/semver@npm:7.3.13"
-  checksum: 00c0724d54757c2f4bc60b5032fe91cda6410e48689633d5f35ece8a0a66445e3e57fa1d6e07eb780f792e82ac542948ec4d0b76eb3484297b79bd18b8cf1cb0
+  version: 7.5.5
+  resolution: "@types/semver@npm:7.5.5"
+  checksum: 533e6c93d1262d65f449423d94a445f7f3db0672e7429f21b6a1636d6051dbab3a2989ddcda9b79c69bb37830931d09fc958a65305a891357f5cea3257c297f5
   languageName: node
   linkType: hard
 
 "@types/stack-utils@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "@types/stack-utils@npm:2.0.1"
-  checksum: 205fdbe3326b7046d7eaf5e494d8084f2659086a266f3f9cf00bccc549c8e36e407f88168ad4383c8b07099957ad669f75f2532ed4bc70be2b037330f7bae019
+  version: 2.0.3
+  resolution: "@types/stack-utils@npm:2.0.3"
+  checksum: 72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
   languageName: node
   linkType: hard
 
 "@types/yargs-parser@npm:*":
-  version: 21.0.0
-  resolution: "@types/yargs-parser@npm:21.0.0"
-  checksum: b2f4c8d12ac18a567440379909127cf2cec393daffb73f246d0a25df36ea983b93b7e9e824251f959e9f928cbc7c1aab6728d0a0ff15d6145f66cec2be67d9a2
+  version: 21.0.3
+  resolution: "@types/yargs-parser@npm:21.0.3"
+  checksum: ef236c27f9432983e91432d974243e6c4cdae227cb673740320eff32d04d853eed59c92ca6f1142a335cfdc0e17cccafa62e95886a8154ca8891cc2dec4ee6fc
   languageName: node
   linkType: hard
 
 "@types/yargs@npm:^17.0.8":
-  version: 17.0.24
-  resolution: "@types/yargs@npm:17.0.24"
+  version: 17.0.31
+  resolution: "@types/yargs@npm:17.0.31"
   dependencies:
     "@types/yargs-parser": "*"
-  checksum: 5f3ac4dc4f6e211c1627340160fbe2fd247ceba002190da6cf9155af1798450501d628c9165a183f30a224fc68fa5e700490d740ff4c73e2cdef95bc4e8ba7bf
+  checksum: a7f4fe5b05162790cbcbccceb22821e2cb3e49d95a4d8403352f258744cd504124f3ab502eddb2262f5d2d9cc6a0547851ae44621b14fe4c505d8f1434c2a19e
   languageName: node
   linkType: hard
 
 "@typescript-eslint/eslint-plugin@npm:^5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:5.59.0"
+  version: 5.62.0
+  resolution: "@typescript-eslint/eslint-plugin@npm:5.62.0"
   dependencies:
     "@eslint-community/regexpp": ^4.4.0
-    "@typescript-eslint/scope-manager": 5.59.0
-    "@typescript-eslint/type-utils": 5.59.0
-    "@typescript-eslint/utils": 5.59.0
+    "@typescript-eslint/scope-manager": 5.62.0
+    "@typescript-eslint/type-utils": 5.62.0
+    "@typescript-eslint/utils": 5.62.0
     debug: ^4.3.4
-    grapheme-splitter: ^1.0.4
+    graphemer: ^1.4.0
     ignore: ^5.2.0
     natural-compare-lite: ^1.4.0
     semver: ^7.3.7
@@ -1534,43 +1542,43 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 3b2582fe7baa9bf7733be79c6e35a390806f91c8d5ba5b604f71cb3635fb36abc975b926195c3ef5c6a4018bb94f66e009d727e3af2ce8b92c96aa3ee9ed194a
+  checksum: fc104b389c768f9fa7d45a48c86d5c1ad522c1d0512943e782a56b1e3096b2cbcc1eea3fcc590647bf0658eef61aac35120a9c6daf979bf629ad2956deb516a1
   languageName: node
   linkType: hard
 
 "@typescript-eslint/parser@npm:^5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/parser@npm:5.59.0"
+  version: 5.62.0
+  resolution: "@typescript-eslint/parser@npm:5.62.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.59.0
-    "@typescript-eslint/types": 5.59.0
-    "@typescript-eslint/typescript-estree": 5.59.0
+    "@typescript-eslint/scope-manager": 5.62.0
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/typescript-estree": 5.62.0
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 1a442d6b776fc1dca4fe104bac77eae0a59b807ba11cef00dec8f5dbbc0fb4e5fc10519eac03dd94d52e4dd6d814800d0e5c0a3bd43eefce80d829c65ba47ad0
+  checksum: d168f4c7f21a7a63f47002e2d319bcbb6173597af5c60c1cf2de046b46c76b4930a093619e69faf2d30214c29ab27b54dcf1efc7046a6a6bd6f37f59a990e752
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/scope-manager@npm:5.59.0"
+"@typescript-eslint/scope-manager@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.62.0"
   dependencies:
-    "@typescript-eslint/types": 5.59.0
-    "@typescript-eslint/visitor-keys": 5.59.0
-  checksum: dd89cd34291f7674edcbe9628748faa61dbf7199f9776586167e81fd91b93ba3a7f0ddd493c559c0dbb805b58629858fae648d56550e8ac5330b2ed1802b0178
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/visitor-keys": 5.62.0
+  checksum: 6062d6b797fe1ce4d275bb0d17204c827494af59b5eaf09d8a78cdd39dadddb31074dded4297aaf5d0f839016d601032857698b0e4516c86a41207de606e9573
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/type-utils@npm:5.59.0"
+"@typescript-eslint/type-utils@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/type-utils@npm:5.62.0"
   dependencies:
-    "@typescript-eslint/typescript-estree": 5.59.0
-    "@typescript-eslint/utils": 5.59.0
+    "@typescript-eslint/typescript-estree": 5.62.0
+    "@typescript-eslint/utils": 5.62.0
     debug: ^4.3.4
     tsutils: ^3.21.0
   peerDependencies:
@@ -1578,23 +1586,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 811981ea117808315fe37ce8489ae6e20979f588cf0fdef2bd969d58c505ececff0bccf7957f3b178933028433ce28764ebc9fea32a35a4c2da81b5b1e98b454
+  checksum: fc41eece5f315dfda14320be0da78d3a971d650ea41300be7196934b9715f3fe1120a80207551eb71d39568275dbbcf359bde540d1ca1439d8be15e9885d2739
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/types@npm:5.59.0"
-  checksum: 5dc608a867b07b4262a236a264a65e894f841388b3aba461c4c1a30d76a2c3aed0c6a1e3d1ea2f64cce55e783091bafb826bf01a0ef83258820af63da860addf
+"@typescript-eslint/types@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/types@npm:5.62.0"
+  checksum: 48c87117383d1864766486f24de34086155532b070f6264e09d0e6139449270f8a9559cfef3c56d16e3bcfb52d83d42105d61b36743626399c7c2b5e0ac3b670
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/typescript-estree@npm:5.59.0"
+"@typescript-eslint/typescript-estree@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
   dependencies:
-    "@typescript-eslint/types": 5.59.0
-    "@typescript-eslint/visitor-keys": 5.59.0
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/visitor-keys": 5.62.0
     debug: ^4.3.4
     globby: ^11.1.0
     is-glob: ^4.0.3
@@ -1603,42 +1611,42 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: d80f2766e2830dc830b9f4f1b9e744e1e7a285ebe72babdf0970f75bfe26cb832c6623bb836a53c48f1e707069d1e407ac1ea095bd583807007f713ba6e2e0e1
+  checksum: 3624520abb5807ed8f57b1197e61c7b1ed770c56dfcaca66372d584ff50175225798bccb701f7ef129d62c5989070e1ee3a0aa2d84e56d9524dcf011a2bb1a52
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/utils@npm:5.59.0"
+"@typescript-eslint/utils@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/utils@npm:5.62.0"
   dependencies:
     "@eslint-community/eslint-utils": ^4.2.0
     "@types/json-schema": ^7.0.9
     "@types/semver": ^7.3.12
-    "@typescript-eslint/scope-manager": 5.59.0
-    "@typescript-eslint/types": 5.59.0
-    "@typescript-eslint/typescript-estree": 5.59.0
+    "@typescript-eslint/scope-manager": 5.62.0
+    "@typescript-eslint/types": 5.62.0
+    "@typescript-eslint/typescript-estree": 5.62.0
     eslint-scope: ^5.1.1
     semver: ^7.3.7
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
-  checksum: 228318df02f2381f859af184cafa5de4146a2e1518a5062444bf9bd7d468e058f9bd93a3e46cc4683d9bd02159648f416e5c7c539901ca16142456cae3c1af5f
+  checksum: ee9398c8c5db6d1da09463ca7bf36ed134361e20131ea354b2da16a5fdb6df9ba70c62a388d19f6eebb421af1786dbbd79ba95ddd6ab287324fc171c3e28d931
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:5.59.0":
-  version: 5.59.0
-  resolution: "@typescript-eslint/visitor-keys@npm:5.59.0"
+"@typescript-eslint/visitor-keys@npm:5.62.0":
+  version: 5.62.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
   dependencies:
-    "@typescript-eslint/types": 5.59.0
+    "@typescript-eslint/types": 5.62.0
     eslint-visitor-keys: ^3.3.0
-  checksum: e21656de02e221a27a5fe9f7fd34a1ca28530e47675134425f84fd0d1f276695fe39e35120837a491b02255d49aa2fd871e2c858ecccc66c687db972d057bd1c
+  checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
   languageName: node
   linkType: hard
 
-"abbrev@npm:^1.0.0":
-  version: 1.1.1
-  resolution: "abbrev@npm:1.1.1"
-  checksum: a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17
+"abbrev@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "abbrev@npm:2.0.0"
+  checksum: 0e994ad2aa6575f94670d8a2149afe94465de9cedaaaac364e7fb43a40c3691c980ff74899f682f4ca58fa96b4cbd7421a015d3a6defe43a442117d7821a2f36
   languageName: node
   linkType: hard
 
@@ -1651,32 +1659,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.8.0":
-  version: 8.8.1
-  resolution: "acorn@npm:8.8.1"
+"acorn@npm:^8.9.0":
+  version: 8.11.2
+  resolution: "acorn@npm:8.11.2"
   bin:
     acorn: bin/acorn
-  checksum: 4079b67283b94935157698831967642f24a075c52ce3feaaaafe095776dfbe15d86a1b33b1e53860fc0d062ed6c83f4284a5c87c85b9ad51853a01173da6097f
+  checksum: 818450408684da89423e3daae24e4dc9b68692db8ab49ea4569c7c5abb7a3f23669438bf129cc81dfdada95e1c9b944ee1bfca2c57a05a4dc73834a612fbf6a7
   languageName: node
   linkType: hard
 
-"agent-base@npm:6, agent-base@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "agent-base@npm:6.0.2"
+"agent-base@npm:^7.0.2, agent-base@npm:^7.1.0":
+  version: 7.1.0
+  resolution: "agent-base@npm:7.1.0"
   dependencies:
-    debug: 4
-  checksum: f52b6872cc96fd5f622071b71ef200e01c7c4c454ee68bc9accca90c98cfb39f2810e3e9aa330435835eedc8c23f4f8a15267f67c6e245d2b33757575bdac49d
-  languageName: node
-  linkType: hard
-
-"agentkeepalive@npm:^4.2.1":
-  version: 4.2.1
-  resolution: "agentkeepalive@npm:4.2.1"
-  dependencies:
-    debug: ^4.1.0
-    depd: ^1.1.2
-    humanize-ms: ^1.2.1
-  checksum: 39cb49ed8cf217fd6da058a92828a0a84e0b74c35550f82ee0a10e1ee403c4b78ade7948be2279b188b7a7303f5d396ea2738b134731e464bf28de00a4f72a18
+    debug: ^4.3.4
+  checksum: f7828f991470a0cc22cb579c86a18cbae83d8a3cbed39992ab34fc7217c4d126017f1c74d0ab66be87f71455318a8ea3e757d6a37881b8d0f2a2c6aa55e5418f
   languageName: node
   linkType: hard
 
@@ -1718,10 +1715,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "ansi-regex@npm:6.0.1"
+  checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
 "ansi-sequence-parser@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "ansi-sequence-parser@npm:1.1.0"
-  checksum: 75f4d3a4c555655a698aec05b5763cbddcd16ccccdbfd178fb0aa471ab74fdf98e031b875ef26e64be6a95cf970c89238744b26de6e34af97f316d5186b1df53
+  version: 1.1.1
+  resolution: "ansi-sequence-parser@npm:1.1.1"
+  checksum: ead5b15c596e8e85ca02951a844366c6776769dcc9fd1bd3a0db11bb21364554822c6a439877fb599e7e1ffa0b5f039f1e5501423950457f3dcb2f480c30b188
   languageName: node
   linkType: hard
 
@@ -1750,6 +1754,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: ef940f2f0ced1a6347398da88a91da7930c33ecac3c77b72c5905f8b8fe402c52e6fde304ff5347f616e27a742da3f1dc76de98f6866c69251ad0b07a66776d9
+  languageName: node
+  linkType: hard
+
 "anymatch@npm:^3.0.3":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
@@ -1757,23 +1768,6 @@ __metadata:
     normalize-path: ^3.0.0
     picomatch: ^2.0.4
   checksum: 3e044fd6d1d26545f235a9fe4d7a534e2029d8e59fa7fd9f2a6eb21230f6b5380ea1eaf55136e60cbf8e613544b3b766e7a6fa2102e2a3a117505466e3025dc2
-  languageName: node
-  linkType: hard
-
-"aproba@npm:^1.0.3 || ^2.0.0":
-  version: 2.0.0
-  resolution: "aproba@npm:2.0.0"
-  checksum: 5615cadcfb45289eea63f8afd064ab656006361020e1735112e346593856f87435e02d8dcc7ff0d11928bc7d425f27bc7c2a84f6c0b35ab0ff659c814c138a24
-  languageName: node
-  linkType: hard
-
-"are-we-there-yet@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "are-we-there-yet@npm:3.0.1"
-  dependencies:
-    delegates: ^1.0.0
-    readable-stream: ^3.6.0
-  checksum: 52590c24860fa7173bedeb69a4c05fb573473e860197f618b9a28432ee4379049336727ae3a1f9c4cb083114601c1140cee578376164d0e651217a9843f9fe83
   languageName: node
   linkType: hard
 
@@ -1800,20 +1794,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "babel-jest@npm:29.5.0"
+"babel-jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "babel-jest@npm:29.7.0"
   dependencies:
-    "@jest/transform": ^29.5.0
+    "@jest/transform": ^29.7.0
     "@types/babel__core": ^7.1.14
     babel-plugin-istanbul: ^6.1.1
-    babel-preset-jest: ^29.5.0
+    babel-preset-jest: ^29.6.3
     chalk: ^4.0.0
     graceful-fs: ^4.2.9
     slash: ^3.0.0
   peerDependencies:
     "@babel/core": ^7.8.0
-  checksum: eafb6d37deb71f0c80bf3c80215aa46732153e5e8bcd73f6ff47d92e5c0c98c8f7f75995d0efec6289c371edad3693cd8fa2367b0661c4deb71a3a7117267ede
+  checksum: ee6f8e0495afee07cac5e4ee167be705c711a8cc8a737e05a587a131fdae2b3c8f9aa55dfd4d9c03009ac2d27f2de63d8ba96d3e8460da4d00e8af19ef9a83f7
   languageName: node
   linkType: hard
 
@@ -1830,15 +1824,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-plugin-jest-hoist@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "babel-plugin-jest-hoist@npm:29.5.0"
+"babel-plugin-jest-hoist@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "babel-plugin-jest-hoist@npm:29.6.3"
   dependencies:
     "@babel/template": ^7.3.3
     "@babel/types": ^7.3.3
     "@types/babel__core": ^7.1.14
     "@types/babel__traverse": ^7.0.6
-  checksum: 099b5254073b6bc985b6d2d045ad26fb8ed30ff8ae6404c4fe8ee7cd0e98a820f69e3dfb871c7c65aae0f4b65af77046244c07bb92d49ef9005c90eedf681539
+  checksum: 51250f22815a7318f17214a9d44650ba89551e6d4f47a2dc259128428324b52f5a73979d010cefd921fd5a720d8c1d55ad74ff601cd94c7bd44d5f6292fde2d1
   languageName: node
   linkType: hard
 
@@ -1864,15 +1858,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-preset-jest@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "babel-preset-jest@npm:29.5.0"
+"babel-preset-jest@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "babel-preset-jest@npm:29.6.3"
   dependencies:
-    babel-plugin-jest-hoist: ^29.5.0
+    babel-plugin-jest-hoist: ^29.6.3
     babel-preset-current-node-syntax: ^1.0.0
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 5566ca2762766c9319b4973d018d2fa08c0fcf6415c72cc54f4c8e7199e851ea8f5e6c6730f03ed7ed44fc8beefa959dd15911f2647dee47c615ff4faeddb1ad
+  checksum: aa4ff2a8a728d9d698ed521e3461a109a1e66202b13d3494e41eea30729a5e7cc03b3a2d56c594423a135429c37bf63a9fa8b0b9ce275298be3095a88c69f6fb
   languageName: node
   linkType: hard
 
@@ -1918,17 +1912,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.21.3":
-  version: 4.21.4
-  resolution: "browserslist@npm:4.21.4"
+"browserslist@npm:^4.21.9":
+  version: 4.22.1
+  resolution: "browserslist@npm:4.22.1"
   dependencies:
-    caniuse-lite: ^1.0.30001400
-    electron-to-chromium: ^1.4.251
-    node-releases: ^2.0.6
-    update-browserslist-db: ^1.0.9
+    caniuse-lite: ^1.0.30001541
+    electron-to-chromium: ^1.4.535
+    node-releases: ^2.0.13
+    update-browserslist-db: ^1.0.13
   bin:
     browserslist: cli.js
-  checksum: 4af3793704dbb4615bcd29059ab472344dc7961c8680aa6c4bb84f05340e14038d06a5aead58724eae69455b8fade8b8c69f1638016e87e5578969d74c078b79
+  checksum: 7e6b10c53f7dd5d83fd2b95b00518889096382539fed6403829d447e05df4744088de46a571071afb447046abc3c66ad06fbc790e70234ec2517452e32ffd862
   languageName: node
   linkType: hard
 
@@ -1957,29 +1951,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cacache@npm:^16.1.0":
-  version: 16.1.3
-  resolution: "cacache@npm:16.1.3"
+"cacache@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "cacache@npm:18.0.0"
   dependencies:
-    "@npmcli/fs": ^2.1.0
-    "@npmcli/move-file": ^2.0.0
-    chownr: ^2.0.0
-    fs-minipass: ^2.1.0
-    glob: ^8.0.1
-    infer-owner: ^1.0.4
-    lru-cache: ^7.7.1
-    minipass: ^3.1.6
+    "@npmcli/fs": ^3.1.0
+    fs-minipass: ^3.0.0
+    glob: ^10.2.2
+    lru-cache: ^10.0.1
+    minipass: ^7.0.3
     minipass-collect: ^1.0.2
     minipass-flush: ^1.0.5
     minipass-pipeline: ^1.2.4
-    mkdirp: ^1.0.4
     p-map: ^4.0.0
-    promise-inflight: ^1.0.1
-    rimraf: ^3.0.2
-    ssri: ^9.0.0
+    ssri: ^10.0.0
     tar: ^6.1.11
-    unique-filename: ^2.0.0
-  checksum: d91409e6e57d7d9a3a25e5dcc589c84e75b178ae8ea7de05cbf6b783f77a5fae938f6e8fda6f5257ed70000be27a681e1e44829251bfffe4c10216002f8f14e6
+    unique-filename: ^3.0.0
+  checksum: 2cd6bf15551abd4165acb3a4d1ef0593b3aa2fd6853ae16b5bb62199c2faecf27d36555a9545c0e07dd03347ec052e782923bdcece724a24611986aafb53e152
   languageName: node
   linkType: hard
 
@@ -2004,10 +1992,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001400":
-  version: 1.0.30001445
-  resolution: "caniuse-lite@npm:1.0.30001445"
-  checksum: f98ca67829c3c52af5af0a62b8510432b2ad9594437d24ad460a6eb1a23d93e7a31631b1f550fbbe482ad05c467aa00da710a41699eb13d1f246d7db4147ab79
+"caniuse-lite@npm:^1.0.30001541":
+  version: 1.0.30001563
+  resolution: "caniuse-lite@npm:1.0.30001563"
+  checksum: c90a1e6efc72fc73ad4a756011242211406883b36dde3a01726e7246281dcbceaf78e1ee61d1298624c4a69cf81c12b41e8d2a2f1b7c89ed84c9333026a0bfbd
   languageName: node
   linkType: hard
 
@@ -2021,7 +2009,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^2.0.0":
+"chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
   dependencies:
@@ -2047,16 +2035,16 @@ __metadata:
   linkType: hard
 
 "ci-info@npm:^3.2.0":
-  version: 3.7.1
-  resolution: "ci-info@npm:3.7.1"
-  checksum: 72d93d5101ea1c186511277fbd8d06ae8a6e028cc2fb94361e92bf735b39c5ebd192e8d15a66ff8c4e3ed569f87c2f844e96f90e141b2de5c649f77ec34ff601
+  version: 3.9.0
+  resolution: "ci-info@npm:3.9.0"
+  checksum: 6b19dc9b2966d1f8c2041a838217299718f15d6c4b63ae36e4674edd2bee48f780e94761286a56aa59eb305a85fbea4ddffb7630ec063e7ec7e7e5ad42549a87
   languageName: node
   linkType: hard
 
 "cjs-module-lexer@npm:^1.0.0":
-  version: 1.2.2
-  resolution: "cjs-module-lexer@npm:1.2.2"
-  checksum: 977f3f042bd4f08e368c890d91eecfbc4f91da0bc009a3c557bc4dfbf32022ad1141244ac1178d44de70fc9f3dea7add7cd9a658a34b9fae98a55d8f92331ce5
+  version: 1.2.3
+  resolution: "cjs-module-lexer@npm:1.2.3"
+  checksum: 5ea3cb867a9bb609b6d476cd86590d105f3cfd6514db38ff71f63992ab40939c2feb68967faa15a6d2b1f90daa6416b79ea2de486e9e2485a6f8b66a21b4fb0a
   languageName: node
   linkType: hard
 
@@ -2086,9 +2074,9 @@ __metadata:
   linkType: hard
 
 "collect-v8-coverage@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "collect-v8-coverage@npm:1.0.1"
-  checksum: 4efe0a1fccd517b65478a2364b33dadd0a43fc92a56f59aaece9b6186fe5177b2de471253587de7c91516f07c7268c2f6770b6cbcffc0e0ece353b766ec87e55
+  version: 1.0.2
+  resolution: "collect-v8-coverage@npm:1.0.2"
+  checksum: c10f41c39ab84629d16f9f6137bc8a63d332244383fc368caf2d2052b5e04c20cd1fd70f66fcf4e2422b84c8226598b776d39d5f2d2a51867cc1ed5d1982b4da
   languageName: node
   linkType: hard
 
@@ -2124,33 +2112,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-support@npm:^1.1.3":
-  version: 1.1.3
-  resolution: "color-support@npm:1.1.3"
-  bin:
-    color-support: bin.js
-  checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
   checksum: 902a9f5d8967a3e2faf138d5cb784b9979bad2e6db5357c5b21c568df4ebe62bcb15108af1b2253744844eb964fc023fbd9afbbbb6ddd0bcc204c6fb5b7bf3af
-  languageName: node
-  linkType: hard
-
-"console-control-strings@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "console-control-strings@npm:1.1.0"
-  checksum: 8755d76787f94e6cf79ce4666f0c5519906d7f5b02d4b884cf41e11dcd759ed69c57da0670afd9236d229a46e0f9cf519db0cd829c6dca820bb5a5c3def584ed
-  languageName: node
-  linkType: hard
-
-"convert-source-map@npm:^1.6.0, convert-source-map@npm:^1.7.0":
-  version: 1.9.0
-  resolution: "convert-source-map@npm:1.9.0"
-  checksum: dc55a1f28ddd0e9485ef13565f8f756b342f9a46c4ae18b843fe3c30c675d058d6a4823eff86d472f187b176f0adf51ea7b69ea38be34be4a63cbbf91b0593c8
   languageName: node
   linkType: hard
 
@@ -2161,7 +2126,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"create-jest@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "create-jest@npm:29.7.0"
+  dependencies:
+    "@jest/types": ^29.6.3
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    jest-config: ^29.7.0
+    jest-util: ^29.7.0
+    prompts: ^2.0.1
+  bin:
+    create-jest: bin/create-jest.js
+  checksum: 1427d49458adcd88547ef6fa39041e1fe9033a661293aa8d2c3aa1b4967cb5bf4f0c00436c7a61816558f28ba2ba81a94d5c962e8022ea9a883978fc8e1f2945
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -2179,7 +2161,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -2191,10 +2173,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dedent@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "dedent@npm:0.7.0"
-  checksum: 87de191050d9a40dd70cad01159a0bcf05ecb59750951242070b6abf9569088684880d00ba92a955b4058804f16eeaf91d604f283929b4f614d181cd7ae633d2
+"dedent@npm:^1.0.0":
+  version: 1.5.1
+  resolution: "dedent@npm:1.5.1"
+  peerDependencies:
+    babel-plugin-macros: ^3.1.0
+  peerDependenciesMeta:
+    babel-plugin-macros:
+      optional: true
+  checksum: c3c300a14edf1bdf5a873f9e4b22e839d62490bc5c8d6169c1f15858a1a76733d06a9a56930e963d677a2ceeca4b6b0894cc5ea2f501aa382ca5b92af3413c2a
   languageName: node
   linkType: hard
 
@@ -2206,23 +2193,9 @@ __metadata:
   linkType: hard
 
 "deepmerge@npm:^4.2.2":
-  version: 4.2.2
-  resolution: "deepmerge@npm:4.2.2"
-  checksum: a8c43a1ed8d6d1ed2b5bf569fa4c8eb9f0924034baf75d5d406e47e157a451075c4db353efea7b6bcc56ec48116a8ce72fccf867b6e078e7c561904b5897530b
-  languageName: node
-  linkType: hard
-
-"delegates@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "delegates@npm:1.0.0"
-  checksum: a51744d9b53c164ba9c0492471a1a2ffa0b6727451bdc89e31627fdf4adda9d51277cfcbfb20f0a6f08ccb3c436f341df3e92631a3440226d93a8971724771fd
-  languageName: node
-  linkType: hard
-
-"depd@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "depd@npm:1.1.2"
-  checksum: 6b406620d269619852885ce15965272b829df6f409724415e0002c8632ab6a8c0a08ec1f0bd2add05dc7bd7507606f7e2cc034fa24224ab829580040b835ecd9
+  version: 4.3.1
+  resolution: "deepmerge@npm:4.3.1"
+  checksum: 2024c6a980a1b7128084170c4cf56b0fd58a63f2da1660dcfe977415f27b17dbe5888668b59d0b063753f3220719d5e400b7f113609489c90160bb9a5518d052
   languageName: node
   linkType: hard
 
@@ -2233,10 +2206,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff-sequences@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "diff-sequences@npm:29.4.3"
-  checksum: 28b265e04fdddcf7f9f814effe102cc95a9dec0564a579b5aed140edb24fc345c611ca52d76d725a3cab55d3888b915b5e8a4702e0f6058968a90fa5f41fcde7
+"diff-sequences@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "diff-sequences@npm:29.6.3"
+  checksum: f4914158e1f2276343d98ff5b31fc004e7304f5470bf0f1adb2ac6955d85a531a6458d33e87667f98f6ae52ebd3891bb47d420bb48a5bd8b7a27ee25b20e33aa
   languageName: node
   linkType: hard
 
@@ -2258,10 +2231,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.251":
-  version: 1.4.284
-  resolution: "electron-to-chromium@npm:1.4.284"
-  checksum: be496e9dca6509dbdbb54dc32146fc99f8eb716d28a7ee8ccd3eba0066561df36fc51418d8bd7cf5a5891810bf56c0def3418e74248f51ea4a843d423603d10a
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 7d00d7cd8e49b9afa762a813faac332dee781932d6f2c848dc348939c4253f1d4564341b7af1d041853bc3f32c2ef141b58e0a4d9862c17a7f08f68df1e0f1ed
+  languageName: node
+  linkType: hard
+
+"electron-to-chromium@npm:^1.4.535":
+  version: 1.4.587
+  resolution: "electron-to-chromium@npm:1.4.587"
+  checksum: 86d06fd6074bdfd0e726eb5809067d826b7275ac3417dc9caa651b467919231450b7892329c02b857d8f62c5353738e243796639a8b21ede1acc0f8f95ab37fb
   languageName: node
   linkType: hard
 
@@ -2276,6 +2256,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: d4c5c39d5a9868b5fa152f00cada8a936868fd3367f33f71be515ecee4c803132d11b31a6222b2571b1e5f7e13890156a94880345594d0ce7e3c9895f560f192
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 8487182da74aabd810ac6d6f1994111dfc0e331b01271ae01ec1eb0ad7b5ecc2bbbbd2f053c05cb55a1ac30449527d819bbfbf0e3de1023db308cbcb47f86601
   languageName: node
   linkType: hard
 
@@ -2340,13 +2327,13 @@ __metadata:
   linkType: hard
 
 "eslint-config-prettier@npm:^8.8.0":
-  version: 8.8.0
-  resolution: "eslint-config-prettier@npm:8.8.0"
+  version: 8.10.0
+  resolution: "eslint-config-prettier@npm:8.10.0"
   peerDependencies:
     eslint: ">=7.0.0"
   bin:
     eslint-config-prettier: bin/cli.js
-  checksum: 1e94c3882c4d5e41e1dcfa2c368dbccbfe3134f6ac7d40101644d3bfbe3eb2f2ffac757f3145910b5eacf20c0e85e02b91293d3126d770cbf3dc390b3564681c
+  checksum: 153266badd477e49b0759816246b2132f1dbdb6c7f313ca60a9af5822fd1071c2bc5684a3720d78b725452bbac04bb130878b2513aea5e72b1b792de5a69fec8
   languageName: node
   linkType: hard
 
@@ -2385,19 +2372,19 @@ __metadata:
   linkType: hard
 
 "eslint-scope@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "eslint-scope@npm:7.2.0"
+  version: 7.2.2
+  resolution: "eslint-scope@npm:7.2.2"
   dependencies:
     esrecurse: ^4.3.0
     estraverse: ^5.2.0
-  checksum: 64591a2d8b244ade9c690b59ef238a11d5c721a98bcee9e9f445454f442d03d3e04eda88e95a4daec558220a99fa384309d9faae3d459bd40e7a81b4063980ae
+  checksum: ec97dbf5fb04b94e8f4c5a91a7f0a6dd3c55e46bfc7bbcd0e3138c3a76977570e02ed89a1810c778dcd72072ff0e9621ba1379b4babe53921d71e2e4486fda3e
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "eslint-visitor-keys@npm:3.4.0"
-  checksum: 33159169462d3989321a1ec1e9aaaf6a24cc403d5d347e9886d1b5bfe18ffa1be73bdc6203143a28a606b142b1af49787f33cff0d6d0813eb5f2e8d2e1a6043c
+"eslint-visitor-keys@npm:^3.3.0, eslint-visitor-keys@npm:^3.4.0, eslint-visitor-keys@npm:^3.4.1":
+  version: 3.4.3
+  resolution: "eslint-visitor-keys@npm:3.4.3"
+  checksum: 36e9ef87fca698b6fd7ca5ca35d7b2b6eeaaf106572e2f7fd31c12d3bfdaccdb587bba6d3621067e5aece31c8c3a348b93922ab8f7b2cbc6aaab5e1d89040c60
   languageName: node
   linkType: hard
 
@@ -2451,14 +2438,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"espree@npm:^9.5.1":
-  version: 9.5.1
-  resolution: "espree@npm:9.5.1"
+"espree@npm:^9.5.1, espree@npm:^9.6.0":
+  version: 9.6.1
+  resolution: "espree@npm:9.6.1"
   dependencies:
-    acorn: ^8.8.0
+    acorn: ^8.9.0
     acorn-jsx: ^5.3.2
-    eslint-visitor-keys: ^3.4.0
-  checksum: cdf6e43540433d917c4f2ee087c6e987b2063baa85a1d9cdaf51533d78275ebd5910c42154e7baf8e3e89804b386da0a2f7fad2264d8f04420e7506bf87b3b88
+    eslint-visitor-keys: ^3.4.1
+  checksum: eb8c149c7a2a77b3f33a5af80c10875c3abd65450f60b8af6db1bfcfa8f101e21c1e56a561c6dc13b848e18148d43469e7cd208506238554fb5395a9ea5a1ab9
   languageName: node
   linkType: hard
 
@@ -2511,13 +2498,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.7":
-  version: 4.0.7
-  resolution: "eventemitter3@npm:4.0.7"
-  checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
-  languageName: node
-  linkType: hard
-
 "eventemitter3@npm:^5.0.1":
   version: 5.0.1
   resolution: "eventemitter3@npm:5.0.1"
@@ -2549,16 +2529,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:^29.0.0, expect@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "expect@npm:29.5.0"
+"expect@npm:^29.0.0, expect@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "expect@npm:29.7.0"
   dependencies:
-    "@jest/expect-utils": ^29.5.0
-    jest-get-type: ^29.4.3
-    jest-matcher-utils: ^29.5.0
-    jest-message-util: ^29.5.0
-    jest-util: ^29.5.0
-  checksum: 58f70b38693df6e5c6892db1bcd050f0e518d6f785175dc53917d4fa6a7359a048e5690e19ddcb96b65c4493881dd89a3dabdab1a84dfa55c10cdbdabf37b2d7
+    "@jest/expect-utils": ^29.7.0
+    jest-get-type: ^29.6.3
+    jest-matcher-utils: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
+  checksum: 9257f10288e149b81254a0fda8ffe8d54a7061cd61d7515779998b012579d2b8c22354b0eb901daf0145f347403da582f75f359f4810c007182ad3fb318b5c0c
+  languageName: node
+  linkType: hard
+
+"exponential-backoff@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "exponential-backoff@npm:3.1.1"
+  checksum: 3d21519a4f8207c99f7457287291316306255a328770d320b401114ec8481986e4e467e854cb9914dd965e0a1ca810a23ccb559c642c88f4c7f55c55778a9b48
   languageName: node
   linkType: hard
 
@@ -2570,22 +2557,22 @@ __metadata:
   linkType: hard
 
 "fast-diff@npm:^1.1.2":
-  version: 1.2.0
-  resolution: "fast-diff@npm:1.2.0"
-  checksum: 1b5306eaa9e826564d9e5ffcd6ebd881eb5f770b3f977fcbf38f05c824e42172b53c79920e8429c54eb742ce15a0caf268b0fdd5b38f6de52234c4a8368131ae
+  version: 1.3.0
+  resolution: "fast-diff@npm:1.3.0"
+  checksum: d22d371b994fdc8cce9ff510d7b8dc4da70ac327bcba20df607dd5b9cae9f908f4d1028f5fe467650f058d1e7270235ae0b8230809a262b4df587a3b3aa216c3
   languageName: node
   linkType: hard
 
 "fast-glob@npm:^3.2.9":
-  version: 3.2.12
-  resolution: "fast-glob@npm:3.2.12"
+  version: 3.3.2
+  resolution: "fast-glob@npm:3.3.2"
   dependencies:
     "@nodelib/fs.stat": ^2.0.2
     "@nodelib/fs.walk": ^1.2.3
     glob-parent: ^5.1.2
     merge2: ^1.3.0
     micromatch: ^4.0.4
-  checksum: 0b1990f6ce831c7e28c4d505edcdaad8e27e88ab9fa65eedadb730438cfc7cde4910d6c975d6b7b8dc8a73da4773702ebcfcd6e3518e73938bb1383badfe01c2
+  checksum: 900e4979f4dbc3313840078419245621259f349950411ca2fa445a2f9a1a6d98c3b5e7e0660c5ccd563aa61abe133a21765c6c0dec8e57da1ba71d8000b05ec1
   languageName: node
   linkType: hard
 
@@ -2670,19 +2657,30 @@ __metadata:
   linkType: hard
 
 "flat-cache@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "flat-cache@npm:3.0.4"
+  version: 3.2.0
+  resolution: "flat-cache@npm:3.2.0"
   dependencies:
-    flatted: ^3.1.0
+    flatted: ^3.2.9
+    keyv: ^4.5.3
     rimraf: ^3.0.2
-  checksum: 4fdd10ecbcbf7d520f9040dd1340eb5dfe951e6f0ecf2252edeec03ee68d989ec8b9a20f4434270e71bcfd57800dc09b3344fca3966b2eb8f613072c7d9a2365
+  checksum: e7e0f59801e288b54bee5cb9681e9ee21ee28ef309f886b312c9d08415b79fc0f24ac842f84356ce80f47d6a53de62197ce0e6e148dc42d5db005992e2a756ec
   languageName: node
   linkType: hard
 
-"flatted@npm:^3.1.0":
-  version: 3.2.7
-  resolution: "flatted@npm:3.2.7"
-  checksum: 427633049d55bdb80201c68f7eb1cbd533e03eac541f97d3aecab8c5526f12a20ccecaeede08b57503e772c769e7f8680b37e8d482d1e5f8d7e2194687f9ea35
+"flatted@npm:^3.2.9":
+  version: 3.2.9
+  resolution: "flatted@npm:3.2.9"
+  checksum: f14167fbe26a9d20f6fca8d998e8f1f41df72c8e81f9f2c9d61ed2bea058248f5e1cbd05e7f88c0e5087a6a0b822a1e5e2b446e879f3cfbe0b07ba2d7f80b026
+  languageName: node
+  linkType: hard
+
+"foreground-child@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "foreground-child@npm:3.1.1"
+  dependencies:
+    cross-spawn: ^7.0.0
+    signal-exit: ^4.0.1
+  checksum: 139d270bc82dc9e6f8bc045fe2aae4001dc2472157044fdfad376d0a3457f77857fa883c1c8b21b491c6caade9a926a4bed3d3d2e8d3c9202b151a4cbbd0bcd5
   languageName: node
   linkType: hard
 
@@ -2695,23 +2693,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^10.0.0":
-  version: 10.1.0
-  resolution: "fs-extra@npm:10.1.0"
+"fs-extra@npm:11.1.1":
+  version: 11.1.1
+  resolution: "fs-extra@npm:11.1.1"
   dependencies:
     graceful-fs: ^4.2.0
     jsonfile: ^6.0.1
     universalify: ^2.0.0
-  checksum: dc94ab37096f813cc3ca12f0f1b5ad6744dfed9ed21e953d72530d103cea193c2f81584a39e9dee1bea36de5ee66805678c0dddc048e8af1427ac19c00fffc50
+  checksum: fb883c68245b2d777fbc1f2082c9efb084eaa2bbf9fddaa366130d196c03608eebef7fb490541276429ee1ca99f317e2d73e96f5ca0999eefedf5a624ae1edfd
   languageName: node
   linkType: hard
 
-"fs-minipass@npm:^2.0.0, fs-minipass@npm:^2.1.0":
+"fs-minipass@npm:^2.0.0":
   version: 2.1.0
   resolution: "fs-minipass@npm:2.1.0"
   dependencies:
     minipass: ^3.0.0
   checksum: 1b8d128dae2ac6cc94230cc5ead341ba3e0efaef82dab46a33d171c044caaa6ca001364178d42069b2809c35a1c3c35079a32107c770e9ffab3901b59af8c8b1
+  languageName: node
+  linkType: hard
+
+"fs-minipass@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "fs-minipass@npm:3.0.3"
+  dependencies:
+    minipass: ^7.0.3
+  checksum: 8722a41109130851d979222d3ec88aabaceeaaf8f57b2a8f744ef8bd2d1ce95453b04a61daa0078822bc5cd21e008814f06fe6586f56fef511e71b8d2394d802
   languageName: node
   linkType: hard
 
@@ -2723,44 +2730,28 @@ __metadata:
   linkType: hard
 
 "fsevents@npm:^2.3.2":
-  version: 2.3.2
-  resolution: "fsevents@npm:2.3.2"
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: latest
-  checksum: 97ade64e75091afee5265e6956cb72ba34db7819b4c3e94c431d4be2b19b8bb7a2d4116da417950c3425f17c8fe693d25e20212cac583ac1521ad066b77ae31f
+  checksum: 11e6ea6fea15e42461fc55b4b0e4a0a3c654faa567f1877dbd353f39156f69def97a69936d1746619d656c4b93de2238bf731f6085a03a50cabf287c9d024317
   conditions: os=darwin
   languageName: node
   linkType: hard
 
 "fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>":
-  version: 2.3.2
-  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#~builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
     node-gyp: latest
   conditions: os=darwin
   languageName: node
   linkType: hard
 
-"function-bind@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "function-bind@npm:1.1.1"
-  checksum: b32fbaebb3f8ec4969f033073b43f5c8befbb58f1a79e12f1d7490358150359ebd92f49e72ff0144f65f2c48ea2a605bff2d07965f548f6474fd8efd95bf361a
-  languageName: node
-  linkType: hard
-
-"gauge@npm:^4.0.3":
-  version: 4.0.4
-  resolution: "gauge@npm:4.0.4"
-  dependencies:
-    aproba: ^1.0.3 || ^2.0.0
-    color-support: ^1.1.3
-    console-control-strings: ^1.1.0
-    has-unicode: ^2.0.1
-    signal-exit: ^3.0.7
-    string-width: ^4.2.3
-    strip-ansi: ^6.0.1
-    wide-align: ^1.1.5
-  checksum: 788b6bfe52f1dd8e263cda800c26ac0ca2ff6de0b6eee2fe0d9e3abf15e149b651bd27bf5226be10e6e3edb5c4e5d5985a5a1a98137e7a892f75eff76467ad2d
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 2b0ff4ce708d99715ad14a6d1f894e2a83242e4a52ccfcefaee5e40050562e5f6dafc1adbb4ce2d4ab47279a45dc736ab91ea5042d843c3c092820dfe032efb1
   languageName: node
   linkType: hard
 
@@ -2810,6 +2801,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"glob@npm:^10.2.2, glob@npm:^10.3.10":
+  version: 10.3.10
+  resolution: "glob@npm:10.3.10"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^2.3.5
+    minimatch: ^9.0.1
+    minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
+    path-scurry: ^1.10.1
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: 4f2fe2511e157b5a3f525a54092169a5f92405f24d2aed3142f4411df328baca13059f4182f1db1bf933e2c69c0bd89e57ae87edd8950cba8c7ccbe84f721cf3
+  languageName: node
+  linkType: hard
+
 "glob@npm:^7.1.3, glob@npm:^7.1.4":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
@@ -2824,19 +2830,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1":
-  version: 8.1.0
-  resolution: "glob@npm:8.1.0"
-  dependencies:
-    fs.realpath: ^1.0.0
-    inflight: ^1.0.4
-    inherits: 2
-    minimatch: ^5.0.1
-    once: ^1.3.0
-  checksum: 92fbea3221a7d12075f26f0227abac435de868dd0736a17170663783296d0dd8d3d532a5672b4488a439bf5d7fb85cdd07c11185d6cd39184f0385cbdfb86a47
-  languageName: node
-  linkType: hard
-
 "globals@npm:^11.1.0":
   version: 11.12.0
   resolution: "globals@npm:11.12.0"
@@ -2845,11 +2838,11 @@ __metadata:
   linkType: hard
 
 "globals@npm:^13.19.0":
-  version: 13.19.0
-  resolution: "globals@npm:13.19.0"
+  version: 13.23.0
+  resolution: "globals@npm:13.23.0"
   dependencies:
     type-fest: ^0.20.2
-  checksum: a000dbd00bcf28f0941d8a29c3522b1c3b8e4bfe4e60e262c477a550c3cbbe8dbe2925a6905f037acd40f9a93c039242e1f7079c76b0fd184bc41dcc3b5c8e2e
+  checksum: 194c97cf8d1ef6ba59417234c2386549c4103b6e5f24b1ff1952de61a4753e5d2069435ba629de711a6480b1b1d114a98e2ab27f85e966d5a10c319c3bbd3dc3
   languageName: node
   linkType: hard
 
@@ -2881,6 +2874,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"graphemer@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "graphemer@npm:1.4.0"
+  checksum: bab8f0be9b568857c7bec9fda95a89f87b783546d02951c40c33f84d05bb7da3fd10f863a9beb901463669b6583173a8c8cc6d6b306ea2b9b9d5d3d943c3a673
+  languageName: node
+  linkType: hard
+
 "has-flag@npm:^3.0.0":
   version: 3.0.0
   resolution: "has-flag@npm:3.0.0"
@@ -2895,19 +2895,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-unicode@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "has-unicode@npm:2.0.1"
-  checksum: 1eab07a7436512db0be40a710b29b5dc21fa04880b7f63c9980b706683127e3c1b57cb80ea96d47991bdae2dfe479604f6a1ba410106ee1046a41d1bd0814400
-  languageName: node
-  linkType: hard
-
-"has@npm:^1.0.3":
-  version: 1.0.3
-  resolution: "has@npm:1.0.3"
+"hasown@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "hasown@npm:2.0.0"
   dependencies:
-    function-bind: ^1.1.1
-  checksum: b9ad53d53be4af90ce5d1c38331e712522417d017d5ef1ebd0507e07c2fbad8686fffb8e12ddecd4c39ca9b9b47431afbb975b8abf7f3c3b82c98e9aad052792
+    function-bind: ^1.1.2
+  checksum: 6151c75ca12554565098641c98a40f4cc86b85b0fd5b6fe92360967e4605a4f9610f7757260b4e8098dd1c2ce7f4b095f2006fe72a570e3b6d2d28de0298c176
   languageName: node
   linkType: hard
 
@@ -2918,31 +2911,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-cache-semantics@npm:^4.1.0":
+"http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
   checksum: 83ac0bc60b17a3a36f9953e7be55e5c8f41acc61b22583060e8dedc9dd5e3607c823a88d0926f9150e571f90946835c7fe150732801010845c72cd8bbff1a236
   languageName: node
   linkType: hard
 
-"http-proxy-agent@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "http-proxy-agent@npm:5.0.0"
+"http-proxy-agent@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "http-proxy-agent@npm:7.0.0"
   dependencies:
-    "@tootallnate/once": 2
-    agent-base: 6
-    debug: 4
-  checksum: e2ee1ff1656a131953839b2a19cd1f3a52d97c25ba87bd2559af6ae87114abf60971e498021f9b73f9fd78aea8876d1fb0d4656aac8a03c6caa9fc175f22b786
+    agent-base: ^7.1.0
+    debug: ^4.3.4
+  checksum: 48d4fac997917e15f45094852b63b62a46d0c8a4f0b9c6c23ca26d27b8df8d178bed88389e604745e748bd9a01f5023e25093722777f0593c3f052009ff438b6
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.0":
-  version: 5.0.1
-  resolution: "https-proxy-agent@npm:5.0.1"
+"https-proxy-agent@npm:^7.0.1":
+  version: 7.0.2
+  resolution: "https-proxy-agent@npm:7.0.2"
   dependencies:
-    agent-base: 6
+    agent-base: ^7.0.2
     debug: 4
-  checksum: 571fccdf38184f05943e12d37d6ce38197becdd69e58d03f43637f7fa1269cf303a7d228aa27e5b27bbd3af8f09fd938e1c91dcfefff2df7ba77c20ed8dfc765
+  checksum: 088969a0dd476ea7a0ed0a2cf1283013682b08f874c3bc6696c83fa061d2c157d29ef0ad3eb70a2046010bb7665573b2388d10fdcb3e410a66995e5248444292
   languageName: node
   linkType: hard
 
@@ -2950,15 +2942,6 @@ __metadata:
   version: 2.1.0
   resolution: "human-signals@npm:2.1.0"
   checksum: b87fd89fce72391625271454e70f67fe405277415b48bcc0117ca73d31fa23a4241787afdc8d67f5a116cf37258c052f59ea82daffa72364d61351423848e3b8
-  languageName: node
-  linkType: hard
-
-"humanize-ms@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "humanize-ms@npm:1.2.1"
-  dependencies:
-    ms: ^2.0.0
-  checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
   languageName: node
   linkType: hard
 
@@ -2972,9 +2955,9 @@ __metadata:
   linkType: hard
 
 "ignore@npm:^5.2.0":
-  version: 5.2.4
-  resolution: "ignore@npm:5.2.4"
-  checksum: 3d4c309c6006e2621659311783eaea7ebcd41fe4ca1d78c91c473157ad6666a57a2df790fe0d07a12300d9aac2888204d7be8d59f9aaf665b1c7fcdb432517ef
+  version: 5.3.0
+  resolution: "ignore@npm:5.3.0"
+  checksum: 2736da6621f14ced652785cb05d86301a66d70248597537176612bd0c8630893564bd5f6421f8806b09e8472e75c591ef01672ab8059c07c6eb2c09cefe04bf9
   languageName: node
   linkType: hard
 
@@ -3014,13 +2997,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"infer-owner@npm:^1.0.4":
-  version: 1.0.4
-  resolution: "infer-owner@npm:1.0.4"
-  checksum: 181e732764e4a0611576466b4b87dac338972b839920b2a8cde43642e4ed6bd54dc1fb0b40874728f2a2df9a1b097b8ff83b56d5f8f8e3927f837fdcb47d8a89
-  languageName: node
-  linkType: hard
-
 "inflight@npm:^1.0.4":
   version: 1.0.6
   resolution: "inflight@npm:1.0.6"
@@ -3031,7 +3007,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:^2.0.3":
+"inherits@npm:2":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 4a48a733847879d6cf6691860a6b1e3f0f4754176e4d71494c41f3475553768b10f84b5ce1d40fbd0e34e6bfbb864ee35858ad4dd2cf31e02fc4a154b724d7f1
@@ -3052,12 +3028,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.9.0":
-  version: 2.11.0
-  resolution: "is-core-module@npm:2.11.0"
+"is-core-module@npm:^2.13.0":
+  version: 2.13.1
+  resolution: "is-core-module@npm:2.13.1"
   dependencies:
-    has: ^1.0.3
-  checksum: f96fd490c6b48eb4f6d10ba815c6ef13f410b0ba6f7eb8577af51697de523e5f2cd9de1c441b51d27251bf0e4aebc936545e33a5d26d5d51f28d25698d4a8bab
+    hasown: ^2.0.0
+  checksum: 256559ee8a9488af90e4bad16f5583c6d59e92f0742e9e8bb4331e758521ee86b810b93bae44f390766ffbc518a0488b18d9dab7da9a5ff997d499efc9403f7c
   languageName: node
   linkType: hard
 
@@ -3126,14 +3102,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "istanbul-lib-coverage@npm:3.2.0"
-  checksum: a2a545033b9d56da04a8571ed05c8120bf10e9bce01cf8633a3a2b0d1d83dff4ac4fe78d6d5673c27fc29b7f21a41d75f83a36be09f82a61c367b56aa73c1ff9
+"isexe@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "isexe@npm:3.1.1"
+  checksum: 7fe1931ee4e88eb5aa524cd3ceb8c882537bc3a81b02e438b240e47012eef49c86904d0f0e593ea7c3a9996d18d0f1f3be8d3eaa92333977b0c3a9d353d5563e
   languageName: node
   linkType: hard
 
-"istanbul-lib-instrument@npm:^5.0.4, istanbul-lib-instrument@npm:^5.1.0":
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-instrument@npm:^5.0.4":
   version: 5.2.1
   resolution: "istanbul-lib-instrument@npm:5.2.1"
   dependencies:
@@ -3146,14 +3129,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-instrument@npm:^6.0.0":
+  version: 6.0.1
+  resolution: "istanbul-lib-instrument@npm:6.0.1"
+  dependencies:
+    "@babel/core": ^7.12.3
+    "@babel/parser": ^7.14.7
+    "@istanbuljs/schema": ^0.1.2
+    istanbul-lib-coverage: ^3.2.0
+    semver: ^7.5.4
+  checksum: fb23472e739cfc9b027cefcd7d551d5e7ca7ff2817ae5150fab99fe42786a7f7b56a29a2aa8309c37092e18297b8003f9c274f50ca4360949094d17fbac81472
+  languageName: node
+  linkType: hard
+
 "istanbul-lib-report@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "istanbul-lib-report@npm:3.0.0"
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
   dependencies:
     istanbul-lib-coverage: ^3.0.0
-    make-dir: ^3.0.0
+    make-dir: ^4.0.0
     supports-color: ^7.1.0
-  checksum: 3f29eb3f53c59b987386e07fe772d24c7f58c6897f34c9d7a296f4000de7ae3de9eb95c3de3df91dc65b134c84dee35c54eee572a56243e8907c48064e34ff1b
+  checksum: fd17a1b879e7faf9bb1dc8f80b2a16e9f5b7b8498fe6ed580a618c34df0bfe53d2abd35bf8a0a00e628fb7405462576427c7df20bbe4148d19c14b431c974b21
   languageName: node
   linkType: hard
 
@@ -3169,68 +3165,81 @@ __metadata:
   linkType: hard
 
 "istanbul-reports@npm:^3.1.3":
-  version: 3.1.5
-  resolution: "istanbul-reports@npm:3.1.5"
+  version: 3.1.6
+  resolution: "istanbul-reports@npm:3.1.6"
   dependencies:
     html-escaper: ^2.0.0
     istanbul-lib-report: ^3.0.0
-  checksum: 7867228f83ed39477b188ea07e7ccb9b4f5320b6f73d1db93a0981b7414fa4ef72d3f80c4692c442f90fc250d9406e71d8d7ab65bb615cb334e6292b73192b89
+  checksum: 44c4c0582f287f02341e9720997f9e82c071627e1e862895745d5f52ec72c9b9f38e1d12370015d2a71dcead794f34c7732aaef3fab80a24bc617a21c3d911d6
   languageName: node
   linkType: hard
 
-"jest-changed-files@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-changed-files@npm:29.5.0"
+"jackspeak@npm:^2.3.5":
+  version: 2.3.6
+  resolution: "jackspeak@npm:2.3.6"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+    "@pkgjs/parseargs": ^0.11.0
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: 57d43ad11eadc98cdfe7496612f6bbb5255ea69fe51ea431162db302c2a11011642f50cfad57288bd0aea78384a0612b16e131944ad8ecd09d619041c8531b54
+  languageName: node
+  linkType: hard
+
+"jest-changed-files@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-changed-files@npm:29.7.0"
   dependencies:
     execa: ^5.0.0
+    jest-util: ^29.7.0
     p-limit: ^3.1.0
-  checksum: a67a7cb3c11f8f92bd1b7c79e84f724cbd11a9ad51f3cdadafe3ce7ee3c79ee50dbea128f920f5fddc807e9e4e83f5462143094391feedd959a77dd20ab96cf3
+  checksum: 963e203893c396c5dfc75e00a49426688efea7361b0f0e040035809cecd2d46b3c01c02be2d9e8d38b1138357d2de7719ea5b5be21f66c10f2e9685a5a73bb99
   languageName: node
   linkType: hard
 
-"jest-circus@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-circus@npm:29.5.0"
+"jest-circus@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-circus@npm:29.7.0"
   dependencies:
-    "@jest/environment": ^29.5.0
-    "@jest/expect": ^29.5.0
-    "@jest/test-result": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/environment": ^29.7.0
+    "@jest/expect": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     chalk: ^4.0.0
     co: ^4.6.0
-    dedent: ^0.7.0
+    dedent: ^1.0.0
     is-generator-fn: ^2.0.0
-    jest-each: ^29.5.0
-    jest-matcher-utils: ^29.5.0
-    jest-message-util: ^29.5.0
-    jest-runtime: ^29.5.0
-    jest-snapshot: ^29.5.0
-    jest-util: ^29.5.0
+    jest-each: ^29.7.0
+    jest-matcher-utils: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-runtime: ^29.7.0
+    jest-snapshot: ^29.7.0
+    jest-util: ^29.7.0
     p-limit: ^3.1.0
-    pretty-format: ^29.5.0
+    pretty-format: ^29.7.0
     pure-rand: ^6.0.0
     slash: ^3.0.0
     stack-utils: ^2.0.3
-  checksum: 44ff5d06acedae6de6c866e20e3b61f83e29ab94cf9f960826e7e667de49c12dd9ab9dffd7fa3b7d1f9688a8b5bfb1ebebadbea69d9ed0d3f66af4a0ff8c2b27
+  checksum: 349437148924a5a109c9b8aad6d393a9591b4dac1918fc97d81b7fc515bc905af9918495055071404af1fab4e48e4b04ac3593477b1d5dcf48c4e71b527c70a7
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-cli@npm:29.5.0"
+"jest-cli@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-cli@npm:29.7.0"
   dependencies:
-    "@jest/core": ^29.5.0
-    "@jest/test-result": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/core": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/types": ^29.6.3
     chalk: ^4.0.0
+    create-jest: ^29.7.0
     exit: ^0.1.2
-    graceful-fs: ^4.2.9
     import-local: ^3.0.2
-    jest-config: ^29.5.0
-    jest-util: ^29.5.0
-    jest-validate: ^29.5.0
-    prompts: ^2.0.1
+    jest-config: ^29.7.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
     yargs: ^17.3.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -3239,34 +3248,34 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: 39897bbbc0f0d8a6b975ab12fd13887eaa28d92e3dee9e0173a5cb913ae8cc2ae46e090d38c6d723e84d9d6724429cd08685b4e505fa447d31ca615630c7dbba
+  checksum: 664901277a3f5007ea4870632ed6e7889db9da35b2434e7cb488443e6bf5513889b344b7fddf15112135495b9875892b156faeb2d7391ddb9e2a849dcb7b6c36
   languageName: node
   linkType: hard
 
-"jest-config@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-config@npm:29.5.0"
+"jest-config@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-config@npm:29.7.0"
   dependencies:
     "@babel/core": ^7.11.6
-    "@jest/test-sequencer": ^29.5.0
-    "@jest/types": ^29.5.0
-    babel-jest: ^29.5.0
+    "@jest/test-sequencer": ^29.7.0
+    "@jest/types": ^29.6.3
+    babel-jest: ^29.7.0
     chalk: ^4.0.0
     ci-info: ^3.2.0
     deepmerge: ^4.2.2
     glob: ^7.1.3
     graceful-fs: ^4.2.9
-    jest-circus: ^29.5.0
-    jest-environment-node: ^29.5.0
-    jest-get-type: ^29.4.3
-    jest-regex-util: ^29.4.3
-    jest-resolve: ^29.5.0
-    jest-runner: ^29.5.0
-    jest-util: ^29.5.0
-    jest-validate: ^29.5.0
+    jest-circus: ^29.7.0
+    jest-environment-node: ^29.7.0
+    jest-get-type: ^29.6.3
+    jest-regex-util: ^29.6.3
+    jest-resolve: ^29.7.0
+    jest-runner: ^29.7.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
     micromatch: ^4.0.4
     parse-json: ^5.2.0
-    pretty-format: ^29.5.0
+    pretty-format: ^29.7.0
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
   peerDependencies:
@@ -3277,135 +3286,135 @@ __metadata:
       optional: true
     ts-node:
       optional: true
-  checksum: c37c4dab964c54ab293d4e302d40b09687037ac9d00b88348ec42366970747feeaf265e12e3750cd3660b40c518d4031335eda11ac10b70b10e60797ebbd4b9c
+  checksum: 4cabf8f894c180cac80b7df1038912a3fc88f96f2622de33832f4b3314f83e22b08fb751da570c0ab2b7988f21604bdabade95e3c0c041068ac578c085cf7dff
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-diff@npm:29.5.0"
+"jest-diff@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-diff@npm:29.7.0"
   dependencies:
     chalk: ^4.0.0
-    diff-sequences: ^29.4.3
-    jest-get-type: ^29.4.3
-    pretty-format: ^29.5.0
-  checksum: dfd0f4a299b5d127779c76b40106c37854c89c3e0785098c717d52822d6620d227f6234c3a9291df204d619e799e3654159213bf93220f79c8e92a55475a3d39
+    diff-sequences: ^29.6.3
+    jest-get-type: ^29.6.3
+    pretty-format: ^29.7.0
+  checksum: 08e24a9dd43bfba1ef07a6374e5af138f53137b79ec3d5cc71a2303515335898888fa5409959172e1e05de966c9e714368d15e8994b0af7441f0721ee8e1bb77
   languageName: node
   linkType: hard
 
-"jest-docblock@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "jest-docblock@npm:29.4.3"
+"jest-docblock@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-docblock@npm:29.7.0"
   dependencies:
     detect-newline: ^3.0.0
-  checksum: e0e9df1485bb8926e5b33478cdf84b3387d9caf3658e7dc1eaa6dc34cb93dea0d2d74797f6e940f0233a88f3dadd60957f2288eb8f95506361f85b84bf8661df
+  checksum: 66390c3e9451f8d96c5da62f577a1dad701180cfa9b071c5025acab2f94d7a3efc2515cfa1654ebe707213241541ce9c5530232cdc8017c91ed64eea1bd3b192
   languageName: node
   linkType: hard
 
-"jest-each@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-each@npm:29.5.0"
+"jest-each@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-each@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     chalk: ^4.0.0
-    jest-get-type: ^29.4.3
-    jest-util: ^29.5.0
-    pretty-format: ^29.5.0
-  checksum: b8b297534d25834c5d4e31e4c687359787b1e402519e42664eb704cc3a12a7a91a017565a75acb02e8cf9afd3f4eef3350bd785276bec0900184641b765ff7a5
+    jest-get-type: ^29.6.3
+    jest-util: ^29.7.0
+    pretty-format: ^29.7.0
+  checksum: e88f99f0184000fc8813f2a0aa79e29deeb63700a3b9b7928b8a418d7d93cd24933608591dbbdea732b473eb2021c72991b5cc51a17966842841c6e28e6f691c
   languageName: node
   linkType: hard
 
-"jest-environment-node@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-environment-node@npm:29.5.0"
+"jest-environment-node@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-environment-node@npm:29.7.0"
   dependencies:
-    "@jest/environment": ^29.5.0
-    "@jest/fake-timers": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/environment": ^29.7.0
+    "@jest/fake-timers": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
-    jest-mock: ^29.5.0
-    jest-util: ^29.5.0
-  checksum: 57981911cc20a4219b0da9e22b2e3c9f31b505e43f78e61c899e3227ded455ce1a3a9483842c69cfa4532f02cfb536ae0995bf245f9211608edacfc1e478d411
+    jest-mock: ^29.7.0
+    jest-util: ^29.7.0
+  checksum: 501a9966292cbe0ca3f40057a37587cb6def25e1e0c5e39ac6c650fe78d3c70a2428304341d084ac0cced5041483acef41c477abac47e9a290d5545fd2f15646
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "jest-get-type@npm:29.4.3"
-  checksum: 6ac7f2dde1c65e292e4355b6c63b3a4897d7e92cb4c8afcf6d397f2682f8080e094c8b0b68205a74d269882ec06bf696a9de6cd3e1b7333531e5ed7b112605ce
+"jest-get-type@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-get-type@npm:29.6.3"
+  checksum: 88ac9102d4679d768accae29f1e75f592b760b44277df288ad76ce5bf038c3f5ce3719dea8aa0f035dac30e9eb034b848ce716b9183ad7cc222d029f03e92205
   languageName: node
   linkType: hard
 
-"jest-haste-map@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-haste-map@npm:29.5.0"
+"jest-haste-map@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-haste-map@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     "@types/graceful-fs": ^4.1.3
     "@types/node": "*"
     anymatch: ^3.0.3
     fb-watchman: ^2.0.0
     fsevents: ^2.3.2
     graceful-fs: ^4.2.9
-    jest-regex-util: ^29.4.3
-    jest-util: ^29.5.0
-    jest-worker: ^29.5.0
+    jest-regex-util: ^29.6.3
+    jest-util: ^29.7.0
+    jest-worker: ^29.7.0
     micromatch: ^4.0.4
     walker: ^1.0.8
   dependenciesMeta:
     fsevents:
       optional: true
-  checksum: 3828ff7783f168e34be2c63887f82a01634261f605dcae062d83f979a61c37739e21b9607ecb962256aea3fbe5a530a1acee062d0026fcb47c607c12796cf3b7
+  checksum: c2c8f2d3e792a963940fbdfa563ce14ef9e14d4d86da645b96d3cd346b8d35c5ce0b992ee08593939b5f718cf0a1f5a90011a056548a1dbf58397d4356786f01
   languageName: node
   linkType: hard
 
-"jest-leak-detector@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-leak-detector@npm:29.5.0"
+"jest-leak-detector@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-leak-detector@npm:29.7.0"
   dependencies:
-    jest-get-type: ^29.4.3
-    pretty-format: ^29.5.0
-  checksum: 0fb845da7ac9cdfc9b3b2e35f6f623a41c547d7dc0103ceb0349013459d00de5870b5689a625e7e37f9644934b40e8f1dcdd5422d14d57470600350364676313
+    jest-get-type: ^29.6.3
+    pretty-format: ^29.7.0
+  checksum: e3950e3ddd71e1d0c22924c51a300a1c2db6cf69ec1e51f95ccf424bcc070f78664813bef7aed4b16b96dfbdeea53fe358f8aeaaea84346ae15c3735758f1605
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-matcher-utils@npm:29.5.0"
+"jest-matcher-utils@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-matcher-utils@npm:29.7.0"
   dependencies:
     chalk: ^4.0.0
-    jest-diff: ^29.5.0
-    jest-get-type: ^29.4.3
-    pretty-format: ^29.5.0
-  checksum: 1d3e8c746e484a58ce194e3aad152eff21fd0896e8b8bf3d4ab1a4e2cbfed95fb143646f4ad9fdf6e42212b9e8fc033268b58e011b044a9929df45485deb5ac9
+    jest-diff: ^29.7.0
+    jest-get-type: ^29.6.3
+    pretty-format: ^29.7.0
+  checksum: d7259e5f995d915e8a37a8fd494cb7d6af24cd2a287b200f831717ba0d015190375f9f5dc35393b8ba2aae9b2ebd60984635269c7f8cff7d85b077543b7744cd
   languageName: node
   linkType: hard
 
-"jest-message-util@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-message-util@npm:29.5.0"
+"jest-message-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-message-util@npm:29.7.0"
   dependencies:
     "@babel/code-frame": ^7.12.13
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     "@types/stack-utils": ^2.0.0
     chalk: ^4.0.0
     graceful-fs: ^4.2.9
     micromatch: ^4.0.4
-    pretty-format: ^29.5.0
+    pretty-format: ^29.7.0
     slash: ^3.0.0
     stack-utils: ^2.0.3
-  checksum: daddece6bbf846eb6a2ab9be9f2446e54085bef4e5cecd13d2a538fa9c01cb89d38e564c6b74fd8e12d37ed9eface8a362240ae9f21d68b214590631e7a0d8bf
+  checksum: a9d025b1c6726a2ff17d54cc694de088b0489456c69106be6b615db7a51b7beb66788bea7a59991a019d924fbf20f67d085a445aedb9a4d6760363f4d7d09930
   languageName: node
   linkType: hard
 
-"jest-mock@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-mock@npm:29.5.0"
+"jest-mock@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-mock@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
-    jest-util: ^29.5.0
-  checksum: 2a9cf07509948fa8608898c445f04fe4dd6e2049ff431e5531eee028c808d3ba3c67f226ac87b0cf383feaa1055776900d197c895e89783016886ac17a4ff10c
+    jest-util: ^29.7.0
+  checksum: 81ba9b68689a60be1482212878973700347cb72833c5e5af09895882b9eb5c4e02843a1bbdf23f94c52d42708bab53a30c45a3482952c9eec173d1eaac5b86c5
   languageName: node
   linkType: hard
 
@@ -3421,194 +3430,191 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-regex-util@npm:^29.4.3":
-  version: 29.4.3
-  resolution: "jest-regex-util@npm:29.4.3"
-  checksum: 96fc7fc28cd4dd73a63c13a526202c4bd8b351d4e5b68b1a2a2c88da3308c2a16e26feaa593083eb0bac38cca1aa9dd05025412e7de013ba963fb8e66af22b8a
+"jest-regex-util@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-regex-util@npm:29.6.3"
+  checksum: 0518beeb9bf1228261695e54f0feaad3606df26a19764bc19541e0fc6e2a3737191904607fb72f3f2ce85d9c16b28df79b7b1ec9443aa08c3ef0e9efda6f8f2a
   languageName: node
   linkType: hard
 
-"jest-resolve-dependencies@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-resolve-dependencies@npm:29.5.0"
+"jest-resolve-dependencies@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve-dependencies@npm:29.7.0"
   dependencies:
-    jest-regex-util: ^29.4.3
-    jest-snapshot: ^29.5.0
-  checksum: 479d2e5365d58fe23f2b87001e2e0adcbffe0147700e85abdec8f14b9703b0a55758c1929a9989e3f5d5e954fb88870ea4bfa04783523b664562fcf5f10b0edf
+    jest-regex-util: ^29.6.3
+    jest-snapshot: ^29.7.0
+  checksum: aeb75d8150aaae60ca2bb345a0d198f23496494677cd6aefa26fc005faf354061f073982175daaf32b4b9d86b26ca928586344516e3e6969aa614cb13b883984
   languageName: node
   linkType: hard
 
-"jest-resolve@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-resolve@npm:29.5.0"
+"jest-resolve@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-resolve@npm:29.7.0"
   dependencies:
     chalk: ^4.0.0
     graceful-fs: ^4.2.9
-    jest-haste-map: ^29.5.0
+    jest-haste-map: ^29.7.0
     jest-pnp-resolver: ^1.2.2
-    jest-util: ^29.5.0
-    jest-validate: ^29.5.0
+    jest-util: ^29.7.0
+    jest-validate: ^29.7.0
     resolve: ^1.20.0
     resolve.exports: ^2.0.0
     slash: ^3.0.0
-  checksum: 9a125f3cf323ceef512089339d35f3ee37f79fe16a831fb6a26773ea6a229b9e490d108fec7af334142e91845b5996de8e7cdd85a4d8d617078737d804e29c8f
+  checksum: 0ca218e10731aa17920526ec39deaec59ab9b966237905ffc4545444481112cd422f01581230eceb7e82d86f44a543d520a71391ec66e1b4ef1a578bd5c73487
   languageName: node
   linkType: hard
 
-"jest-runner@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-runner@npm:29.5.0"
+"jest-runner@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runner@npm:29.7.0"
   dependencies:
-    "@jest/console": ^29.5.0
-    "@jest/environment": ^29.5.0
-    "@jest/test-result": ^29.5.0
-    "@jest/transform": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/console": ^29.7.0
+    "@jest/environment": ^29.7.0
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     chalk: ^4.0.0
     emittery: ^0.13.1
     graceful-fs: ^4.2.9
-    jest-docblock: ^29.4.3
-    jest-environment-node: ^29.5.0
-    jest-haste-map: ^29.5.0
-    jest-leak-detector: ^29.5.0
-    jest-message-util: ^29.5.0
-    jest-resolve: ^29.5.0
-    jest-runtime: ^29.5.0
-    jest-util: ^29.5.0
-    jest-watcher: ^29.5.0
-    jest-worker: ^29.5.0
+    jest-docblock: ^29.7.0
+    jest-environment-node: ^29.7.0
+    jest-haste-map: ^29.7.0
+    jest-leak-detector: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-resolve: ^29.7.0
+    jest-runtime: ^29.7.0
+    jest-util: ^29.7.0
+    jest-watcher: ^29.7.0
+    jest-worker: ^29.7.0
     p-limit: ^3.1.0
     source-map-support: 0.5.13
-  checksum: 437dea69c5dddca22032259787bac74790d5a171c9d804711415f31e5d1abfb64fa52f54a9015bb17a12b858fd0cf3f75ef6f3c9e94255a8596e179f707229c4
+  checksum: f0405778ea64812bf9b5c50b598850d94ccf95d7ba21f090c64827b41decd680ee19fcbb494007cdd7f5d0d8906bfc9eceddd8fa583e753e736ecd462d4682fb
   languageName: node
   linkType: hard
 
-"jest-runtime@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-runtime@npm:29.5.0"
+"jest-runtime@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-runtime@npm:29.7.0"
   dependencies:
-    "@jest/environment": ^29.5.0
-    "@jest/fake-timers": ^29.5.0
-    "@jest/globals": ^29.5.0
-    "@jest/source-map": ^29.4.3
-    "@jest/test-result": ^29.5.0
-    "@jest/transform": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/environment": ^29.7.0
+    "@jest/fake-timers": ^29.7.0
+    "@jest/globals": ^29.7.0
+    "@jest/source-map": ^29.6.3
+    "@jest/test-result": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     chalk: ^4.0.0
     cjs-module-lexer: ^1.0.0
     collect-v8-coverage: ^1.0.0
     glob: ^7.1.3
     graceful-fs: ^4.2.9
-    jest-haste-map: ^29.5.0
-    jest-message-util: ^29.5.0
-    jest-mock: ^29.5.0
-    jest-regex-util: ^29.4.3
-    jest-resolve: ^29.5.0
-    jest-snapshot: ^29.5.0
-    jest-util: ^29.5.0
+    jest-haste-map: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-mock: ^29.7.0
+    jest-regex-util: ^29.6.3
+    jest-resolve: ^29.7.0
+    jest-snapshot: ^29.7.0
+    jest-util: ^29.7.0
     slash: ^3.0.0
     strip-bom: ^4.0.0
-  checksum: 7af27bd9d54cf1c5735404cf8d76c6509d5610b1ec0106a21baa815c1aff15d774ce534ac2834bc440dccfe6348bae1885fd9a806f23a94ddafdc0f5bae4b09d
+  checksum: d19f113d013e80691e07047f68e1e3448ef024ff2c6b586ce4f90cd7d4c62a2cd1d460110491019719f3c59bfebe16f0e201ed005ef9f80e2cf798c374eed54e
   languageName: node
   linkType: hard
 
-"jest-snapshot@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-snapshot@npm:29.5.0"
+"jest-snapshot@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-snapshot@npm:29.7.0"
   dependencies:
     "@babel/core": ^7.11.6
     "@babel/generator": ^7.7.2
     "@babel/plugin-syntax-jsx": ^7.7.2
     "@babel/plugin-syntax-typescript": ^7.7.2
-    "@babel/traverse": ^7.7.2
     "@babel/types": ^7.3.3
-    "@jest/expect-utils": ^29.5.0
-    "@jest/transform": ^29.5.0
-    "@jest/types": ^29.5.0
-    "@types/babel__traverse": ^7.0.6
-    "@types/prettier": ^2.1.5
+    "@jest/expect-utils": ^29.7.0
+    "@jest/transform": ^29.7.0
+    "@jest/types": ^29.6.3
     babel-preset-current-node-syntax: ^1.0.0
     chalk: ^4.0.0
-    expect: ^29.5.0
+    expect: ^29.7.0
     graceful-fs: ^4.2.9
-    jest-diff: ^29.5.0
-    jest-get-type: ^29.4.3
-    jest-matcher-utils: ^29.5.0
-    jest-message-util: ^29.5.0
-    jest-util: ^29.5.0
+    jest-diff: ^29.7.0
+    jest-get-type: ^29.6.3
+    jest-matcher-utils: ^29.7.0
+    jest-message-util: ^29.7.0
+    jest-util: ^29.7.0
     natural-compare: ^1.4.0
-    pretty-format: ^29.5.0
-    semver: ^7.3.5
-  checksum: fe5df54122ed10eed625de6416a45bc4958d5062b018f05b152bf9785ab7f355dcd55e40cf5da63895bf8278f8d7b2bb4059b2cfbfdee18f509d455d37d8aa2b
+    pretty-format: ^29.7.0
+    semver: ^7.5.3
+  checksum: 86821c3ad0b6899521ce75ee1ae7b01b17e6dfeff9166f2cf17f012e0c5d8c798f30f9e4f8f7f5bed01ea7b55a6bc159f5eda778311162cbfa48785447c237ad
   languageName: node
   linkType: hard
 
-"jest-util@npm:^29.0.0, jest-util@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-util@npm:29.5.0"
+"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-util@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     chalk: ^4.0.0
     ci-info: ^3.2.0
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
-  checksum: fd9212950d34d2ecad8c990dda0d8ea59a8a554b0c188b53ea5d6c4a0829a64f2e1d49e6e85e812014933d17426d7136da4785f9cf76fff1799de51b88bc85d3
+  checksum: 042ab4980f4ccd4d50226e01e5c7376a8556b472442ca6091a8f102488c0f22e6e8b89ea874111d2328a2080083bf3225c86f3788c52af0bd0345a00eb57a3ca
   languageName: node
   linkType: hard
 
-"jest-validate@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-validate@npm:29.5.0"
+"jest-validate@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-validate@npm:29.7.0"
   dependencies:
-    "@jest/types": ^29.5.0
+    "@jest/types": ^29.6.3
     camelcase: ^6.2.0
     chalk: ^4.0.0
-    jest-get-type: ^29.4.3
+    jest-get-type: ^29.6.3
     leven: ^3.1.0
-    pretty-format: ^29.5.0
-  checksum: 43ca5df7cb75572a254ac3e92fbbe7be6b6a1be898cc1e887a45d55ea003f7a112717d814a674d37f9f18f52d8de40873c8f084f17664ae562736c78dd44c6a1
+    pretty-format: ^29.7.0
+  checksum: 191fcdc980f8a0de4dbdd879fa276435d00eb157a48683af7b3b1b98b0f7d9de7ffe12689b617779097ff1ed77601b9f7126b0871bba4f776e222c40f62e9dae
   languageName: node
   linkType: hard
 
-"jest-watcher@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-watcher@npm:29.5.0"
+"jest-watcher@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-watcher@npm:29.7.0"
   dependencies:
-    "@jest/test-result": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/test-result": ^29.7.0
+    "@jest/types": ^29.6.3
     "@types/node": "*"
     ansi-escapes: ^4.2.1
     chalk: ^4.0.0
     emittery: ^0.13.1
-    jest-util: ^29.5.0
+    jest-util: ^29.7.0
     string-length: ^4.0.1
-  checksum: 62303ac7bdc7e61a8b4239a239d018f7527739da2b2be6a81a7be25b74ca769f1c43ee8558ce8e72bb857245c46d6e03af331227ffb00a57280abb2a928aa776
+  checksum: 67e6e7fe695416deff96b93a14a561a6db69389a0667e9489f24485bb85e5b54e12f3b2ba511ec0b777eca1e727235b073e3ebcdd473d68888650489f88df92f
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest-worker@npm:29.5.0"
+"jest-worker@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-worker@npm:29.7.0"
   dependencies:
     "@types/node": "*"
-    jest-util: ^29.5.0
+    jest-util: ^29.7.0
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
-  checksum: 1151a1ae3602b1ea7c42a8f1efe2b5a7bf927039deaa0827bf978880169899b705744e288f80a63603fb3fc2985e0071234986af7dc2c21c7a64333d8777c7c9
+  checksum: 30fff60af49675273644d408b650fc2eb4b5dcafc5a0a455f238322a8f9d8a98d847baca9d51ff197b6747f54c7901daa2287799230b856a0f48287d131f8c13
   languageName: node
   linkType: hard
 
 "jest@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "jest@npm:29.5.0"
+  version: 29.7.0
+  resolution: "jest@npm:29.7.0"
   dependencies:
-    "@jest/core": ^29.5.0
-    "@jest/types": ^29.5.0
+    "@jest/core": ^29.7.0
+    "@jest/types": ^29.6.3
     import-local: ^3.0.2
-    jest-cli: ^29.5.0
+    jest-cli: ^29.7.0
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -3616,14 +3622,14 @@ __metadata:
       optional: true
   bin:
     jest: bin/jest.js
-  checksum: a8ff2eb0f421623412236e23cbe67c638127fffde466cba9606bc0c0553b4c1e5cb116d7e0ef990b5d1712851652c8ee461373b578df50857fe635b94ff455d5
+  checksum: 17ca8d67504a7dbb1998cf3c3077ec9031ba3eb512da8d71cb91bcabb2b8995c4e4b292b740cb9bf1cbff5ce3e110b3f7c777b0cefb6f41ab05445f248d0ee0b
   languageName: node
   linkType: hard
 
 "js-sdsl@npm:^4.1.4":
-  version: 4.4.0
-  resolution: "js-sdsl@npm:4.4.0"
-  checksum: 7bb08a2d746ab7ff742720339aa006c631afe05e77d11eda988c1c35fae8e03e492e4e347e883e786e3ce6170685d4780c125619111f0730c11fdb41b04059c7
+  version: 4.4.2
+  resolution: "js-sdsl@npm:4.4.2"
+  checksum: ba705adc1788bf3c6f6c8e5077824f2bb4f0acab5a984420ce5cc492c7fff3daddc26335ad2c9a67d4f5e3241ec790f9e5b72a625adcf20cf321d2fd85e62b8b
   languageName: node
   linkType: hard
 
@@ -3666,6 +3672,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-buffer@npm:3.0.1":
+  version: 3.0.1
+  resolution: "json-buffer@npm:3.0.1"
+  checksum: 9026b03edc2847eefa2e37646c579300a1f3a4586cfb62bf857832b60c852042d0d6ae55d1afb8926163fa54c2b01d83ae24705f34990348bdac6273a29d4581
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -3694,7 +3707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json5@npm:^2.2.2, json5@npm:^2.2.3":
+"json5@npm:^2.2.3":
   version: 2.2.3
   resolution: "json5@npm:2.2.3"
   bin:
@@ -3720,6 +3733,15 @@ __metadata:
     graceful-fs:
       optional: true
   checksum: 7af3b8e1ac8fe7f1eccc6263c6ca14e1966fcbc74b618d3c78a0a2075579487547b94f72b7a1114e844a1e15bb00d440e5d1720bfc4612d790a6f285d5ea8354
+  languageName: node
+  linkType: hard
+
+"keyv@npm:^4.5.3":
+  version: 4.5.4
+  resolution: "keyv@npm:4.5.4"
+  dependencies:
+    json-buffer: 3.0.1
+  checksum: 74a24395b1c34bd44ad5cb2b49140d087553e170625240b86755a6604cd65aa16efdbdeae5cdb17ba1284a0fbb25ad06263755dbc71b8d8b06f74232ce3cdd72
   languageName: node
   linkType: hard
 
@@ -3786,10 +3808,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+"lru-cache@npm:^10.0.1, lru-cache@npm:^9.1.1 || ^10.0.0":
+  version: 10.0.2
+  resolution: "lru-cache@npm:10.0.2"
+  dependencies:
+    semver: ^7.3.5
+  checksum: 83ad0e899d79f48574bdda131fe8157c6d65cbd073a6e78e0d1a3467a85dce1ef4d8dc9fd618a56c57a068271501c81d54471e13f84dd121e046b155ed061ed4
   languageName: node
   linkType: hard
 
@@ -3811,13 +3835,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^7.7.1":
-  version: 7.14.1
-  resolution: "lru-cache@npm:7.14.1"
-  checksum: d72c6713c6a6d86836a7a6523b3f1ac6764768cca47ec99341c3e76db06aacd4764620e5e2cda719a36848785a52a70e531822dc2b33fb071fa709683746c104
-  languageName: node
-  linkType: hard
-
 "lunr@npm:^2.3.9":
   version: 2.3.9
   resolution: "lunr@npm:2.3.9"
@@ -3825,12 +3842,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "make-dir@npm:3.1.0"
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
   dependencies:
-    semver: ^6.0.0
-  checksum: 484200020ab5a1fdf12f393fe5f385fc8e4378824c940fba1729dcd198ae4ff24867bc7a5646331e50cead8abff5d9270c456314386e629acec6dff4b8016b78
+    semver: ^7.5.3
+  checksum: bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
   languageName: node
   linkType: hard
 
@@ -3841,27 +3858,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-fetch-happen@npm:^10.0.3":
-  version: 10.2.1
-  resolution: "make-fetch-happen@npm:10.2.1"
+"make-fetch-happen@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "make-fetch-happen@npm:13.0.0"
   dependencies:
-    agentkeepalive: ^4.2.1
-    cacache: ^16.1.0
-    http-cache-semantics: ^4.1.0
-    http-proxy-agent: ^5.0.0
-    https-proxy-agent: ^5.0.0
+    "@npmcli/agent": ^2.0.0
+    cacache: ^18.0.0
+    http-cache-semantics: ^4.1.1
     is-lambda: ^1.0.1
-    lru-cache: ^7.7.1
-    minipass: ^3.1.6
-    minipass-collect: ^1.0.2
-    minipass-fetch: ^2.0.3
+    minipass: ^7.0.2
+    minipass-fetch: ^3.0.0
     minipass-flush: ^1.0.5
     minipass-pipeline: ^1.2.4
     negotiator: ^0.6.3
     promise-retry: ^2.0.1
-    socks-proxy-agent: ^7.0.0
-    ssri: ^9.0.0
-  checksum: 2332eb9a8ec96f1ffeeea56ccefabcb4193693597b132cd110734d50f2928842e22b84cfa1508e921b8385cdfd06dda9ad68645fed62b50fff629a580f5fb72c
+    ssri: ^10.0.0
+  checksum: 7c7a6d381ce919dd83af398b66459a10e2fe8f4504f340d1d090d3fa3d1b0c93750220e1d898114c64467223504bd258612ba83efbc16f31b075cd56de24b4af
   languageName: node
   linkType: hard
 
@@ -3923,21 +3935,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^5.0.1":
-  version: 5.1.4
-  resolution: "minimatch@npm:5.1.4"
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 0de6d7d154e70d12487b30a7bfcb74bd15fd1f1ec007a2516699ba76e63f78ca2e5016c200b242ed75123aff8dcccf49947f71b629fb1b1f221c8e76a13ed8de
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "minimatch@npm:9.0.1"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 97f5f5284bb57dc65b9415dec7f17a0f6531a33572193991c60ff18450dcfad5c2dad24ffeaf60b5261dccd63aae58cc3306e2209d57e7f88c51295a532d8ec3
+  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
   languageName: node
   linkType: hard
 
@@ -3950,18 +3953,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-fetch@npm:^2.0.3":
-  version: 2.1.2
-  resolution: "minipass-fetch@npm:2.1.2"
+"minipass-fetch@npm:^3.0.0":
+  version: 3.0.4
+  resolution: "minipass-fetch@npm:3.0.4"
   dependencies:
     encoding: ^0.1.13
-    minipass: ^3.1.6
+    minipass: ^7.0.3
     minipass-sized: ^1.0.3
     minizlib: ^2.1.2
   dependenciesMeta:
     encoding:
       optional: true
-  checksum: 3f216be79164e915fc91210cea1850e488793c740534985da017a4cbc7a5ff50506956d0f73bb0cb60e4fe91be08b6b61ef35101706d3ef5da2c8709b5f08f91
+  checksum: af7aad15d5c128ab1ebe52e043bdf7d62c3c6f0cecb9285b40d7b395e1375b45dcdfd40e63e93d26a0e8249c9efd5c325c65575aceee192883970ff8cb11364a
   languageName: node
   linkType: hard
 
@@ -3992,7 +3995,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^3.0.0, minipass@npm:^3.1.1, minipass@npm:^3.1.6":
+"minipass@npm:^3.0.0":
   version: 3.3.6
   resolution: "minipass@npm:3.3.6"
   dependencies:
@@ -4001,12 +4004,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "minipass@npm:4.0.0"
-  dependencies:
-    yallist: ^4.0.0
-  checksum: 7a609afbf394abfcf9c48e6c90226f471676c8f2a67f07f6838871afb03215ede431d1433feffe1b855455bcb13ef0eb89162841b9796109d6fed8d89790f381
+"minipass@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "minipass@npm:5.0.0"
+  checksum: 425dab288738853fded43da3314a0b5c035844d6f3097a8e3b5b29b328da8f3c1af6fc70618b32c29ff906284cf6406b6841376f21caaadd0793c1d5a6a620ea
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0, minipass@npm:^7.0.2, minipass@npm:^7.0.3":
+  version: 7.0.4
+  resolution: "minipass@npm:7.0.4"
+  checksum: 87585e258b9488caf2e7acea242fd7856bbe9a2c84a7807643513a338d66f368c7d518200ad7b70a508664d408aa000517647b2930c259a8b1f9f0984f344a21
   languageName: node
   linkType: hard
 
@@ -4020,7 +4028,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:^1.0.3, mkdirp@npm:^1.0.4":
+"mkdirp@npm:^1.0.3":
   version: 1.0.4
   resolution: "mkdirp@npm:1.0.4"
   bin:
@@ -4029,10 +4037,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mock-socket@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "mock-socket@npm:9.2.1"
-  checksum: daf07689563163dbcefbefe23b2a9784a75d0af31706f23ad535c6ab2abbcdefa2e91acddeb50a3c39009139e47a8f909cbb38e8137452193ccb9331637fee3e
+"mock-socket@npm:^9.3.1":
+  version: 9.3.1
+  resolution: "mock-socket@npm:9.3.1"
+  checksum: cb2dde4fc5dde280dd5ccb78eaaa223382ee16437f46b86558017655584ad08c22e733bde2dd5cc86927def506b6caeb0147e3167b9a62d70d5cf19d44103853
   languageName: node
   linkType: hard
 
@@ -4040,13 +4048,6 @@ __metadata:
   version: 2.1.2
   resolution: "ms@npm:2.1.2"
   checksum: 673cdb2c3133eb050c745908d8ce632ed2c02d85640e2edb3ace856a2266a813b30c613569bf3354fdf4ea7d1a1494add3bfa95e2713baa27d0c2c71fc44f58f
-  languageName: node
-  linkType: hard
-
-"ms@npm:^2.0.0":
-  version: 2.1.3
-  resolution: "ms@npm:2.1.3"
-  checksum: aa92de608021b242401676e35cfa5aa42dd70cbdc082b916da7fb925c542173e36bce97ea3e804923fe92c0ad991434e4a38327e15a1b5b5f945d66df615ae6d
   languageName: node
   linkType: hard
 
@@ -4071,15 +4072,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nock@npm:^13.3.1":
-  version: 13.3.1
-  resolution: "nock@npm:13.3.1"
+"nock@npm:^13.3.4":
+  version: 13.3.8
+  resolution: "nock@npm:13.3.8"
   dependencies:
     debug: ^4.1.0
     json-stringify-safe: ^5.0.1
-    lodash: ^4.17.21
     propagate: ^2.0.0
-  checksum: 0f2a73e8432f6b5650656c53eef99f9e5bbde3df538dc2f07057edc4438cfc61a394c9d06dd82e60f6e86d42433f20f3c04364a1f088beee7bf03a24e3f0fdd0
+  checksum: 98f7d9d1c6b4fad560d7f1033705f9a0318e288060c10e36973d1798d6c824fee1f23a9ecbb1118bf70068f58bb04eaa50c5d046f5cf0ceaf4a2dc76fe7a82b2
   languageName: node
   linkType: hard
 
@@ -4104,34 +4104,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^3.3.1":
-  version: 3.3.1
-  resolution: "node-fetch@npm:3.3.1"
+"node-fetch@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "node-fetch@npm:3.3.2"
   dependencies:
     data-uri-to-buffer: ^4.0.0
     fetch-blob: ^3.1.4
     formdata-polyfill: ^4.0.10
-  checksum: 62145fd3ba4770a76110bc31fdc0054ab2f5442b5ce96e9c4b39fc9e94a3d305560eec76e1165d9259eab866e02a8eecf9301062bb5dfc9f08a4d08b69d223dd
+  checksum: 06a04095a2ddf05b0830a0d5302699704d59bda3102894ea64c7b9d4c865ecdff2d90fd042df7f5bc40337266961cb6183dcc808ea4f3000d024f422b462da92
   languageName: node
   linkType: hard
 
 "node-gyp@npm:latest":
-  version: 9.3.1
-  resolution: "node-gyp@npm:9.3.1"
+  version: 10.0.1
+  resolution: "node-gyp@npm:10.0.1"
   dependencies:
     env-paths: ^2.2.0
-    glob: ^7.1.4
+    exponential-backoff: ^3.1.1
+    glob: ^10.3.10
     graceful-fs: ^4.2.6
-    make-fetch-happen: ^10.0.3
-    nopt: ^6.0.0
-    npmlog: ^6.0.0
-    rimraf: ^3.0.2
+    make-fetch-happen: ^13.0.0
+    nopt: ^7.0.0
+    proc-log: ^3.0.0
     semver: ^7.3.5
     tar: ^6.1.2
-    which: ^2.0.2
+    which: ^4.0.0
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: b860e9976fa645ca0789c69e25387401b4396b93c8375489b5151a6c55cf2640a3b6183c212b38625ef7c508994930b72198338e3d09b9d7ade5acc4aaf51ea7
+  checksum: 60a74e66d364903ce02049966303a57f898521d139860ac82744a5fdd9f7b7b3b61f75f284f3bfe6e6add3b8f1871ce305a1d41f775c7482de837b50c792223f
   languageName: node
   linkType: hard
 
@@ -4142,21 +4142,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.6":
-  version: 2.0.8
-  resolution: "node-releases@npm:2.0.8"
-  checksum: b1ab02c0d5d8e081bf9537232777a7a787dc8fef07f70feabe70a344599b220fe16462f746ac30f3eed5a58549445ad69368964d12a1f8b3b764f6caab7ba34a
+"node-releases@npm:^2.0.13":
+  version: 2.0.13
+  resolution: "node-releases@npm:2.0.13"
+  checksum: 17ec8f315dba62710cae71a8dad3cd0288ba943d2ece43504b3b1aa8625bf138637798ab470b1d9035b0545996f63000a8a926e0f6d35d0996424f8b6d36dda3
   languageName: node
   linkType: hard
 
-"nopt@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "nopt@npm:6.0.0"
+"nopt@npm:^7.0.0":
+  version: 7.2.0
+  resolution: "nopt@npm:7.2.0"
   dependencies:
-    abbrev: ^1.0.0
+    abbrev: ^2.0.0
   bin:
     nopt: bin/nopt.js
-  checksum: 82149371f8be0c4b9ec2f863cc6509a7fd0fa729929c009f3a58e4eb0c9e4cae9920e8f1f8eb46e7d032fec8fb01bede7f0f41a67eb3553b7b8e14fa53de1dac
+  checksum: a9c0f57fb8cb9cc82ae47192ca2b7ef00e199b9480eed202482c962d61b59a7fbe7541920b2a5839a97b42ee39e288c0aed770e38057a608d7f579389dfde410
   languageName: node
   linkType: hard
 
@@ -4173,18 +4173,6 @@ __metadata:
   dependencies:
     path-key: ^3.0.0
   checksum: 5374c0cea4b0bbfdfae62da7bbdf1e1558d338335f4cacf2515c282ff358ff27b2ecb91ffa5330a8b14390ac66a1e146e10700440c1ab868208430f56b5f4d23
-  languageName: node
-  linkType: hard
-
-"npmlog@npm:^6.0.0":
-  version: 6.0.2
-  resolution: "npmlog@npm:6.0.2"
-  dependencies:
-    are-we-there-yet: ^3.0.0
-    console-control-strings: ^1.1.0
-    gauge: ^4.0.3
-    set-blocking: ^2.0.0
-  checksum: ae238cd264a1c3f22091cdd9e2b106f684297d3c184f1146984ecbe18aaa86343953f26b9520dedd1b1372bc0316905b736c1932d778dbeb1fcf5a1001390e2a
   languageName: node
   linkType: hard
 
@@ -4207,16 +4195,16 @@ __metadata:
   linkType: hard
 
 "optionator@npm:^0.9.1":
-  version: 0.9.1
-  resolution: "optionator@npm:0.9.1"
+  version: 0.9.3
+  resolution: "optionator@npm:0.9.3"
   dependencies:
+    "@aashutoshrathi/word-wrap": ^1.2.3
     deep-is: ^0.1.3
     fast-levenshtein: ^2.0.6
     levn: ^0.4.1
     prelude-ls: ^1.2.1
     type-check: ^0.4.0
-    word-wrap: ^1.2.3
-  checksum: dbc6fa065604b24ea57d734261914e697bd73b69eff7f18e967e8912aa2a40a19a9f599a507fa805be6c13c24c4eae8c71306c239d517d42d4c041c942f508a0
+  checksum: 09281999441f2fe9c33a5eeab76700795365a061563d66b098923eb719251a42bdbe432790d35064d0816ead9296dbeb1ad51a733edf4167c96bd5d0882e428a
   languageName: node
   linkType: hard
 
@@ -4272,13 +4260,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pako@npm:^2.0.4":
-  version: 2.1.0
-  resolution: "pako@npm:2.1.0"
-  checksum: 71666548644c9a4d056bcaba849ca6fd7242c6cf1af0646d3346f3079a1c7f4a66ffec6f7369ee0dc88f61926c10d6ab05da3e1fca44b83551839e89edd75a3e
-  languageName: node
-  linkType: hard
-
 "parent-module@npm:^1.0.0":
   version: 1.0.1
   resolution: "parent-module@npm:1.0.1"
@@ -4328,6 +4309,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-scurry@npm:^1.10.1":
+  version: 1.10.1
+  resolution: "path-scurry@npm:1.10.1"
+  dependencies:
+    lru-cache: ^9.1.1 || ^10.0.0
+    minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
+  checksum: e2557cff3a8fb8bc07afdd6ab163a92587884f9969b05bbbaf6fe7379348bfb09af9ed292af12ed32398b15fb443e81692047b786d1eeb6d898a51eb17ed7d90
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -4350,9 +4341,9 @@ __metadata:
   linkType: hard
 
 "pirates@npm:^4.0.4":
-  version: 4.0.5
-  resolution: "pirates@npm:4.0.5"
-  checksum: c9994e61b85260bec6c4fc0307016340d9b0c4f4b6550a957afaaff0c9b1ad58fbbea5cfcf083860a25cb27a375442e2b0edf52e2e1e40e69934e08dcc52d227
+  version: 4.0.6
+  resolution: "pirates@npm:4.0.6"
+  checksum: 46a65fefaf19c6f57460388a5af9ab81e3d7fd0e7bc44ca59d753cb5c4d0df97c6c6e583674869762101836d68675f027d60f841c105d72734df9dfca97cbcc6
   languageName: node
   linkType: hard
 
@@ -4390,21 +4381,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.0.0, pretty-format@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "pretty-format@npm:29.5.0"
+"pretty-format@npm:^29.0.0, pretty-format@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "pretty-format@npm:29.7.0"
   dependencies:
-    "@jest/schemas": ^29.4.3
+    "@jest/schemas": ^29.6.3
     ansi-styles: ^5.0.0
     react-is: ^18.0.0
-  checksum: 4065356b558e6db25b4d41a01efb386935a6c06a0c9c104ef5ce59f2f476b8210edb8b3949b386e60ada0a6dc5ebcb2e6ccddc8c64dfd1a9943c3c3a9e7eaf89
+  checksum: 032c1602383e71e9c0c02a01bbd25d6759d60e9c7cf21937dde8357aa753da348fcec5def5d1002c9678a8524d5fe099ad98861286550ef44de8808cc61e43b6
   languageName: node
   linkType: hard
 
-"promise-inflight@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "promise-inflight@npm:1.0.1"
-  checksum: 22749483091d2c594261517f4f80e05226d4d5ecc1fc917e1886929da56e22b5718b7f2a75f3807e7a7d471bc3be2907fe92e6e8f373ddf5c64bae35b5af3981
+"proc-log@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "proc-log@npm:3.0.0"
+  checksum: 02b64e1b3919e63df06f836b98d3af002b5cd92655cab18b5746e37374bfb73e03b84fe305454614b34c25b485cc687a9eebdccf0242cda8fda2475dd2c97e02
   languageName: node
   linkType: hard
 
@@ -4436,16 +4427,16 @@ __metadata:
   linkType: hard
 
 "punycode@npm:^2.1.0":
-  version: 2.2.0
-  resolution: "punycode@npm:2.2.0"
-  checksum: 32f291c1b1e8bef8a7d351a369579565bc17530ee5224d2f2b5c37b2647aa0ec7f1972294e2de1b632812f90c8080a7c0c5645c14758aadc0f27b35dd4906d89
+  version: 2.3.1
+  resolution: "punycode@npm:2.3.1"
+  checksum: bb0a0ceedca4c3c57a9b981b90601579058903c62be23c5e8e843d2c2d4148a3ecf029d5133486fb0e1822b098ba8bba09e89d6b21742d02fa26bda6441a6fb2
   languageName: node
   linkType: hard
 
 "pure-rand@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "pure-rand@npm:6.0.1"
-  checksum: 4bb565399993b815658a72e359f574ce4f04827a42a905105d61163ae86f456d91595a0e4241e7bce04328fae0638ae70ac0428d93ecb55971c465bd084f8648
+  version: 6.0.4
+  resolution: "pure-rand@npm:6.0.4"
+  checksum: e1c4e69f8bf7303e5252756d67c3c7551385cd34d94a1f511fe099727ccbab74c898c03a06d4c4a24a89b51858781057b83ebbfe740d984240cdc04fead36068
   languageName: node
   linkType: hard
 
@@ -4460,17 +4451,6 @@ __metadata:
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
-  languageName: node
-  linkType: hard
-
-"readable-stream@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "readable-stream@npm:3.6.0"
-  dependencies:
-    inherits: ^2.0.3
-    string_decoder: ^1.1.1
-    util-deprecate: ^1.0.1
-  checksum: d4ea81502d3799439bb955a3a5d1d808592cf3133350ed352aeaa499647858b27b1c4013984900238b0873ec8d0d8defce72469fb7a83e61d53f5ad61cb80dc8
   languageName: node
   linkType: hard
 
@@ -4512,28 +4492,28 @@ __metadata:
   linkType: hard
 
 "resolve@npm:^1.20.0":
-  version: 1.22.1
-  resolution: "resolve@npm:1.22.1"
+  version: 1.22.8
+  resolution: "resolve@npm:1.22.8"
   dependencies:
-    is-core-module: ^2.9.0
+    is-core-module: ^2.13.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: 07af5fc1e81aa1d866cbc9e9460fbb67318a10fa3c4deadc35c3ad8a898ee9a71a86a65e4755ac3195e0ea0cfbe201eb323ebe655ce90526fd61917313a34e4e
+  checksum: f8a26958aa572c9b064562750b52131a37c29d072478ea32e129063e2da7f83e31f7f11e7087a18225a8561cfe8d2f0df9dbea7c9d331a897571c0a2527dbb4c
   languageName: node
   linkType: hard
 
 "resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>":
-  version: 1.22.1
-  resolution: "resolve@patch:resolve@npm%3A1.22.1#~builtin<compat/resolve>::version=1.22.1&hash=c3c19d"
+  version: 1.22.8
+  resolution: "resolve@patch:resolve@npm%3A1.22.8#~builtin<compat/resolve>::version=1.22.8&hash=c3c19d"
   dependencies:
-    is-core-module: ^2.9.0
+    is-core-module: ^2.13.0
     path-parse: ^1.0.7
     supports-preserve-symlinks-flag: ^1.0.0
   bin:
     resolve: bin/resolve
-  checksum: 5656f4d0bedcf8eb52685c1abdf8fbe73a1603bb1160a24d716e27a57f6cecbe2432ff9c89c2bd57542c3a7b9d14b1882b73bfe2e9d7849c9a4c0b8b39f02b8b
+  checksum: 5479b7d431cacd5185f8db64bfcb7286ae5e31eb299f4c4f404ad8aa6098b77599563ac4257cb2c37a42f59dfc06a1bec2bcf283bb448f319e37f0feb9a09847
   languageName: node
   linkType: hard
 
@@ -4580,13 +4560,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:~5.2.0":
-  version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1"
-  checksum: b99c4b41fdd67a6aaf280fcd05e9ffb0813654894223afb78a31f14a19ad220bba8aba1cb14eddce1fcfb037155fe6de4e861784eb434f7d11ed58d1e70dd491
-  languageName: node
-  linkType: hard
-
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -4594,18 +4567,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.x, semver@npm:^7.3.5, semver@npm:^7.3.7":
-  version: 7.3.8
-  resolution: "semver@npm:7.3.8"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
-  languageName: node
-  linkType: hard
-
-"semver@npm:^6.0.0, semver@npm:^6.3.0":
+"semver@npm:^6.3.0, semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -4614,10 +4576,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-blocking@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "set-blocking@npm:2.0.0"
-  checksum: 6e65a05f7cf7ebdf8b7c75b101e18c0b7e3dff4940d480efed8aad3a36a4005140b660fa1d804cb8bce911cac290441dc728084a30504d3516ac2ff7ad607b02
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
+  version: 7.5.4
+  resolution: "semver@npm:7.5.4"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 12d8ad952fa353b0995bf180cdac205a4068b759a140e5d3c608317098b3575ac2f1e09182206bf2eb26120e1c0ed8fb92c48c592f6099680de56bb071423ca3
   languageName: node
   linkType: hard
 
@@ -4638,14 +4604,14 @@ __metadata:
   linkType: hard
 
 "shiki@npm:^0.14.1":
-  version: 0.14.1
-  resolution: "shiki@npm:0.14.1"
+  version: 0.14.5
+  resolution: "shiki@npm:0.14.5"
   dependencies:
     ansi-sequence-parser: ^1.1.0
     jsonc-parser: ^3.2.0
     vscode-oniguruma: ^1.7.0
     vscode-textmate: ^8.0.0
-  checksum: b19ea337cc84da69d99ca39d109f82946e0c56c11cc4c67b3b91cc14a9479203365fd0c9e0dd87e908f493ab409dc6f1849175384b6ca593ce7da884ae1edca2
+  checksum: 41d847817cfc9bb6d8bf190316896698d250303656546446659cc02caed8dcc171b10cd113bb5da82425b51d0032e87aafcdc36c3dd61dadc123170b438da736
   languageName: node
   linkType: hard
 
@@ -4653,6 +4619,13 @@ __metadata:
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
   checksum: a2f098f247adc367dffc27845853e9959b9e88b01cb301658cfe4194352d8d2bb32e18467c786a7fe15f1d44b233ea35633d076d5e737870b7139949d1ab6318
+  languageName: node
+  linkType: hard
+
+"signal-exit@npm:^4.0.1":
+  version: 4.1.0
+  resolution: "signal-exit@npm:4.1.0"
+  checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
   languageName: node
   linkType: hard
 
@@ -4677,28 +4650,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"smoldot@npm:1.0.4":
-  version: 1.0.4
-  resolution: "smoldot@npm:1.0.4"
+"smoldot@npm:2.0.1":
+  version: 2.0.1
+  resolution: "smoldot@npm:2.0.1"
   dependencies:
-    pako: ^2.0.4
     ws: ^8.8.1
-  checksum: 81ecc38b98f7ac4dd093753e85956262608dca3c8a288c20a25fe1762a6afcdbe6f3622ea30a346df3f4145e0900ef0595e56e96e9e0de83c59f0649d1ab4786
+  checksum: 77c1f541d039fe740157e9b81e2b13fc72dabe3ffd75644ee9958aee48d5c5458b6cc974d1e9233b1bcf3fde7af42a53a0e48452b6657405c64158a0c8168eee
   languageName: node
   linkType: hard
 
-"socks-proxy-agent@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "socks-proxy-agent@npm:7.0.0"
+"socks-proxy-agent@npm:^8.0.1":
+  version: 8.0.2
+  resolution: "socks-proxy-agent@npm:8.0.2"
   dependencies:
-    agent-base: ^6.0.2
-    debug: ^4.3.3
-    socks: ^2.6.2
-  checksum: 720554370154cbc979e2e9ce6a6ec6ced205d02757d8f5d93fe95adae454fc187a5cbfc6b022afab850a5ce9b4c7d73e0f98e381879cf45f66317a4895953846
+    agent-base: ^7.0.2
+    debug: ^4.3.4
+    socks: ^2.7.1
+  checksum: 4fb165df08f1f380881dcd887b3cdfdc1aba3797c76c1e9f51d29048be6e494c5b06d68e7aea2e23df4572428f27a3ec22b3d7c75c570c5346507433899a4b6d
   languageName: node
   linkType: hard
 
-"socks@npm:^2.6.2":
+"socks@npm:^2.7.1":
   version: 2.7.1
   resolution: "socks@npm:2.7.1"
   dependencies:
@@ -4732,12 +4704,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ssri@npm:^9.0.0":
-  version: 9.0.1
-  resolution: "ssri@npm:9.0.1"
+"ssri@npm:^10.0.0":
+  version: 10.0.5
+  resolution: "ssri@npm:10.0.5"
   dependencies:
-    minipass: ^3.1.1
-  checksum: fb58f5e46b6923ae67b87ad5ef1c5ab6d427a17db0bead84570c2df3cd50b4ceb880ebdba2d60726588272890bae842a744e1ecce5bd2a2a582fccd5068309eb
+    minipass: ^7.0.3
+  checksum: 0a31b65f21872dea1ed3f7c200d7bc1c1b91c15e419deca14f282508ba917cbb342c08a6814c7f68ca4ca4116dd1a85da2bbf39227480e50125a1ceffeecb750
   languageName: node
   linkType: hard
 
@@ -4760,7 +4732,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^1.0.2 || 2 || 3 || 4, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -4771,21 +4743,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:^1.1.1":
-  version: 1.3.0
-  resolution: "string_decoder@npm:1.3.0"
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
   dependencies:
-    safe-buffer: ~5.2.0
-  checksum: 8417646695a66e73aefc4420eb3b84cc9ffd89572861fe004e6aeb13c7bc00e2f616247505d2dbbef24247c372f70268f594af7126f43548565c68c117bdeb56
+    eastasianwidth: ^0.2.0
+    emoji-regex: ^9.2.2
+    strip-ansi: ^7.0.1
+  checksum: 7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
   version: 6.0.1
   resolution: "strip-ansi@npm:6.0.1"
   dependencies:
     ansi-regex: ^5.0.1
   checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
+  languageName: node
+  linkType: hard
+
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
+  dependencies:
+    ansi-regex: ^6.0.1
+  checksum: 859c73fcf27869c22a4e4d8c6acfe690064659e84bef9458aa6d13719d09ca88dcfd40cbf31fd0be63518ea1a643fe070b4827d353e09533a5b0b9fd4553d64d
   languageName: node
   linkType: hard
 
@@ -4845,16 +4828,16 @@ __metadata:
   linkType: hard
 
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
-  version: 6.1.13
-  resolution: "tar@npm:6.1.13"
+  version: 6.2.0
+  resolution: "tar@npm:6.2.0"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
-    minipass: ^4.0.0
+    minipass: ^5.0.0
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: 8a278bed123aa9f53549b256a36b719e317c8b96fe86a63406f3c62887f78267cea9b22dc6f7007009738509800d4a4dccc444abd71d762287c90f35b002eb1c
+  checksum: db4d9fe74a2082c3a5016630092c54c8375ff3b280186938cfd104f2e089c4fd9bad58688ef6be9cf186a889671bf355c7cda38f09bbf60604b281715ca57f5c
   languageName: node
   linkType: hard
 
@@ -4907,8 +4890,8 @@ __metadata:
   linkType: hard
 
 "ts-jest@npm:^29.1.0":
-  version: 29.1.0
-  resolution: "ts-jest@npm:29.1.0"
+  version: 29.1.1
+  resolution: "ts-jest@npm:29.1.1"
   dependencies:
     bs-logger: 0.x
     fast-json-stable-stringify: 2.x
@@ -4916,7 +4899,7 @@ __metadata:
     json5: ^2.2.3
     lodash.memoize: 4.x
     make-error: 1.x
-    semver: 7.x
+    semver: ^7.5.3
     yargs-parser: ^21.0.1
   peerDependencies:
     "@babel/core": ">=7.0.0-beta.0 <8"
@@ -4935,7 +4918,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 535dc42ad523cbe1e387701fb2e448518419b515c082f09b25411f0b3dd0b854cf3e8141c316d6f4b99883aeb4a4f94159cbb1edfb06d7f77ea6229fadb2e1bf
+  checksum: a8c9e284ed4f819526749f6e4dc6421ec666f20ab44d31b0f02b4ed979975f7580b18aea4813172d43e39b29464a71899f8893dd29b06b4a351a3af8ba47b402
   languageName: node
   linkType: hard
 
@@ -4946,10 +4929,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.1.0, tslib@npm:^2.5.0, tslib@npm:^2.5.3":
-  version: 2.5.3
-  resolution: "tslib@npm:2.5.3"
-  checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
+"tslib@npm:^2.1.0, tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 
@@ -5004,13 +4987,13 @@ __metadata:
   linkType: hard
 
 "typedoc-theme-hierarchy@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "typedoc-theme-hierarchy@npm:4.0.0"
+  version: 4.1.2
+  resolution: "typedoc-theme-hierarchy@npm:4.1.2"
   dependencies:
-    fs-extra: ^10.0.0
+    fs-extra: 11.1.1
   peerDependencies:
-    typedoc: ^0.24.0
-  checksum: b84594636edcb15cca2c92c3819d1c901753066fe7a47eb247bb130f892802096bc9bb4b6f511991e78f74dc32d4c44c7dc9ce6fbeb622b60881249df87f0d7b
+    typedoc: ^0.24.0 || ^0.25.0
+  checksum: f7c39739afbcb454179a1a8dcb9c39cc2ef791ab77f5599c246486eebb47abd2200767cdef4e950a04ce019689ed7d4640af6c80881a260e5419833f98d8defc
   languageName: node
   linkType: hard
 
@@ -5050,42 +5033,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unique-filename@npm:^2.0.0":
-  version: 2.0.1
-  resolution: "unique-filename@npm:2.0.1"
-  dependencies:
-    unique-slug: ^3.0.0
-  checksum: 807acf3381aff319086b64dc7125a9a37c09c44af7620bd4f7f3247fcd5565660ac12d8b80534dcbfd067e6fe88a67e621386dd796a8af828d1337a8420a255f
+"undici-types@npm:~5.26.4":
+  version: 5.26.5
+  resolution: "undici-types@npm:5.26.5"
+  checksum: 3192ef6f3fd5df652f2dc1cd782b49d6ff14dc98e5dced492aa8a8c65425227da5da6aafe22523c67f035a272c599bb89cfe803c1db6311e44bed3042fc25487
   languageName: node
   linkType: hard
 
-"unique-slug@npm:^3.0.0":
+"unique-filename@npm:^3.0.0":
   version: 3.0.0
-  resolution: "unique-slug@npm:3.0.0"
+  resolution: "unique-filename@npm:3.0.0"
+  dependencies:
+    unique-slug: ^4.0.0
+  checksum: 8e2f59b356cb2e54aab14ff98a51ac6c45781d15ceaab6d4f1c2228b780193dc70fae4463ce9e1df4479cb9d3304d7c2043a3fb905bdeca71cc7e8ce27e063df
+  languageName: node
+  linkType: hard
+
+"unique-slug@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "unique-slug@npm:4.0.0"
   dependencies:
     imurmurhash: ^0.1.4
-  checksum: 49f8d915ba7f0101801b922062ee46b7953256c93ceca74303bd8e6413ae10aa7e8216556b54dc5382895e8221d04f1efaf75f945c2e4a515b4139f77aa6640c
+  checksum: 0884b58365af59f89739e6f71e3feacb5b1b41f2df2d842d0757933620e6de08eff347d27e9d499b43c40476cbaf7988638d3acb2ffbcb9d35fd035591adfd15
   languageName: node
   linkType: hard
 
 "universalify@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "universalify@npm:2.0.0"
-  checksum: 2406a4edf4a8830aa6813278bab1f953a8e40f2f63a37873ffa9a3bc8f9745d06cc8e88f3572cb899b7e509013f7f6fcc3e37e8a6d914167a5381d8440518c44
+  version: 2.0.1
+  resolution: "universalify@npm:2.0.1"
+  checksum: ecd8469fe0db28e7de9e5289d32bd1b6ba8f7183db34f3bfc4ca53c49891c2d6aa05f3fb3936a81285a905cc509fb641a0c3fc131ec786167eff41236ae32e60
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.0.9":
-  version: 1.0.10
-  resolution: "update-browserslist-db@npm:1.0.10"
+"update-browserslist-db@npm:^1.0.13":
+  version: 1.0.13
+  resolution: "update-browserslist-db@npm:1.0.13"
   dependencies:
     escalade: ^3.1.1
     picocolors: ^1.0.0
   peerDependencies:
     browserslist: ">= 4.21.0"
   bin:
-    browserslist-lint: cli.js
-  checksum: 12db73b4f63029ac407b153732e7cd69a1ea8206c9100b482b7d12859cd3cd0bc59c602d7ae31e652706189f1acb90d42c53ab24a5ba563ed13aebdddc5561a0
+    update-browserslist-db: cli.js
+  checksum: 1e47d80182ab6e4ad35396ad8b61008ae2a1330221175d0abd37689658bdb61af9b705bfc41057fd16682474d79944fb2d86767c5ed5ae34b6276b9bed353322
   languageName: node
   linkType: hard
 
@@ -5098,21 +5088,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "util-deprecate@npm:1.0.2"
-  checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
 "v8-to-istanbul@npm:^9.0.1":
-  version: 9.1.0
-  resolution: "v8-to-istanbul@npm:9.1.0"
+  version: 9.1.3
+  resolution: "v8-to-istanbul@npm:9.1.3"
   dependencies:
     "@jridgewell/trace-mapping": ^0.3.12
     "@types/istanbul-lib-coverage": ^2.0.1
-    convert-source-map: ^1.6.0
-  checksum: 2069d59ee46cf8d83b4adfd8a5c1a90834caffa9f675e4360f1157ffc8578ef0f763c8f32d128334424159bb6b01f3876acd39cd13297b2769405a9da241f8d1
+    convert-source-map: ^2.0.0
+  checksum: 5d592ab3d186b386065dace8e01c543a922a904b3cfac39667de172455a6b3d0e8e1401574fecb8a12092ad0809b5a8fd15f1cc14d0666139a1bb77cd6ac2cf8
   languageName: node
   linkType: hard
 
@@ -5163,7 +5146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^2.0.1, which@npm:^2.0.2":
+"which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
   dependencies:
@@ -5174,23 +5157,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wide-align@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "wide-align@npm:1.1.5"
+"which@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "which@npm:4.0.0"
   dependencies:
-    string-width: ^1.0.2 || 2 || 3 || 4
-  checksum: d5fc37cd561f9daee3c80e03b92ed3e84d80dde3365a8767263d03dacfc8fa06b065ffe1df00d8c2a09f731482fcacae745abfbb478d4af36d0a891fad4834d3
+    isexe: ^3.1.1
+  bin:
+    node-which: bin/which.js
+  checksum: f17e84c042592c21e23c8195108cff18c64050b9efb8459589116999ea9da6dd1509e6a1bac3aeebefd137be00fabbb61b5c2bc0aa0f8526f32b58ee2f545651
   languageName: node
   linkType: hard
 
-"word-wrap@npm:^1.2.3":
-  version: 1.2.5
-  resolution: "word-wrap@npm:1.2.5"
-  checksum: f93ba3586fc181f94afdaff3a6fef27920b4b6d9eaefed0f428f8e07adea2a7f54a5f2830ce59406c8416f033f86902b91eb824072354645eea687dff3691ccb
-  languageName: node
-  linkType: hard
-
-"wrap-ansi@npm:^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -5198,6 +5176,17 @@ __metadata:
     string-width: ^4.1.0
     strip-ansi: ^6.0.0
   checksum: a790b846fd4505de962ba728a21aaeda189b8ee1c7568ca5e817d85930e06ef8d1689d49dbf0e881e8ef84436af3a88bc49115c2e2788d841ff1b8b5b51a608b
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: ^6.1.0
+    string-width: ^5.0.1
+    strip-ansi: ^7.0.1
+  checksum: 371733296dc2d616900ce15a0049dca0ef67597d6394c57347ba334393599e800bab03c41d4d45221b6bc967b8c453ec3ae4749eff3894202d16800fdfe0e238
   languageName: node
   linkType: hard
 
@@ -5218,9 +5207,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.13.0, ws@npm:^8.8.1":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
+"ws@npm:^8.14.1, ws@npm:^8.8.1":
+  version: 8.14.2
+  resolution: "ws@npm:8.14.2"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -5229,7 +5218,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
+  checksum: 3ca0dad26e8cc6515ff392b622a1467430814c463b3368b0258e33696b1d4bed7510bc7030f7b72838b9fdeb8dbd8839cbf808367d6aae2e1d668ce741d4308b
   languageName: node
   linkType: hard
 
@@ -5262,8 +5251,8 @@ __metadata:
   linkType: hard
 
 "yargs@npm:^17.3.1, yargs@npm:^17.5.1":
-  version: 17.7.1
-  resolution: "yargs@npm:17.7.1"
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
   dependencies:
     cliui: ^8.0.1
     escalade: ^3.1.1
@@ -5272,7 +5261,7 @@ __metadata:
     string-width: ^4.2.3
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
-  checksum: 3d8a43c336a4942bc68080768664aca85c7bd406f018bad362fd255c41c8f4e650277f42fd65d543fce99e084124ddafee7bbfc1a5c6a8fda4cec78609dcf8d4
+  checksum: 73b572e863aa4a8cbef323dd911d79d193b772defd5a51aab0aca2d446655216f5002c42c5306033968193bdbf892a7a4c110b0d77954a7fdf563e653967b56a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,6 +1309,7 @@ __metadata:
     "@substrate/asset-transfer-api-registry": ^0.2.11
     "@substrate/dev": ^0.6.7
     chalk: 4.1.2
+    node-fetch: 2.6.7
     typedoc: ^0.24.8
     typedoc-plugin-missing-exports: ^1.0.0
     typedoc-theme-hierarchy: ^4.0.0
@@ -4097,6 +4098,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-fetch@npm:2.6.7":
+  version: 2.6.7
+  resolution: "node-fetch@npm:2.6.7"
+  dependencies:
+    whatwg-url: ^5.0.0
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 8d816ffd1ee22cab8301c7756ef04f3437f18dace86a1dae22cf81db8ef29c0bf6655f3215cb0cdb22b420b6fe141e64b26905e7f33f9377a7fa59135ea3e10b
+  languageName: node
+  linkType: hard
+
 "node-fetch@npm:^3.3.1":
   version: 3.3.1
   resolution: "node-fetch@npm:3.3.1"
@@ -4892,6 +4907,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 726321c5eaf41b5002e17ffbd1fb7245999a073e8979085dacd47c4b4e8068ff5777142fc6726d6ca1fd2ff16921b48788b87225cbc57c72636f6efa8efbffe3
+  languageName: node
+  linkType: hard
+
 "ts-jest@npm:^29.1.0":
   version: 29.1.0
   resolution: "ts-jest@npm:29.1.0"
@@ -5129,6 +5151,23 @@ __metadata:
   version: 3.2.1
   resolution: "web-streams-polyfill@npm:3.2.1"
   checksum: b119c78574b6d65935e35098c2afdcd752b84268e18746606af149e3c424e15621b6f1ff0b42b2676dc012fc4f0d313f964b41a4b5031e525faa03997457da02
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: c92a0a6ab95314bde9c32e1d0a6dfac83b578f8fa5f21e675bc2706ed6981bc26b7eb7e6a1fab158e5ce4adf9caa4a0aee49a52505d4d13c7be545f15021b17c
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: ~0.0.3
+    webidl-conversions: ^3.0.0
+  checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,7 @@ __metadata:
   dependencies:
     "@polkadot/api": ^10.9.1
     "@substrate/dev": ^0.6.7
+    "@types/node-fetch": ^2.6.9
     chalk: 4.1.2
     node-fetch: 2.6.7
     typedoc: ^0.24.8
@@ -1480,6 +1481,16 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
+  languageName: node
+  linkType: hard
+
+"@types/node-fetch@npm:^2.6.9":
+  version: 2.6.9
+  resolution: "@types/node-fetch@npm:2.6.9"
+  dependencies:
+    "@types/node": "*"
+    form-data: ^4.0.0
+  checksum: 212269aff4b251477c13c33cee6cea23e4fd630be6c0bfa3714968cce7efd7055b52f2f82aab3394596d8c758335cc802e7c5fa3f775e7f2a472fa914c90dc15
   languageName: node
   linkType: hard
 
@@ -1791,6 +1802,13 @@ __metadata:
   version: 2.1.0
   resolution: "array-union@npm:2.1.0"
   checksum: 5bee12395cba82da674931df6d0fea23c4aa4660cb3b338ced9f828782a65caa232573e6bf3968f23e0c5eb301764a382cef2f128b170a9dc59de0e36c39f98d
+  languageName: node
+  linkType: hard
+
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 7b78c451df768adba04e2d02e63e2d0bf3b07adcd6e42b4cf665cb7ce899bedd344c69a1dcbce355b5f972d597b25aaa1c1742b52cffd9caccb22f348114f6be
   languageName: node
   linkType: hard
 
@@ -2112,6 +2130,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: ~1.0.0
+  checksum: 49fa4aeb4916567e33ea81d088f6584749fc90c7abec76fd516bf1c5aa5c79f3584b5ba3de6b86d26ddd64bae5329c4c7479343250cfe71c75bb366eae53bb7c
+  languageName: node
+  linkType: hard
+
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -2196,6 +2223,13 @@ __metadata:
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 2024c6a980a1b7128084170c4cf56b0fd58a63f2da1660dcfe977415f27b17dbe5888668b59d0b063753f3220719d5e400b7f113609489c90160bb9a5518d052
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 46fe6e83e2cb1d85ba50bd52803c68be9bd953282fa7096f51fc29edd5d67ff84ff753c51966061e5ba7cb5e47ef6d36a91924eddb7f3f3483b1c560f77a0020
   languageName: node
   linkType: hard
 
@@ -2681,6 +2715,17 @@ __metadata:
     cross-spawn: ^7.0.0
     signal-exit: ^4.0.1
   checksum: 139d270bc82dc9e6f8bc045fe2aae4001dc2472157044fdfad376d0a3457f77857fa883c1c8b21b491c6caade9a926a4bed3d3d2e8d3c9202b151a4cbbd0bcd5
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "form-data@npm:4.0.0"
+  dependencies:
+    asynckit: ^0.4.0
+    combined-stream: ^1.0.8
+    mime-types: ^2.1.12
+  checksum: 01135bf8675f9d5c61ff18e2e2932f719ca4de964e3be90ef4c36aacfc7b9cb2fceb5eca0b7e0190e3383fe51c5b37f4cb80b62ca06a99aaabfcfd6ac7c9328c
   languageName: node
   linkType: hard
 
@@ -3916,6 +3961,22 @@ __metadata:
     braces: ^3.0.2
     picomatch: ^2.3.1
   checksum: 02a17b671c06e8fefeeb6ef996119c1e597c942e632a21ef589154f23898c9c6a9858526246abb14f8bca6e77734aa9dcf65476fca47cedfb80d9577d52843fc
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 0d99a03585f8b39d68182803b12ac601d9c01abfa28ec56204fa330bc9f3d1c5e14beb049bafadb3dbdf646dfb94b87e24d4ec7b31b7279ef906a8ea9b6a513f
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.12":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: 1.52.0
+  checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* removes the `@substrate/asset-transfer-api-registry` npm package
* constructs the ATA registry by fetching the latest registry data from `https://paritytech.github.io/asset-transfer-api-registry/registry.json`