### PR TITLE
fix: update lp pool token storage key destructuring

### DIFF
--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -841,7 +841,7 @@ describe('AssetTransferAPI', () => {
 						sendersAddr: 'FBeL7DanUDs5SZrxZY1CizMaPgG9vZgJgvr52C2dg81SsF1',
 					},
 				);
-			}).rejects.toThrow('paysWithFeeOrigin value must be a valid MultiLocation. Received: hello there');
+			}).rejects.toThrow('paysWithFeeOrigin value must be a valid asset location. Received: hello there');
 		});
 
 		it('Should error during payload construction when a paysWithFeeOrigin is provided that is not part of a valid lp token pair', async () => {
@@ -861,7 +861,7 @@ describe('AssetTransferAPI', () => {
 					},
 				);
 			}).rejects.toThrow(
-				'paysWithFeeOrigin value must be a valid MultiLocation. Received: {"parents":"1","interior":{"X2":["Parachain":"2007","PalletInstance":"1000000"]}}',
+				'paysWithFeeOrigin value must be a valid asset location. Received: {"parents":"1","interior":{"X2":["Parachain":"2007","PalletInstance":"1000000"]}}',
 			);
 		});
 	});
@@ -1755,6 +1755,34 @@ describe('AssetTransferAPI', () => {
 					isLimited,
 				);
 			}).rejects.toThrow('Did not find limitedReserveTransferAssets from pallet xcmPallet in the current runtime');
+		});
+	});
+	describe('checkAssetLpTokenPairExists', () => {
+		it('Should correctly return true when an assetConversion lp pool token location pair contains a match to a given paysWithFee asset location', async () => {
+			const paysWithFeeOrigin = `{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`;
+
+			expect(await systemAssetsApi['checkAssetLpTokenPairExists'](paysWithFeeOrigin)).toEqual([
+				true,
+				{
+					Parents: '0',
+					Interior: {
+						X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+					},
+				},
+			]);
+		});
+		it('Should correctly return false when an assetConversion lp pool token location pair does not contain a match to a given paysWithFee asset location', async () => {
+			const paysWithFeeOrigin = `{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"2000"}]}}`;
+
+			expect(await systemAssetsApi['checkAssetLpTokenPairExists'](paysWithFeeOrigin)).toEqual([
+				false,
+				{
+					Parents: '0',
+					Interior: {
+						X2: [{ PalletInstance: '50' }, { GeneralIndex: '2000' }],
+					},
+				},
+			]);
 		});
 	});
 });

--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -274,6 +274,48 @@ describe('AssetTransferApi Integration Tests', () => {
 					},
 				);
 			};
+			const nativeBaseSystemPaysWithFeeOriginAssetLocationCreateTx = async <T extends Format>(
+				ataAPI: AssetTransferApi,
+				format: T,
+				xcmVersion: number,
+				opts: CreateXcmCallOpts,
+			): Promise<TxResult<T>> => {
+				return await ataAPI.createTransferTransaction(
+					'2000', // Since this is not `0` we know this is to a parachain
+					'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+					['KSM'],
+					['100'],
+					{
+						paysWithFeeOrigin: `{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`,
+						format,
+						xcmVersion,
+						weightLimit: opts.weightLimit,
+						isLimited: opts.isLimited,
+						sendersAddr: 'FBeL7DanUDs5SZrxZY1CizMaPgG9vZgJgvr52C2dg81SsF1',
+					},
+				);
+			};
+			const nativeBaseSystemPaysWithFeeOriginAssetIdCreateTx = async <T extends Format>(
+				ataAPI: AssetTransferApi,
+				format: T,
+				xcmVersion: number,
+				opts: CreateXcmCallOpts,
+			): Promise<TxResult<T>> => {
+				return await ataAPI.createTransferTransaction(
+					'2000', // Since this is not `0` we know this is to a parachain
+					'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+					['KSM'],
+					['100'],
+					{
+						paysWithFeeOrigin: `1984`,
+						format,
+						xcmVersion,
+						weightLimit: opts.weightLimit,
+						isLimited: opts.isLimited,
+						sendersAddr: 'FBeL7DanUDs5SZrxZY1CizMaPgG9vZgJgvr52C2dg81SsF1',
+					},
+				);
+			};
 			const foreignAssetMultiLocationBaseSystemCreateTx = async <T extends Format>(
 				ataAPI: AssetTransferApi,
 				format: T,
@@ -548,6 +590,46 @@ describe('AssetTransferApi Integration Tests', () => {
 						method: 'limitedReserveTransferAssets',
 						origin: 'statemine',
 						tx: '0x1f0801010100411f0100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b0104000002043705000091010000000001a10fa10f',
+						xcmVersion: 2,
+					});
+				});
+				it('Should correctly construct a paysWithFeeOrigin tx for V2 using an assets location', async () => {
+					const res = await nativeBaseSystemPaysWithFeeOriginAssetLocationCreateTx(systemAssetsApi, 'payload', 2, {
+						isLimited: true,
+						weightLimit: {
+							refTime: '1000',
+							proofSize: '2000',
+						},
+						isForeignAssetsTransfer: false,
+						isLiquidTokenTransfer: false,
+					});
+					expect(res).toStrictEqual({
+						dest: 'karura',
+						direction: 'SystemToPara',
+						format: 'payload',
+						method: 'limitedReserveTransferAssets',
+						origin: 'statemine',
+						tx: '0xf81f0801010100411f0100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000001a10f411f45022800010002043205011fcc240000040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503',
+						xcmVersion: 2,
+					});
+				});
+				it('Should correctly construct a paysWithFeeOrigin tx for V2 using an assets id', async () => {
+					const res = await nativeBaseSystemPaysWithFeeOriginAssetIdCreateTx(systemAssetsApi, 'payload', 2, {
+						isLimited: true,
+						weightLimit: {
+							refTime: '1000',
+							proofSize: '2000',
+						},
+						isForeignAssetsTransfer: false,
+						isLiquidTokenTransfer: false,
+					});
+					expect(res).toStrictEqual({
+						dest: 'karura',
+						direction: 'SystemToPara',
+						format: 'payload',
+						method: 'limitedReserveTransferAssets',
+						origin: 'statemine',
+						tx: '0xf81f0801010100411f0100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b01040001000091010000000001a10f411f45022800010000cc240000040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503',
 						xcmVersion: 2,
 					});
 				});
