### PR TITLE
test: set registries to NPM for AssetTransferApi

### DIFF
--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -18,9 +18,11 @@ const mockSubmittableExt = mockSystemApi.registry.createType(
 	'0xfc041f0801010100411f0100010100c224aad9c6f3bbd784120e9fceee5bfd22a62c69144ee673f76d6a34d280de160104000002043205040091010000000000',
 ) as SubmittableExtrinsic<'promise', ISubmittableResult>;
 
-const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
-const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2);
-const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, { registryType: 'NPM' });
+const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, { registryType: 'NPM' });
+const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, {
+	registryType: 'NPM',
+});
 
 describe('AssetTransferAPI', () => {
 	describe('establishDirection', () => {
@@ -421,6 +423,7 @@ describe('AssetTransferAPI', () => {
 			};
 			const mockSystemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, {
 				injectedRegistry,
+				registryType: 'NPM',
 			});
 
 			expect(mockSystemAssetsApi.opts.injectedRegistry).toStrictEqual(injectedRegistry);

--- a/src/createXcmTypes/util/getAssetId.spec.ts
+++ b/src/createXcmTypes/util/getAssetId.spec.ts
@@ -10,7 +10,7 @@ import { getAssetId } from './getAssetId';
 describe('getAssetId', () => {
 	describe('Statemine', () => {
 		const registry = new Registry('statemine', {});
-		const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
+		const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, { registryType: 'NPM' });
 		it('Should correctly return the integer assetId when given a valid native system chain token symbol', async () => {
 			const expected = '10';
 
@@ -53,7 +53,9 @@ describe('getAssetId', () => {
 
 	describe('Bifrost', () => {
 		const registry = new Registry('bifrost', {});
-		const bifrostAssetsApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2);
+		const bifrostAssetsApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2, {
+			registryType: 'NPM',
+		});
 
 		it('Should correctly return the xcAsset multilocation when given a valid asset symbol', async () => {
 			const expected = '{"v1":{"parents":1,"interior":{"x2":[{"parachain":2023},{"palletInstance":10}]}}}';
@@ -72,7 +74,9 @@ describe('getAssetId', () => {
 
 	describe('Moonriver', () => {
 		const registry = new Registry('moonriver', {});
-		const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'bifrost', 2);
+		const moonriverAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'bifrost', 2, {
+			registryType: 'NPM',
+		});
 
 		it('Should correctly return the xcAsset integer assetId when given a valid xcAsset symbol', async () => {
 			const expected = '42259045809535163221576417993425387648';

--- a/src/createXcmTypes/util/getXcAssetMultiLocationByAssetId.spec.ts
+++ b/src/createXcmTypes/util/getXcAssetMultiLocationByAssetId.spec.ts
@@ -7,10 +7,10 @@ import { adjustedMockMoonriverParachainApi } from '../../testHelpers/adjustedMoc
 import { getXcAssetMultiLocationByAssetId } from './getXcAssetMultiLocationByAssetId';
 
 const bifrostRegistry = new Registry('bifrost', {});
-const bifrostApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 3);
+const bifrostApi = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 3, { registryType: 'NPM' });
 
 const moonriverRegistry = new Registry('moonriver', {});
-const moonriverApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const moonriverApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, { registryType: 'NPM' });
 
 describe('getXcAssetMultiLocationByAssetId', () => {
 	describe('Bifrost', () => {

--- a/src/errors/checkLocalTxInput/checkLocalTxInput.spec.ts
+++ b/src/errors/checkLocalTxInput/checkLocalTxInput.spec.ts
@@ -9,7 +9,7 @@ describe('checkLocalTxInput', () => {
 	const registry = new Registry('statemine', {});
 	const specName = 'statemine';
 
-	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
+	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, { registryType: 'NPM' });
 
 	it('Should correctly return Balances with an empty assetIds', async () => {
 		const res = await checkLocalTxInput(systemAssetsApi.api, [], ['10000'], specName, registry, 2, false, false);

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -25,7 +25,9 @@ import {
 	CheckXTokensPalletOriginIsNonForeignAssetTx,
 } from './checkXcmTxInputs';
 
-const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, {
+	registryType: 'NPM',
+});
 const runTests = async (tests: Test[]) => {
 	for (const test of tests) {
 		const [specName, testInputs, direction, errorMessage] = test;

--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -6,8 +6,8 @@ import { adjustedMockRelayApi } from '../testHelpers/adjustedMockRelayApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApi';
 import type { Format, TxResult } from '../types';
 
-const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2);
-const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
+const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, { registryType: 'NPM' });
+const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, { registryType: 'NPM' });
 
 describe('AssetTransferApi Integration Tests', () => {
 	describe('createTransferTransaction', () => {

--- a/src/integrationTests/parachains/bifrost.spec.ts
+++ b/src/integrationTests/parachains/bifrost.spec.ts
@@ -9,7 +9,7 @@ import { paraTransferMultiassets as bifrostTransferMultiassets } from '../util';
 import { paraTransferMultiassetWithFee as bifrostTransferMultiassetWithFee } from '../util';
 import { paraTeleportNativeAsset as bifrsotTeleportNativeAsset } from '../util';
 
-const bifrostATA = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2);
+const bifrostATA = new AssetTransferApi(adjustedMockBifrostParachainApi, 'bifrost', 2, { registryType: 'NPM' });
 
 describe('Bifrost', () => {
 	describe('ParaToPara', () => {

--- a/src/integrationTests/parachains/moonriver.spec.ts
+++ b/src/integrationTests/parachains/moonriver.spec.ts
@@ -9,7 +9,7 @@ import { paraTransferMultiassets as moonriverTransferMultiassets } from '../util
 import { paraTransferMultiassetWithFee as moonriverTransferMultiassetWithFee } from '../util';
 import { paraTeleportNativeAsset as moonriverTeleportNativeAsset } from '../util';
 
-const moonriverATA = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2);
+const moonriverATA = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, { registryType: 'NPM' });
 
 describe('Moonriver', () => {
 	describe('ParaToPara', () => {

--- a/src/util/getFeeAssetItemIndex.spec.ts
+++ b/src/util/getFeeAssetItemIndex.spec.ts
@@ -18,8 +18,8 @@ type Test = [
 ];
 
 describe('getFeeAssetItemIndex', () => {
-	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2);
-	const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2);
+	const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, { registryType: 'NPM' });
+	const relayAssetsApi = new AssetTransferApi(adjustedMockRelayApi, 'kusama', 2, { registryType: 'NPM' });
 	const registry = new Registry('statemine', {});
 
 	it('Should select and return the index of the correct multiassets when given their token symbols', async () => {


### PR DESCRIPTION
This ensures that any instantiation of `AssetTransferApi` uses the `NPM` registry instead of the CDN so that tests can run in an offline enviornment.