### PR TITLE
chore(examples): update xmcVersion to safeXcmVersion

### DIFF
--- a/examples/WestendAssetHubToWestendCollectivesXcmV4.ts
+++ b/examples/WestendAssetHubToWestendCollectivesXcmV4.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a `limitedTeleportAssets` call to send 1 WND from a Westend AssetHub (System Parachain) account
- * to a Westend Collectives (System Parachain) account, where the `xcmVersion` is set to `4` and and no `weightLimit` option is provided declaring that
+ * to a Westend Collectives (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/WestendAssetHubToWestendXcmV4.ts
+++ b/examples/WestendAssetHubToWestendXcmV4.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a `limitedTeleportAssets` call to send 1 WND from a Westend AssetHub (System Parachain) account
- * to a Westend (Relay Chain) account, where the `xcmVersion` is set to `4` and no `weightLimit` option is provided declaring that
+ * to a Westend (Relay Chain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/WestendToAssetHubXcmV4.ts
+++ b/examples/WestendToAssetHubXcmV4.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a `limitedTeleportAssets` call to send 1 WND from a Westend (Relay Chain) account
- * to a Westend AssetHub (System Parachain) account, where the `xcmVersion` is set to `4`and no `weightLimit` option is provided declaring that
+ * to a Westend AssetHub (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/assetHubToMoonriverPaysWithFeeOrigin.ts
+++ b/examples/assetHubToMoonriverPaysWithFeeOrigin.ts
@@ -29,7 +29,7 @@ const main = async () => {
 			['1000000'],
 			{
 				format: 'payload',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 				paysWithFeeOrigin: '1984',
 				sendersAddr: 'FBeL7DanUDs5SZrxZY1CizMaPgG9vZgJgvr52C2dg81SsF1',
 			},

--- a/examples/claimAssets.ts
+++ b/examples/claimAssets.ts
@@ -22,7 +22,7 @@ const main = async () => {
 			'5HBuLJz9LdkUNseUEL6DLeVkx2bqEi6pQr8Ea7fS4bzx7i7E',
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/kusama/assetHub/bridgeTransfers/assetHubDOTToPolkadot.ts
+++ b/examples/kusama/assetHub/bridgeTransfers/assetHubDOTToPolkadot.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 DOT (foreign asset with location `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}`)
  * from a Kusama Asset Hub (System Parachain) account
- * to a Polkadot Asset Hub account, where the `xcmVersion` is set to 4 and no `weightLimit` option is provided declaring that
+ * to a Polkadot Asset Hub account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['10000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/kusama/assetHub/bridgeTransfers/assetHubKSMToPolkadot.ts
+++ b/examples/kusama/assetHub/bridgeTransfers/assetHubKSMToPolkadot.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 KSM (asset with location `{"parents":"1","interior":{"Here":""}}`)
  * from a Kusama Asset Hub (System Parachain) account
- * to a Polkadot Asset Hub account, where the `xcmVersion` is set to 4 and no `weightLimit` option is provided declaring that
+ * to a Polkadot Asset Hub account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/kusama/assetHub/foreignAssetTransfers/reserve/assetHubMOVRToBifrostKusama.ts
+++ b/examples/kusama/assetHub/foreignAssetTransfers/reserve/assetHubMOVRToBifrostKusama.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 MOVR (foreign asset with location `{"parents":"1","interior":{"X2":[{"Parachain":"2125"},{"GeneralIndex":"0"}]}}`)
  * from a Kusama Asset Hub (System Parachain) account
- * to a Bifrost (ParaChain) account, where the `xcmVersion` is set to 3 and no `weightLimit` option is provided declaring that
+ * to a Bifrost (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/kusama/assetHub/foreignAssetTransfers/teleport/assetHubMOVRToMoonriver.ts
+++ b/examples/kusama/assetHub/foreignAssetTransfers/teleport/assetHubMOVRToMoonriver.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 MOVR (foreign asset with location `{"parents":"1","interior":{"X2":[{"Parachain":"2023"},{"PalletInstance":"10"}]}}`)
  * from a Kusama Asset Hub (System Parachain) account
- * to a Moonriver (ParaChain) account, where the `xcmVersion` is set to 3 and no `weightLimit` option is provided declaring that
+ * to a Moonriver (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToParaParachainPrimaryNativeReserveTransfer.ts
+++ b/examples/paraToParaParachainPrimaryNativeReserveTransfer.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send PHA from a Phala Network (Parachain) account
- * to a Moonbeam (Parachain) account, where the `xcmVersion` is set to 3 and no `weightLimit` option is provided declaring that
+ * to a Moonbeam (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow `unlimited` weight to be used.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToParaTransferMultiAsset.ts
+++ b/examples/paraToParaTransferMultiAsset.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send `BNC` from a Moonriver (Parachain) account
- * to a Bifrost Kusama (Parachain) account, where the `xcmVersion` is set to 2 and no `weightLimit` is provided declaring that
+ * to a Bifrost Kusama (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * it will be `unlimited` since there is no `weightLimit` option as well.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToParaTransferMultiAssetWithFee.ts
+++ b/examples/paraToParaTransferMultiAssetWithFee.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send PHA from a Moonriver (Parachain) account
- * to a Kusama Khala (Parachain) account, where the `xcmVersion` is set to 2 and a `weightLimit` option is provided declaring that
+ * to a Kusama Khala (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and a `weightLimit` option is provided declaring that
  * it will be a weight limited tx with a custom `refTime` and `proofSize`.
  *
  */
@@ -29,7 +29,7 @@ const main = async () => {
 					refTime: '10000',
 					proofSize: '3000',
 				},
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 				// NOTE: for `xTokens` pallet `transferMultiassetWithFee` txs, `paysWithFeeDest` is the multiLocation of the asset that is intended to be used to pay for fees in the dest chain
 				paysWithFeeDest:
 					'{"parents": "1", "interior": {"X3": [{"Parachain": "1000"}, {"PalletInstance": "50"}, {"GeneralIndex": "1984"}]}}',

--- a/examples/paraToParaTransferMultiAssets.ts
+++ b/examples/paraToParaTransferMultiAssets.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send vMOVR and vBNC from a Moonriver (Parachain) account
- * to a Bifrost Kusama (Parachain) account, where the `xcmVersion` is set to 2 and no `weightLimit` is provided declaring that
+ * to a Bifrost Kusama (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * the tx will be allowed to use unlimited weight for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000', '10000000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToRelayTransferMultiAsset.ts
+++ b/examples/paraToRelayTransferMultiAsset.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send KSM from a Moonriver (Parachain) account
- * to a Kusama Relay chain account, where the `xcmVersion` is set to 3 and no `weightLimit` is provided declaring that
+ * to a Kusama Relay chain account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * it will allow `unlimited` weight for the tx.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToSystemParachainPrimaryNative.ts
+++ b/examples/paraToSystemParachainPrimaryNative.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send MOVR from a Moonriver (Parachain) account
- * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to 3 and no `weightLimit` is provided declaring that
+ * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * it will allow `unlimited` weight for the tx.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToSystemTransferMultiAsset.ts
+++ b/examples/paraToSystemTransferMultiAsset.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 xcUSDT from a Moonriver (Parachain) account
- * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to 2 and no `weightLimit` is provided declaring that
+ * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * it will allow `unlimited` weight for the tx.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/paraToSystemTransferMultiAssetWithFee.ts
+++ b/examples/paraToSystemTransferMultiAssetWithFee.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 xcRMRK from a Moonriver (Parachain) account
- * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to 3 and a `weightLimit` is provided declaring that
+ * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and a `weightLimit` is provided declaring that
  * it will be a weight limited tx with a custom `refTime` and `proofSize`.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -30,7 +30,7 @@ const main = async () => {
 					refTime: '10000',
 					proofSize: '3000',
 				},
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 				// NOTE: for xTokens `transferMultiassetWithFee` txs, paysWithFeeDest is the multiLocation of the asset that is intended to be used to pay for fees in the dest chain
 				paysWithFeeDest:
 					'{"parents": "1", "interior": {"X3": [{"Parachain": "1000"}, {"PalletInstance": "50"}, {"GeneralIndex": "1984"}]}}',

--- a/examples/paraToSystemTransferMultiAssets.ts
+++ b/examples/paraToSystemTransferMultiAssets.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 xcUSDT and 1 xcRMRK from a Moonriver (Parachain) account
- * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to 3 and no `weightLimit` is provided declaring that
+ * to a Kusama Asset Hub (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * it will allow `unlimited` weight for the tx.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000', '10000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/polkadot/assetHub/bridgeTransfers/assetHubDOTToKusama.ts
+++ b/examples/polkadot/assetHub/bridgeTransfers/assetHubDOTToKusama.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 DOT (asset with location `{"parents":"1","interior":{"Here":""}}`)
  * from a Polkadot Asset Hub (System Parachain) account
- * to a Kusama Asset Hub account, where the `xcmVersion` is set to 4 and no `weightLimit` option is provided declaring that
+ * to a Kusama Asset Hub account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['10000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/polkadot/assetHub/bridgeTransfers/assetHubKSMToKusama.ts
+++ b/examples/polkadot/assetHub/bridgeTransfers/assetHubKSMToKusama.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 KSM (foreign asset with location `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Kusama"}}}`)
  * from a Polkadot Asset Hub (System Parachain) account
- * to a Kusama Asset Hub account, where the `xcmVersion` is set to 4 and no `weightLimit` option is provided declaring that
+ * to a Kusama Asset Hub account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/polkadot/assetHub/foreignAssetTransfers/local/assetHubKSMTransfer.ts
+++ b/examples/polkadot/assetHub/foreignAssetTransfers/local/assetHubKSMTransfer.ts
@@ -27,7 +27,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3, // Note: GlobalConsensus junctions require XCM V3 or higher
+				xcmVersion: safeXcmVersion, // Note: GlobalConsensus junctions require XCM V3 or higher
 			},
 		);
 

--- a/examples/polkadot/assetHub/foreignAssetTransfers/reserve/assetHubKSMToMoonbeam.ts
+++ b/examples/polkadot/assetHub/foreignAssetTransfers/reserve/assetHubKSMToMoonbeam.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `limitedReserveTransferAssets` call to send 1 KSM (foreign asset with location '{"parents":"1","interior":{"X1":{"GlobalConsensus":"Kusama"}}}')
  * from a Polkadot Asset Hub (System Parachain) account
- * to a Moonbeam (ParaChain) account, where the `xcmVersion` is set to 3 and no `weightLimit` option is provided declaring that
+ * to a Moonbeam (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/polkadot/assetHub/foreignAssetTransfers/teleport/assetHubEQToEquilibrium.ts
+++ b/examples/polkadot/assetHub/foreignAssetTransfers/teleport/assetHubEQToEquilibrium.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `limitedTeleportAssets` call to send EQ (foreign asset with location `{"parents":"1","interior":{"X1":{"Parachain":"2011"}}}`)
  * from a Polkadot Asset Hub (System Parachain) account
- * to an Equilibrium (ParaChain) account, where the `xcmVersion` is set to 3 and no `weightLimit` option is provided declaring that
+ * to an Equilibrium (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/relayToPara.ts
+++ b/examples/relayToPara.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 KSM from a Kusama (Relay Chain) account
- * to a Moonriver (Parachain) account, where the `xcmVersion` is set to 2 and no `weightLimit` is provided declaring that
+ * to a Moonriver (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` is provided declaring that
  * the tx will allow unlimited weight for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/relayToSystem.ts
+++ b/examples/relayToSystem.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 WND from a Westend (Relay Chain) account
- * to a Westmint (System Parachain) account, where the `xcmVersion` is set to 2 and no `weightLimit` option is provided declaring that
+ * to a Westmint (System Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -26,7 +26,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/rococo/assetHub/bridgeTransfers/assetHubROCToWestend.ts
+++ b/examples/rococo/assetHub/bridgeTransfers/assetHubROCToWestend.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 ROC (asset with location `{"parents":"1","interior":{"Here":""}}`)
  * from a Rococo Asset Hub (System Parachain) account
- * to a Westend Asset Hub account, where the `xcmVersion` is set to 4 and no `weightLimit` option is provided declaring that
+ * to a Westend Asset Hub account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/rococo/assetHub/bridgeTransfers/assetHubWETHToEthereumSepolia.ts
+++ b/examples/rococo/assetHub/bridgeTransfers/assetHubWETHToEthereumSepolia.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send WETH (foreign asset with location `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`)
  * from a Rococo Asset Hub (System Parachain) account
- * to an Ethereum Sepolia account, where the `xcmVersion` is set to 4, and there is no
+ * to an Ethereum Sepolia account, where the `xcmVersion` is set to safeXcmVersion, and there is no
  * `weightLimit` option provided which declares that the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -34,7 +34,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/rococo/assetHub/bridgeTransfers/assetHubWNDToWestend.ts
+++ b/examples/rococo/assetHub/bridgeTransfers/assetHubWNDToWestend.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssets` call to send 1 WND (foreign asset with location `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`)
  * from a Rococo Asset Hub (System Parachain) account
- * to a Westend Asset Hub account, where the `xcmVersion` is set to 4 and no `weightLimit` option is provided declaring that
+ * to a Westend Asset Hub account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/rococo/assetHub/foreignAssetTransfers/local/assetHubWETHTransfer.ts
+++ b/examples/rococo/assetHub/foreignAssetTransfers/local/assetHubWETHTransfer.ts
@@ -8,8 +8,7 @@ import { TxResult } from '../../../../../src/types';
 import { GREEN, PURPLE, RESET } from '../../../../colors';
 
 /**
- * In this example we are creating a `foreignAssets` pallet `transfer` call to send WETH (foreign asset with location `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`,
-`)
+ * In this example we are creating a `foreignAssets` pallet `transfer` call to send WETH (foreign asset with location `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`,`)
  * from a Rococo Asset Hub (System Parachain) account
  * to a Rococo Asset Hub (System Parachain) account.
  *
@@ -34,7 +33,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/rococo/assetHub/foreignAssetTransfers/reserve/assetHubMUSEToBifrostRemoteReserve.ts
+++ b/examples/rococo/assetHub/foreignAssetTransfers/reserve/assetHubMUSEToBifrostRemoteReserve.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssetsUsingTypeAndThen` call to send MUSE (foreign asset with location `{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}`)
  * from a Rococo Asset Hub (System Parachain) account
- * to a Bifrost Polkadot (Parachain) testnet account, where the `xcmVersion` is set to 4, and there is no
+ * to a Bifrost Polkadot (Parachain) testnet account, where the `xcmVersion` is set to safeXcmVersion, and there is no
  * `weightLimit` option provided which declares that the tx will allow unlimited weight to be used for fees.
  * We provide a `paysWithFeeDest` asset location for MUSE which will be used to pay for fees on the destination chain.
  * We also provide a value of `RemoteReserve` for the `assetTransferType` and `feeTransferType` options declaring a custom reserve location for both
@@ -35,7 +35,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 				paysWithFeeDest: '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}',
 				assetTransferType: 'RemoteReserve',
 				remoteReserveAssetTransferTypeLocation: '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}',

--- a/examples/rococo/assetHub/foreignAssetTransfers/reserve/assetHubMUSEToRhala.ts
+++ b/examples/rococo/assetHub/foreignAssetTransfers/reserve/assetHubMUSEToRhala.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssetsUsingTypeAndThen` call to send MUSE (foreign asset with location `{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}`)
  * from a Rococo Asset Hub (System Parachain) account
- * to a Rhala Testnet (ParaChain) account, where the `xcmVersion` is set to 4, and there is no
+ * to a Rhala Testnet (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion, and there is no
  * `weightLimit` option provided which declares that the tx will allow unlimited weight to be used for fees.
  *  * The `paysWithFeeDest` value is set to pay fees with `MUSE` and the values for `assetTransferType` and `feesTransferType`
  * are both set to `LocalReserve` specifying that the reserve location to be used for transfers and fees is AssetHub.
@@ -32,7 +32,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 				paysWithFeeDest: '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}',
 				assetTransferType: 'LocalReserve',
 				feesTransferType: 'LocalReserve',

--- a/examples/rococo/assetHub/foreignAssetTransfers/reserve/assetHubWETHToRhala.ts
+++ b/examples/rococo/assetHub/foreignAssetTransfers/reserve/assetHubWETHToRhala.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from '../../../../colors';
 /**
  * In this example we are creating a `polkadotXcm` pallet `transferAssetsUsingTypeAndThen` call to send WETH (foreign asset with location `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`)
  * from a Rococo Asset Hub (System Parachain) account
- * to a Rhala Testnet (ParaChain) account, where the `xcmVersion` is set to 4, and there is no
+ * to a Rhala Testnet (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion, and there is no
  * `weightLimit` option provided which declares that the tx will allow unlimited weight to be used for fees.
  * The `paysWithFeeDest` value is set to pay fees with WETH and the values for `assetTransferType` and `feesTransferType`
  * are both set to `LocalReserve` specifying that the reserve location to be used for transfers and fees is AssetHub.
@@ -34,7 +34,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 4,
+				xcmVersion: safeXcmVersion,
 				paysWithFeeDest: `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`,
 				assetTransferType: 'LocalReserve',
 				feesTransferType: 'LocalReserve',

--- a/examples/rococoAssetHubToRelay.ts
+++ b/examples/rococoAssetHubToRelay.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 ROC from a asset-hub-rococo (System Parachain) account
- * to a Rococo (Relay Chain) account, where the `xcmVersion` is set to 2 and no `weightLimit` option is provided declaring that
+ * to a Rococo (Relay Chain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -30,7 +30,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/submittable.ts
+++ b/examples/submittable.ts
@@ -30,7 +30,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'submittable',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/systemToPara.ts
+++ b/examples/systemToPara.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 0.1 USDt from a Kusama AssetHub (System Parachain) account
- * to a Moonriver (Parachain) account, where the `xcmVersion` is set to 2 and no `weightLimit` option is provided declaring that
+ * to a Moonriver (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -27,7 +27,7 @@ const main = async () => {
 			['100000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/systemToParaLpToken.ts
+++ b/examples/systemToParaLpToken.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send LiquidPool Asset '0' from a Westmint (System Parachain) account
- * to a Injected (Parachain) called 'testing', where the `xcmVersion` is set to 2 and no `weightLimit` option is provided declaring that
+ * to a Injected (Parachain) called 'testing', where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -40,7 +40,7 @@ const main = async () => {
 			['100000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 				transferLiquidToken: true,
 			},
 		);

--- a/examples/systemToParaTeleportForeignAssets.ts
+++ b/examples/systemToParaTeleportForeignAssets.ts
@@ -10,7 +10,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 /**
  * In this example we are creating a teleport call to send foreign asset '{"parents":"1","interior":{"X2":[{"Parachain":"2125"},{"GeneralIndex":"0"}]}}'
  * from a Kusama Asset Hub (System Parachain) account
- * to a Tinkernet (ParaChain) account, where the `xcmVersion` is set to 3 and no `weightLimit` option is provided declaring that
+ * to a Tinkernet (ParaChain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -28,7 +28,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 3,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/systemToRelay.ts
+++ b/examples/systemToRelay.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 WND from a Westmint (System Parachain) account
- * to a Westend (Relay Chain) account, where the `xcmVersion` is set to 2 and no `weightLimit` option is provided declaring that
+ * to a Westend (Relay Chain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -27,7 +27,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 

--- a/examples/systemToSystem.ts
+++ b/examples/systemToSystem.ts
@@ -9,7 +9,7 @@ import { GREEN, PURPLE, RESET } from './colors';
 
 /**
  * In this example we are creating a call to send 1 WND from a Westmint (System Parachain) account
- * to a Westend Collectives (System Chain) account, where the `xcmVersion` is set to 2and no `weightLimit` option is provided declaring that
+ * to a Westend Collectives (System Chain) account, where the `xcmVersion` is set to safeXcmVersion and no `weightLimit` option is provided declaring that
  * the tx will allow unlimited weight to be used for fees.
  *
  * NOTE: To specify the amount of weight for the tx to use provide a `weightLimit` option containing desired values for `refTime` and `proofSize`.
@@ -27,7 +27,7 @@ const main = async () => {
 			['1000000000000'],
 			{
 				format: 'call',
-				xcmVersion: 2,
+				xcmVersion: safeXcmVersion,
 			},
 		);
 


### PR DESCRIPTION
This just ensures we no longer hardcode the xcmVersion but instead just pull from safeXcmVersion