### PR TITLE
fix(internal): add deepEqual functionality for comparing two objects

### DIFF
--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -65,6 +65,7 @@ import {
 	UnsignedTransaction,
 	XcmDirection,
 } from './types';
+import { deepEqual } from './util/deepEqual';
 import { resolveMultiLocation } from './util/resolveMultiLocation';
 import { sanitizeKeys } from './util/sanitizeKeys';
 import { validateNumber } from './validate';
@@ -845,10 +846,7 @@ export class AssetTransferApi {
 					const firstLpToken = sanitizeKeys(JSON.parse(firstLpTokenSlice)) as UnionXcmMultiLocation;
 					const secondLpToken = sanitizeKeys(JSON.parse(secondLpTokenSlice)) as UnionXcmMultiLocation;
 
-					if (
-						JSON.stringify(firstLpToken) == JSON.stringify(feeAsset) ||
-						JSON.stringify(secondLpToken) == JSON.stringify(feeAsset)
-					) {
+					if (deepEqual(firstLpToken, feeAsset) || deepEqual(secondLpToken, feeAsset)) {
 						return [true, feeAsset];
 					}
 				}

--- a/src/util/deepEqual.spec.ts
+++ b/src/util/deepEqual.spec.ts
@@ -1,0 +1,14 @@
+import { deepEqual } from './deepEqual';
+
+describe('deepEqual', () => {
+	it('Should return true for 2 equal objects that are out of order', () => {
+		const a = { x: { y: 'z' }, z: ['1', '2', '3'] };
+		const b = { z: ['1', '2', '3'], x: { y: 'z' } };
+		expect(deepEqual(a, b)).toEqual(true);
+	});
+	it('Should return false with 2 unequal objects', () => {
+		const a = { x: { y: 'z' }, z: ['1', '2', '3'] };
+		const b = { w: { y: 'z' }, z: ['1', '2', '3'] };
+		expect(deepEqual(a, b)).toEqual(false);
+	});
+});

--- a/src/util/deepEqual.ts
+++ b/src/util/deepEqual.ts
@@ -1,0 +1,19 @@
+import { AnyJson } from '@polkadot/types/types';
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+/**
+ * Courtesy of https://stackoverflow.com/a/32922084/13609948 for this solution.
+ * Checks the equality between 2 objects.
+ *
+ * @param x
+ * @param y
+ * @returns
+ */
+export function deepEqual(x: AnyJson, y: AnyJson): boolean {
+	const ok = Object.keys,
+		tx = typeof x,
+		ty = typeof y;
+	return x && y && tx === 'object' && tx === ty
+		? ok(x).length === ok(y).length && ok(x).every((key) => deepEqual(x[key], y[key]))
+		: x === y;
+}


### PR DESCRIPTION
closes: https://github.com/paritytech/asset-transfer-api/issues/364

This ensures when we compare two LP tokens that we do a deep equal comparison.