### PR TITLE
fix(internal): ensure all `sanitizeKeys` int values are sanitized to str

### DIFF
--- a/src/createXcmTypes/ParaToPara.spec.ts
+++ b/src/createXcmTypes/ParaToPara.spec.ts
@@ -144,7 +144,7 @@ describe('ParaToPara', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
 									Here: null,
 								},
@@ -157,9 +157,9 @@ describe('ParaToPara', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
-									X3: [{ Parachain: 1000 }, { PalletInstance: 50 }, { GeneralIndex: 8 }],
+									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
 						},
@@ -191,9 +191,9 @@ describe('ParaToPara', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
-									X3: [{ Parachain: 1000 }, { PalletInstance: 50 }, { GeneralIndex: 8 }],
+									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
 						},
@@ -204,9 +204,9 @@ describe('ParaToPara', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
-									X3: [{ Parachain: 1000 }, { PalletInstance: 50 }, { GeneralIndex: 1984 }],
+									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 								},
 							},
 						},

--- a/src/createXcmTypes/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/ParaToSystem.spec.ts
@@ -107,7 +107,7 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
 									Here: null,
 								},
@@ -120,9 +120,9 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
-									X3: [{ Parachain: 1000 }, { PalletInstance: 50 }, { GeneralIndex: 8 }],
+									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
 						},
@@ -154,9 +154,9 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
-									X3: [{ Parachain: 1000 }, { PalletInstance: 50 }, { GeneralIndex: 8 }],
+									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
 						},
@@ -167,9 +167,9 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
-									X3: [{ Parachain: 1000 }, { PalletInstance: 50 }, { GeneralIndex: 1984 }],
+									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 								},
 							},
 						},

--- a/src/createXcmTypes/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/SystemToSystem.spec.ts
@@ -104,7 +104,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 0,
+								Parents: '0',
 								Interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 								},
@@ -132,7 +132,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 1,
+								Parents: '1',
 								Interior: {
 									Here: '',
 								},
@@ -173,7 +173,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: 0,
+								Parents: '0',
 								Interior: {
 									X2: [{ PalletInstance: '55' }, { GeneralIndex: '11' }],
 								},

--- a/src/util/resolveMultiLocation.spec.ts
+++ b/src/util/resolveMultiLocation.spec.ts
@@ -17,7 +17,7 @@ describe('resolveMultiLocation', () => {
 	});
 	it('Should correctly return a resolved multilocation object given a correct value', () => {
 		const str = `{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}`;
-		const exp = { Parents: 1, Interior: { X2: [{ Parachain: 2001 }, { GeneralKey: '0x0001' }] } };
+		const exp = { Parents: '1', Interior: { X2: [{ Parachain: '2001' }, { GeneralKey: '0x0001' }] } };
 
 		expect(resolveMultiLocation(str, 2)).toStrictEqual(exp);
 	});

--- a/src/util/sanitizeKeys.spec.ts
+++ b/src/util/sanitizeKeys.spec.ts
@@ -16,4 +16,13 @@ describe('sanitizeKeys', () => {
 		const exp = { OnlyChild: { PalletInstance: '' }, GlobalConsensus: { Key1: '' } };
 		expect(sanitizeKeys(obj)).toStrictEqual(exp);
 	});
+	it('Should correctly sanitize values that are integers', () => {
+		const obj = { OnlyChild: { PalletInstance: 10 }, GlobalConsensus: { Key1: '' } };
+		const exp = { OnlyChild: { PalletInstance: '10' }, GlobalConsensus: { Key1: '' } };
+		expect(sanitizeKeys(obj)).toStrictEqual(exp);
+
+		const obj2 = { key1: { key2: { key3: [{ key6: 111, key7: 222 }, { key8: null }], key4: 333 } }, key5: 444 };
+		const exp2 = { Key1: { Key2: { Key3: [{ Key6: '111', Key7: '222' }, { Key8: null }], Key4: '333' } }, Key5: '444' };
+		expect(sanitizeKeys(obj2)).toStrictEqual(exp2);
+	});
 });

--- a/src/util/sanitizeKeys.ts
+++ b/src/util/sanitizeKeys.ts
@@ -18,7 +18,8 @@ const isPlainObject = (input: unknown) => {
 };
 
 /**
- * Set all keys in an object with the first key being capitalized
+ * Set all keys in an object with the first key being capitalized.
+ * When a keys value is an integer it will convert that integer into a string.
  *
  * @param xcmObj
  */
@@ -30,7 +31,9 @@ export const sanitizeKeys = <T extends AnyObj>(xcmObj: T): T => {
 		if (Array.isArray(value)) {
 			final[mapKey(key)] = value.map(sanitizeKeys);
 		} else if (!isPlainObject(value)) {
-			final[mapKey(key)] = value;
+			// Ensure when the value is an integer that it is sanitized to a string.
+			const sanitizedValue = Number.isInteger(value) ? Number(value).toString() : value;
+			final[mapKey(key)] = sanitizedValue;
 		} else {
 			final[mapKey(key)] = sanitizeKeys(value as AnyObj);
 		}

--- a/src/validate/validateNumber.ts
+++ b/src/validate/validateNumber.ts
@@ -1,5 +1,10 @@
 import { MAX_NUM_LENGTH } from '../consts';
 
+/**
+ * Check if a given string input is a valid integer.
+ *
+ * @param val
+ */
 export const validateNumber = (val: string): boolean => {
 	if (val.length < MAX_NUM_LENGTH) {
 		const isNum = Number.parseInt(val);


### PR DESCRIPTION
Ensure all values within `sanitizeKeys` are sanitized to strings if the value is a int. This specifically affects anything that uses `resolveMultilocation`, and `sanitizeKeys`.

This is especially effective since values that are recieved in the registry, the chain, or polkadot-js may not be 100% guaranteed to have the same structure we may expect.

closes: https://github.com/paritytech/asset-transfer-api/issues/345