@@ -850,6 +932,46 @@ describe('AssetTransferApi Integration Tests', () => {
 						tx: '0x1f0803010100411f0300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b0304000002043705000091010000000001a10fa10f',
 						xcmVersion: 3,
 					});
+				});
+			});
+			it('Should correctly construct a paysWithFeeOrigin tx for V3 using an assets id', async () => {
+				const res = await nativeBaseSystemPaysWithFeeOriginAssetIdCreateTx(systemAssetsApi, 'payload', 3, {
+					isLimited: true,
+					weightLimit: {
+						refTime: '1000',
+						proofSize: '2000',
+					},
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
+				expect(res).toStrictEqual({
+					dest: 'karura',
+					direction: 'SystemToPara',
+					format: 'payload',
+					method: 'limitedReserveTransferAssets',
+					origin: 'statemine',
+					tx: '0xf81f0803010100411f0300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000001a10f411f45022800010000cc240000040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503',
+					xcmVersion: 3,
+				});
+			});
+			it('Should correctly construct a paysWithFeeOrigin tx for V3 using an assets location', async () => {
+				const res = await nativeBaseSystemPaysWithFeeOriginAssetLocationCreateTx(systemAssetsApi, 'payload', 3, {
+					isLimited: true,
+					weightLimit: {
+						refTime: '1000',
+						proofSize: '2000',
+					},
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
+				expect(res).toStrictEqual({
+					dest: 'karura',
+					direction: 'SystemToPara',
+					format: 'payload',
+					method: 'limitedReserveTransferAssets',
+					origin: 'statemine',
+					tx: '0xf81f0803010100411f0300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b03040001000091010000000001a10f411f45022800010002043205011fcc240000040000000000000000000000000000000000000000000000000000000000000000000000be2554aa8a0151eb4d706308c47d16996af391e4c5e499c7cbef24259b7d4503',
+					xcmVersion: 3,
 				});
 			});
 		});

--- a/src/testHelpers/adjustedMockSystemApiV1004000.ts
+++ b/src/testHelpers/adjustedMockSystemApiV1004000.ts
@@ -327,15 +327,33 @@ export const adjustedMockSystemApi = {
 					const palletAssetConversionData = Object.assign(
 						[
 							[
-								[
-									{ parents: '0', interior: { Here: '' } },
+								Object.assign(
+									[
+										{ parents: '0', interior: { Here: '' } },
+										{
+											parents: '0',
+											interior: {
+												X2: [{ PalletInstance: '50' }, { GeneralIndex: '100' }],
+											},
+										},
+									],
 									{
-										parents: '0',
-										interior: {
-											X2: [{ PalletInstance: '50' }, { GeneralIndex: '100' }],
+										toHuman: () => {
+											return [
+												[
+													{ parents: '0', interior: { Here: '' } },
+													{
+														parents: '0',
+														interior: {
+															X2: [{ PalletInstance: '50' }, { GeneralIndex: '100' }],
+														},
+													},
+												],
+												0,
+											];
 										},
 									},
-								],
+								),
 								Object.assign(
 									{
 										lpToken: mockSystemApi.registry.createType('u32', 0),
@@ -350,15 +368,33 @@ export const adjustedMockSystemApi = {
 								),
 							],
 							[
-								[
-									{ parents: '0', interior: { Here: '' } },
+								Object.assign(
+									[
+										{ parents: '0', interior: { Here: '' } },
+										{
+											parents: '0',
+											interior: {
+												X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+											},
+										},
+									],
 									{
-										parents: '0',
-										interior: {
-											X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+										toHuman: () => {
+											return [
+												[
+													{ parents: '0', interior: { Here: '' } },
+													{
+														parents: '0',
+														interior: {
+															X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
+														},
+													},
+												],
+												1,
+											];
 										},
 									},
-								],
+								),
 								Object.assign(
 									{
 										lpToken: mockSystemApi.registry.createType('u32', 1),


### PR DESCRIPTION
### Description

This PR contains changes to `checkAssetLpTokenPairExists` which now gets the json representation of queried LP token asset locations for creating location types instead of using string derived values which caused issues destructuring some asset locations when using the `paysWithFeeOrigin` option.


closes: [#389](https://github.com/paritytech/asset-transfer-api/issues/389)