### PR TITLE
build: remove .spec files from lib

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "exclude": [
       "node_modules",
       "./src/**/*.spec.ts",
+      "./src/testHelpers"
     ],
     "include": [
       "./src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
       "./node_modules/@types"
     ],
     "exclude": [
-      "node_modules"
+      "node_modules",
+      "./src/**/*.spec.ts",
     ],
     "include": [
       "./src/**/*.ts",


### PR DESCRIPTION
This ensures spec files are not included in the build.