### PR TITLE
fix: renaming statemine in zombienet toml files

### DIFF
--- a/zombienet/medium-network.toml
+++ b/zombienet/medium-network.toml
@@ -27,17 +27,17 @@ chain = "rococo-local"
 [[parachains]]
 id = 1000
 addToGenesis = true
-chain = "statemine-local"
+chain = "asset-hub-rococo-local"
 cumulus_based = true
 
   [[parachains.collators]]
-  name = "statemine-collator01"
+  name = "asset-hub-rococo-collator01"
   command = "./bin/polkadot-parachain"
   args = ["--log=xcm=trace,pallet-assets=trace"]
   ws_port = 9910
 
   [[parachains.collators]]
-  name = "statemine-collator02"
+  name = "asset-hub-rococo-collator02"
   command = "./bin/polkadot-parachain"
   ws_port = 9911
   args = ["--log=xcm=trace,pallet-assets=trace"]

--- a/zombienet/small-network.toml
+++ b/zombienet/small-network.toml
@@ -27,17 +27,17 @@ chain = "rococo-local"
 [[parachains]]
 id = 1000
 addToGenesis = true
-chain = "statemine-local"
+chain = "asset-hub-rococo-local"
 cumulus_based = true
 
   [[parachains.collators]]
-  name = "statemine-collator01"
+  name = "asset-hub-rococo-collator01"
   command = "./bin/polkadot-parachain"
   args = ["--log=xcm=trace,pallet-assets=trace"]
   ws_port = 9910
 
   [[parachains.collators]]
-  name = "statemine-collator02"
+  name = "asset-hub-rococo-collator02"
   command = "./bin/polkadot-parachain"
   ws_port = 9911
   args = ["--log=xcm=trace,pallet-assets=trace"]


### PR DESCRIPTION
### Issue 
I get the error
```
Error: Input("Error opening spec file `statemine-local`: No such file or directory (os error 2)")
```
when I try to run `zombienet` with the toml file of small/medium network.

### Solution
I renamed `statemine` to `asset-hub-rococo` in the toml files of zombienet.