### PR TITLE
fix: improve error messages

### DIFF
--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -1104,7 +1104,7 @@ export class AssetTransferApi {
 				);
 			}
 		} else {
-			checkLocalRelayInput(assetIds, amounts);
+			checkLocalRelayInput(assetIds, amounts, this.registry);
 			/**
 			 * By default local transaction on a relay chain will always be from the balances pallet
 			 */

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -76,3 +76,13 @@ export const JS_ENV = detectJsEnv();
  * Supported consensus system chain names
  */
 export const KNOWN_GLOBAL_CONSENSUS_SYSTEM_NAMES = ['polkadot', 'kusama', 'westend', 'rococo', 'ethereum'];
+
+/**
+ * The asset location of the native relay chain asset from the perspective of `System` and `Para` Chains
+ */
+export const SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION = '{"parents":"1","interior":{"Here":""}}';
+/**
+ * The asset location of the native relay chain asset from the perspective of the Relay chain
+ */
+export const RELAY_CHAINS_NATIVE_ASSET_LOCATION = '{"parents":"0","interior":{"Here":""}}';
+

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -85,4 +85,3 @@ export const SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION = '{"parents":"1","inter
  * The asset location of the native relay chain asset from the perspective of the Relay chain
  */
 export const RELAY_CHAINS_NATIVE_ASSET_LOCATION = '{"parents":"0","interior":{"Here":""}}';
-

--- a/src/createXcmTypes/SystemToBridge.ts
+++ b/src/createXcmTypes/SystemToBridge.ts
@@ -262,16 +262,13 @@ export const createSystemToBridgeAssets = async (
 	let multiAssets: FungibleStrAssetType[] = [];
 	let multiAsset: FungibleStrAssetType;
 	const palletId = fetchPalletInstanceId(api, isLiquidTokenTransfer, isForeignAssetsTransfer);
-	const systemChainId = registry.lookupChainIdBySpecName(specName);
 
 	for (let i = 0; i < assets.length; i++) {
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
-		const { tokens } = registry.currentRelayRegistry[systemChainId];
-
 		const isValidInt = validateNumber(assetId);
-		const isRelayNative = isRelayNativeAsset(tokens, assetId);
+		const isRelayNative = isRelayNativeAsset(registry, assetId);
 		if (!isRelayNative && !isValidInt) {
 			assetId = await getAssetId(api, registry, assetId, specName, xcmVersion, isForeignAssetsTransfer);
 		}

--- a/src/createXcmTypes/SystemToPara.ts
+++ b/src/createXcmTypes/SystemToPara.ts
@@ -279,14 +279,12 @@ export const createSystemToParaMultiAssets = async (
 		);
 	}
 
-	const { tokens } = registry.currentRelayRegistry[systemChainId];
-
 	for (let i = 0; i < assets.length; i++) {
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
 		const isValidInt = validateNumber(assetId);
-		const isRelayNative = isRelayNativeAsset(tokens, assetId);
+		const isRelayNative = isRelayNativeAsset(registry, assetId);
 
 		if (!isRelayNative && !isValidInt) {
 			assetId = await getAssetId(api, registry, assetId, specName, xcmVersion, isForeignAssetsTransfer);

--- a/src/createXcmTypes/SystemToSystem.ts
+++ b/src/createXcmTypes/SystemToSystem.ts
@@ -260,14 +260,12 @@ export const createSystemToSystemMultiAssets = async (
 		);
 	}
 
-	const { tokens } = registry.currentRelayRegistry[systemChainId];
-
 	for (let i = 0; i < assets.length; i++) {
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
 		const isValidInt = validateNumber(assetId);
-		const isRelayNative = isRelayNativeAsset(tokens, assetId);
+		const isRelayNative = isRelayNativeAsset(registry, assetId);
 
 		if (!isRelayNative && !isValidInt) {
 			assetId = await getAssetId(api, registry, assetId, specName, xcmVersion, isForeignAssetsTransfer);

--- a/src/createXcmTypes/util/assetIdsContainsRelayAsset.ts
+++ b/src/createXcmTypes/util/assetIdsContainsRelayAsset.ts
@@ -9,12 +9,11 @@ export const assetIdsContainRelayAsset = (assetIds: string[], registry: Registry
 		return true;
 	}
 
-	const { tokens } = registry.currentRelayRegistry['0'];
 	const relayAssetMultiLocation = `{"parents": 1, "interior": { "Here": ''}}`;
 
 	for (const asset of assetIds) {
 		// check relay tokens and if matched it is the relay asset
-		if (isRelayNativeAsset(tokens, asset)) {
+		if (isRelayNativeAsset(registry, asset)) {
 			return true;
 		}
 

--- a/src/createXcmTypes/util/createAssetLocations.ts
+++ b/src/createXcmTypes/util/createAssetLocations.ts
@@ -2,7 +2,6 @@
 
 import { ApiPromise } from '@polkadot/api';
 
-import { ASSET_HUB_CHAIN_ID } from '../../consts';
 import { Registry } from '../../registry';
 import { RequireOnlyOne } from '../../types';
 import { resolveMultiLocation } from '../../util/resolveMultiLocation';
@@ -37,7 +36,6 @@ export const createAssetLocations = async (
 	let multiAssets: FungibleStrAssetType[] = [];
 	let multiAsset: FungibleStrAssetType;
 
-	const { tokens } = registry.currentRelayRegistry[ASSET_HUB_CHAIN_ID];
 	const palletId = fetchPalletInstanceId(api, isLiquidTokenTransfer, assetIdsContainLocations);
 	const isRelayChain = originChainId === '0' ? true : false;
 
@@ -47,7 +45,7 @@ export const createAssetLocations = async (
 		let assetId = assetIds[i];
 
 		const isValidInt = validateNumber(assetId);
-		const isRelayNative = isRelayNativeAsset(tokens, assetId);
+		const isRelayNative = isRelayNativeAsset(registry, assetId);
 
 		if (!assetIdsContainLocations && !isRelayNative && !isValidInt) {
 			assetId = await getAssetId(api, registry, assetId, specName, xcmVersion, assetIdsContainLocations);

--- a/src/createXcmTypes/util/getAssetId.spec.ts
+++ b/src/createXcmTypes/util/getAssetId.spec.ts
@@ -30,7 +30,7 @@ describe('getAssetId', () => {
 		it('Should error when an asset id symbol is given that is not present in the registry or chain state', async () => {
 			await expect(async () => {
 				await getAssetId(systemAssetsApi.api, registry, 'hello', 'statemine', 2, false);
-			}).rejects.toThrow('assetId hello is not a valid symbol or integer asset id');
+			}).rejects.toThrow('assetId hello is not a valid symbol, integer asset id or location for statemine');
 		});
 
 		it('Should correctly return the foreign asset multilocation when given a valid foreign asset multilocation', async () => {

--- a/src/createXcmTypes/util/getAssetId.ts
+++ b/src/createXcmTypes/util/getAssetId.ts
@@ -112,7 +112,7 @@ export const getAssetId = async (
 			}
 		} else {
 			throw new BaseError(
-				`assetId ${asset} is not a valid symbol or integer asset id for ${specName}`,
+				`assetId ${asset} is not a valid symbol, integer asset id or location for ${specName}`,
 				BaseErrorsEnum.InvalidAsset,
 			);
 		}

--- a/src/createXcmTypes/util/isRelayNativeAsset.spec.ts
+++ b/src/createXcmTypes/util/isRelayNativeAsset.spec.ts
@@ -1,11 +1,47 @@
+// Copyright 2024 Parity Technologies (UK) Ltd.
+
+import { Registry } from '../../registry';
 import { isRelayNativeAsset } from './isRelayNativeAsset';
 
 describe('isRelayNativeAsset', () => {
-	const tokens = ['KSM'];
-	it('Should return true', () => {
-		expect(isRelayNativeAsset(tokens, 'KSM')).toEqual(true);
+	describe('RelayToSystem', () => {
+		const specName = 'kusama';
+		const registry = new Registry(specName, {});
+
+		it('Should return true when an empty string is provided as the assetId', () => {
+			expect(isRelayNativeAsset(registry, '')).toEqual(true);
+		});
+		it('Should return true when a symbol assetId matches the relay assetId', () => {
+			expect(isRelayNativeAsset(registry, 'KSM')).toEqual(true);
+		});
+		it('Should return false when a symbol assetId does not match the relay assetId', () => {
+			expect(isRelayNativeAsset(registry, 'DOT')).toEqual(false);
+		});
+		it('Should return true when the relay chains asset location is given as input from the perspective of the relay chain', () => {
+			expect(isRelayNativeAsset(registry, '{"parents":"0","interior":{"Here":""}}')).toEqual(true);
+		});
+		it('Should return false when the relay chains asset location is given as input from the perspective of a child chain', () => {
+			expect(isRelayNativeAsset(registry, '{"parents":"1","interior":{"Here":""}}')).toEqual(false);
+		});
 	});
-	it('Should return false', () => {
-		expect(isRelayNativeAsset(tokens, 'DOT')).toEqual(false);
+	describe('SystemToRelay', () => {
+		const specName = 'statemint';
+		const registry = new Registry(specName, {});
+
+		it('Should return true when an empty string is provided as the assetId', () => {
+			expect(isRelayNativeAsset(registry, '')).toEqual(true);
+		});
+		it('Should return true when a symbol assetId matches the relay assetId', () => {
+			expect(isRelayNativeAsset(registry, 'DOT')).toEqual(true);
+		});
+		it('Should return false when a symbol assetId does not match the relay assetId', () => {
+			expect(isRelayNativeAsset(registry, 'KSM')).toEqual(false);
+		});
+		it('Should return true when the relay chains asset location is given as input from the persepect of AssetHub', () => {
+			expect(isRelayNativeAsset(registry, '{"parents":"1","interior":{"Here":""}}')).toEqual(true);
+		});
+		it('Should return false when the relay chains asset location is given as input from the perspective of the relay chain', () => {
+			expect(isRelayNativeAsset(registry, '{"parents":"0","interior":{"Here":""}}')).toEqual(false);
+		});
 	});
 });

--- a/src/createXcmTypes/util/isRelayNativeAsset.ts
+++ b/src/createXcmTypes/util/isRelayNativeAsset.ts
@@ -1,12 +1,24 @@
-// Copyright 2023 Parity Technologies (UK) Ltd.
+// Copyright 2024 Parity Technologies (UK) Ltd.
 
-export const isRelayNativeAsset = (tokens: string[], assetId: string): boolean => {
+import { RELAY_CHAIN_IDS } from '../../consts';
+import { Registry } from '../../registry';
+
+export const isRelayNativeAsset = (registry: Registry, assetId: string): boolean => {
+	const relayChainId = RELAY_CHAIN_IDS[0];
+	const { tokens } = registry.currentRelayRegistry[relayChainId];
+	const originChainId = registry.lookupChainIdBySpecName(registry.specName);
+	const originIsRelayChain = originChainId === relayChainId;
+
 	// if assetId is an empty string treat it as the relay asset
 	if (assetId === '') {
 		return true;
 	}
 
-	if (assetId === `{"parents":"0","interior":{"Here":""}}` || assetId === `{"parents":"1","interior":{"Here":""}}`) {
+	if (originIsRelayChain && assetId === `{"parents":"0","interior":{"Here":""}}`) {
+		return true;
+	}
+
+	if (!originIsRelayChain && assetId === `{"parents":"1","interior":{"Here":""}}`) {
 		return true;
 	}
 

--- a/src/errors/checkBaseInputTypes.spec.ts
+++ b/src/errors/checkBaseInputTypes.spec.ts
@@ -1,61 +1,61 @@
 import { checkBaseInputTypes } from './checkBaseInputTypes';
 
 describe('checkBaseInputTypes', () => {
-    it('Should error when destChainId is the wrong type', () => {
-        const err = () =>
-            checkBaseInputTypes(
-                1000 as unknown as string,
-                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-                ['TST'],
-                ['10000000000'],
-            );
+	it('Should error when destChainId is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				1000 as unknown as string,
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				['TST'],
+				['10000000000'],
+			);
 
-        expect(err).toThrow(`'destChainId' must be a string. Received: number`);
-    });
-    it('Should error when destAddr is the wrong type', () => {
-        const err = () => checkBaseInputTypes('1000', 10000000 as unknown as string, ['TST'], ['10000000000']);
+		expect(err).toThrow(`'destChainId' must be a string. Received: number`);
+	});
+	it('Should error when destAddr is the wrong type', () => {
+		const err = () => checkBaseInputTypes('1000', 10000000 as unknown as string, ['TST'], ['10000000000']);
 
-        expect(err).toThrow(`'destAddr' must be a string. Received: number`);
-    });
-    it('Should error when assetIds is the wrong type', () => {
-        const err = () =>
-            checkBaseInputTypes(
-                '1000',
-                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-                'TST' as unknown as string[],
-                ['10000000000'],
-            );
+		expect(err).toThrow(`'destAddr' must be a string. Received: number`);
+	});
+	it('Should error when assetIds is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				'TST' as unknown as string[],
+				['10000000000'],
+			);
 
-        expect(err).toThrow(`'assetIds' must be an array. Received: string`);
-    });
-    it('Should error when assetIds has the wrong types in the array', () => {
-        const err = () =>
-            checkBaseInputTypes(
-                '1000',
-                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-                [1] as unknown as string[],
-                ['10000000000'],
-            );
+		expect(err).toThrow(`'assetIds' must be an array. Received: string`);
+	});
+	it('Should error when assetIds has the wrong types in the array', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				[1] as unknown as string[],
+				['10000000000'],
+			);
 
-        expect(err).toThrow(`All inputs in the 'assetIds' array must be strings: Received: a number at index 0`);
-    });
-    it('Should error when amounts is the wrong type', () => {
-        const err = () =>
-            checkBaseInputTypes(
-                '1000',
-                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-                ['TST'],
-                10000000000 as unknown as string[],
-            );
+		expect(err).toThrow(`All inputs in the 'assetIds' array must be strings: Received: a number at index 0`);
+	});
+	it('Should error when amounts is the wrong type', () => {
+		const err = () =>
+			checkBaseInputTypes(
+				'1000',
+				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+				['TST'],
+				10000000000 as unknown as string[],
+			);
 
-        expect(err).toThrow(`'amounts' must be an array. Received: number`);
-    });
-    it('Should error when amounts has the wrong types in the array', () => {
-        const err = () =>
-            checkBaseInputTypes('1000', '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b', ['TST'], [
-                10000000000,
-            ] as unknown as string[]);
+		expect(err).toThrow(`'amounts' must be an array. Received: number`);
+	});
+	it('Should error when amounts has the wrong types in the array', () => {
+		const err = () =>
+			checkBaseInputTypes('1000', '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b', ['TST'], [
+				10000000000,
+			] as unknown as string[]);
 
-        expect(err).toThrow(`All inputs in the 'amounts' array must be strings: Received: a number at index 0`);
-    });
+		expect(err).toThrow(`All inputs in the 'amounts' array must be strings: Received: a number at index 0`);
+	});
 });

--- a/src/errors/checkBaseInputTypes.spec.ts
+++ b/src/errors/checkBaseInputTypes.spec.ts
@@ -1,61 +1,61 @@
 import { checkBaseInputTypes } from './checkBaseInputTypes';
 
 describe('checkBaseInputTypes', () => {
-	it('Should error when destChainId is the wrong type', () => {
-		const err = () =>
-			checkBaseInputTypes(
-				1000 as unknown as string,
-				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-				['TST'],
-				['10000000000'],
-			);
+    it('Should error when destChainId is the wrong type', () => {
+        const err = () =>
+            checkBaseInputTypes(
+                1000 as unknown as string,
+                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+                ['TST'],
+                ['10000000000'],
+            );
 
-		expect(err).toThrow(`'destChainId' must be a string. Received: number`);
-	});
-	it('Should error when destAddr is the wrong type', () => {
-		const err = () => checkBaseInputTypes('1000', 10000000 as unknown as string, ['TST'], ['10000000000']);
+        expect(err).toThrow(`'destChainId' must be a string. Received: number`);
+    });
+    it('Should error when destAddr is the wrong type', () => {
+        const err = () => checkBaseInputTypes('1000', 10000000 as unknown as string, ['TST'], ['10000000000']);
 
-		expect(err).toThrow(`'destAddr' must be a string. Received: number`);
-	});
-	it('Should error when assetIds is the wrong type', () => {
-		const err = () =>
-			checkBaseInputTypes(
-				'1000',
-				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-				'TST' as unknown as string[],
-				['10000000000'],
-			);
+        expect(err).toThrow(`'destAddr' must be a string. Received: number`);
+    });
+    it('Should error when assetIds is the wrong type', () => {
+        const err = () =>
+            checkBaseInputTypes(
+                '1000',
+                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+                'TST' as unknown as string[],
+                ['10000000000'],
+            );
 
-		expect(err).toThrow(`'assetIds' must be a array. Received: string`);
-	});
-	it('Should error when assetIds has the wrong types in the array', () => {
-		const err = () =>
-			checkBaseInputTypes(
-				'1000',
-				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-				[1] as unknown as string[],
-				['10000000000'],
-			);
+        expect(err).toThrow(`'assetIds' must be an array. Received: string`);
+    });
+    it('Should error when assetIds has the wrong types in the array', () => {
+        const err = () =>
+            checkBaseInputTypes(
+                '1000',
+                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+                [1] as unknown as string[],
+                ['10000000000'],
+            );
 
-		expect(err).toThrow(`All inputs in the 'assetIds' array must be strings: Received: a number at index 0`);
-	});
-	it('Should error when amounts is the wrong type', () => {
-		const err = () =>
-			checkBaseInputTypes(
-				'1000',
-				'0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
-				['TST'],
-				10000000000 as unknown as string[],
-			);
+        expect(err).toThrow(`All inputs in the 'assetIds' array must be strings: Received: a number at index 0`);
+    });
+    it('Should error when amounts is the wrong type', () => {
+        const err = () =>
+            checkBaseInputTypes(
+                '1000',
+                '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
+                ['TST'],
+                10000000000 as unknown as string[],
+            );
 
-		expect(err).toThrow(`'amounts' must be a array. Received: number`);
-	});
-	it('Should error when amounts has the wrong types in the array', () => {
-		const err = () =>
-			checkBaseInputTypes('1000', '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b', ['TST'], [
-				10000000000,
-			] as unknown as string[]);
+        expect(err).toThrow(`'amounts' must be an array. Received: number`);
+    });
+    it('Should error when amounts has the wrong types in the array', () => {
+        const err = () =>
+            checkBaseInputTypes('1000', '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b', ['TST'], [
+                10000000000,
+            ] as unknown as string[]);
 
-		expect(err).toThrow(`All inputs in the 'amounts' array must be strings: Received: a number at index 0`);
-	});
+        expect(err).toThrow(`All inputs in the 'amounts' array must be strings: Received: a number at index 0`);
+    });
 });

--- a/src/errors/checkBaseInputTypes.ts
+++ b/src/errors/checkBaseInputTypes.ts
@@ -11,37 +11,37 @@ import { BaseError, BaseErrorsEnum } from './BaseError';
  * @param amounts
  */
 export const checkBaseInputTypes = (destChainId: string, destAddr: string, assetIds: string[], amounts: string[]) => {
-	if (typeof destChainId !== 'string') {
-		throw new BaseError(`'destChainId' must be a string. Received: ${typeof destChainId}`, BaseErrorsEnum.InvalidInput);
-	}
+    if (typeof destChainId !== 'string') {
+        throw new BaseError(`'destChainId' must be a string. Received: ${typeof destChainId}`, BaseErrorsEnum.InvalidInput);
+    }
 
-	if (typeof destAddr !== 'string') {
-		throw new BaseError(`'destAddr' must be a string. Received: ${typeof destAddr}`, BaseErrorsEnum.InvalidInput);
-	}
+    if (typeof destAddr !== 'string') {
+        throw new BaseError(`'destAddr' must be a string. Received: ${typeof destAddr}`, BaseErrorsEnum.InvalidInput);
+    }
 
-	if (!Array.isArray(assetIds)) {
-		throw new BaseError(`'assetIds' must be a array. Received: ${typeof assetIds}`, BaseErrorsEnum.InvalidInput);
-	} else {
-		for (let i = 0; i < assetIds.length; i++) {
-			if (typeof assetIds[i] !== 'string') {
-				throw new BaseError(
-					`All inputs in the 'assetIds' array must be strings: Received: a ${typeof assetIds[i]} at index ${i}`,
-					BaseErrorsEnum.InvalidInput,
-				);
-			}
-		}
-	}
+    if (!Array.isArray(assetIds)) {
+        throw new BaseError(`'assetIds' must be an array. Received: ${typeof assetIds}`, BaseErrorsEnum.InvalidInput);
+    } else {
+        for (let i = 0; i < assetIds.length; i++) {
+            if (typeof assetIds[i] !== 'string') {
+                throw new BaseError(
+                    `All inputs in the 'assetIds' array must be strings: Received: a ${typeof assetIds[i]} at index ${i}`,
+                    BaseErrorsEnum.InvalidInput,
+                );
+            }
+        }
+    }
 
-	if (!Array.isArray(amounts)) {
-		throw new BaseError(`'amounts' must be a array. Received: ${typeof amounts}`, BaseErrorsEnum.InvalidInput);
-	} else {
-		for (let i = 0; i < amounts.length; i++) {
-			if (typeof amounts[i] !== 'string') {
-				throw new BaseError(
-					`All inputs in the 'amounts' array must be strings: Received: a ${typeof amounts[i]} at index ${i}`,
-					BaseErrorsEnum.InvalidInput,
-				);
-			}
-		}
-	}
+    if (!Array.isArray(amounts)) {
+        throw new BaseError(`'amounts' must be an array. Received: ${typeof amounts}`, BaseErrorsEnum.InvalidInput);
+    } else {
+        for (let i = 0; i < amounts.length; i++) {
+            if (typeof amounts[i] !== 'string') {
+                throw new BaseError(
+                    `All inputs in the 'amounts' array must be strings: Received: a ${typeof amounts[i]} at index ${i}`,
+                    BaseErrorsEnum.InvalidInput,
+                );
+            }
+        }
+    }
 };

--- a/src/errors/checkBaseInputTypes.ts
+++ b/src/errors/checkBaseInputTypes.ts
@@ -11,37 +11,37 @@ import { BaseError, BaseErrorsEnum } from './BaseError';
  * @param amounts
  */
 export const checkBaseInputTypes = (destChainId: string, destAddr: string, assetIds: string[], amounts: string[]) => {
-    if (typeof destChainId !== 'string') {
-        throw new BaseError(`'destChainId' must be a string. Received: ${typeof destChainId}`, BaseErrorsEnum.InvalidInput);
-    }
+	if (typeof destChainId !== 'string') {
+		throw new BaseError(`'destChainId' must be a string. Received: ${typeof destChainId}`, BaseErrorsEnum.InvalidInput);
+	}
 
-    if (typeof destAddr !== 'string') {
-        throw new BaseError(`'destAddr' must be a string. Received: ${typeof destAddr}`, BaseErrorsEnum.InvalidInput);
-    }
+	if (typeof destAddr !== 'string') {
+		throw new BaseError(`'destAddr' must be a string. Received: ${typeof destAddr}`, BaseErrorsEnum.InvalidInput);
+	}
 
-    if (!Array.isArray(assetIds)) {
-        throw new BaseError(`'assetIds' must be an array. Received: ${typeof assetIds}`, BaseErrorsEnum.InvalidInput);
-    } else {
-        for (let i = 0; i < assetIds.length; i++) {
-            if (typeof assetIds[i] !== 'string') {
-                throw new BaseError(
-                    `All inputs in the 'assetIds' array must be strings: Received: a ${typeof assetIds[i]} at index ${i}`,
-                    BaseErrorsEnum.InvalidInput,
-                );
-            }
-        }
-    }
+	if (!Array.isArray(assetIds)) {
+		throw new BaseError(`'assetIds' must be an array. Received: ${typeof assetIds}`, BaseErrorsEnum.InvalidInput);
+	} else {
+		for (let i = 0; i < assetIds.length; i++) {
+			if (typeof assetIds[i] !== 'string') {
+				throw new BaseError(
+					`All inputs in the 'assetIds' array must be strings: Received: a ${typeof assetIds[i]} at index ${i}`,
+					BaseErrorsEnum.InvalidInput,
+				);
+			}
+		}
+	}
 
-    if (!Array.isArray(amounts)) {
-        throw new BaseError(`'amounts' must be an array. Received: ${typeof amounts}`, BaseErrorsEnum.InvalidInput);
-    } else {
-        for (let i = 0; i < amounts.length; i++) {
-            if (typeof amounts[i] !== 'string') {
-                throw new BaseError(
-                    `All inputs in the 'amounts' array must be strings: Received: a ${typeof amounts[i]} at index ${i}`,
-                    BaseErrorsEnum.InvalidInput,
-                );
-            }
-        }
-    }
+	if (!Array.isArray(amounts)) {
+		throw new BaseError(`'amounts' must be an array. Received: ${typeof amounts}`, BaseErrorsEnum.InvalidInput);
+	} else {
+		for (let i = 0; i < amounts.length; i++) {
+			if (typeof amounts[i] !== 'string') {
+				throw new BaseError(
+					`All inputs in the 'amounts' array must be strings: Received: a ${typeof amounts[i]} at index ${i}`,
+					BaseErrorsEnum.InvalidInput,
+				);
+			}
+		}
+	}
 };

--- a/src/errors/checkLocalTxInput/checkLocalRelayInput.spec.ts
+++ b/src/errors/checkLocalTxInput/checkLocalRelayInput.spec.ts
@@ -5,20 +5,22 @@ import { checkLocalRelayInput } from './checkLocalRelayInput';
 import { LocalTxType } from './types';
 
 describe('checkLocalRelayInput', () => {
-    const registry = new Registry('statemine', { chainName: 'rococo' });
+	const registry = new Registry('statemine', { chainName: 'rococo' });
 
-    it('Should return LocalTxType.Balances', () => {
-        const res = checkLocalRelayInput([], ['10000'], registry);
-        expect(res).toEqual(LocalTxType.Balances);
-    });
-    it('Should error with an invalid input', () => {
-        expect(() => checkLocalRelayInput(['roc', 'ksm'], ['100000'], registry)).toThrow(
-            'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
-        );
-    });
-    it('Should correctly error when a non native asset is passed in', () => {
-        expect(() => checkLocalRelayInput(['{"parents":"3","interior":{"X1":{"GlobalConsensus":"Westend"}}}'], ['100000'], registry)).toThrow(
-            'AssetId {"parents":"3","interior":{"X1":{"GlobalConsensus":"Westend"}}} is not the native asset of rococo relay chain. Expected an assetId of ROC or asset location {"parents":"0","interior":{"Here":""}}',
-        );
-    })
+	it('Should return LocalTxType.Balances', () => {
+		const res = checkLocalRelayInput([], ['10000'], registry);
+		expect(res).toEqual(LocalTxType.Balances);
+	});
+	it('Should error with an invalid input', () => {
+		expect(() => checkLocalRelayInput(['roc', 'ksm'], ['100000'], registry)).toThrow(
+			'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
+		);
+	});
+	it('Should correctly error when a non native asset is passed in', () => {
+		expect(() =>
+			checkLocalRelayInput(['{"parents":"3","interior":{"X1":{"GlobalConsensus":"Westend"}}}'], ['100000'], registry),
+		).toThrow(
+			'AssetId {"parents":"3","interior":{"X1":{"GlobalConsensus":"Westend"}}} is not the native asset of rococo relay chain. Expected an assetId of ROC or asset location {"parents":"0","interior":{"Here":""}}',
+		);
+	});
 });

--- a/src/errors/checkLocalTxInput/checkLocalRelayInput.spec.ts
+++ b/src/errors/checkLocalTxInput/checkLocalRelayInput.spec.ts
@@ -1,16 +1,24 @@
-// Copyright 2023 Parity Technologies (UK) Ltd.
+// Copyright 2024 Parity Technologies (UK) Ltd.
 
+import { Registry } from '../../registry';
 import { checkLocalRelayInput } from './checkLocalRelayInput';
 import { LocalTxType } from './types';
 
 describe('checkLocalRelayInput', () => {
-	it('Should return LocalTxType.Balances', () => {
-		const res = checkLocalRelayInput([], ['10000']);
-		expect(res).toEqual(LocalTxType.Balances);
-	});
-	it('Should error with an invalid input', () => {
-		expect(() => checkLocalRelayInput(['dot', 'ksm'], ['100000'])).toThrow(
-			'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
-		);
-	});
+    const registry = new Registry('statemine', { chainName: 'rococo' });
+
+    it('Should return LocalTxType.Balances', () => {
+        const res = checkLocalRelayInput([], ['10000'], registry);
+        expect(res).toEqual(LocalTxType.Balances);
+    });
+    it('Should error with an invalid input', () => {
+        expect(() => checkLocalRelayInput(['roc', 'ksm'], ['100000'], registry)).toThrow(
+            'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
+        );
+    });
+    it('Should correctly error when a non native asset is passed in', () => {
+        expect(() => checkLocalRelayInput(['{"parents":"3","interior":{"X1":{"GlobalConsensus":"Westend"}}}'], ['100000'], registry)).toThrow(
+            'AssetId {"parents":"3","interior":{"X1":{"GlobalConsensus":"Westend"}}} is not the native asset of rococo relay chain. Expected an assetId of ROC or asset location {"parents":"0","interior":{"Here":""}}',
+        );
+    })
 });

--- a/src/errors/checkLocalTxInput/checkLocalRelayInput.ts
+++ b/src/errors/checkLocalTxInput/checkLocalRelayInput.ts
@@ -1,15 +1,29 @@
-// Copyright 2023 Parity Technologies (UK) Ltd.
 
+// Copyright 2024 Parity Technologies (UK) Ltd.
+
+import { RELAY_CHAINS_NATIVE_ASSET_LOCATION, RELAY_CHAIN_IDS } from '../../consts';
+import { isRelayNativeAsset } from '../../createXcmTypes/util/isRelayNativeAsset';
+import { Registry } from '../../registry';
 import { BaseError, BaseErrorsEnum } from '../BaseError';
 import { LocalTxType } from './types';
 
-export const checkLocalRelayInput = (assetIds: string[], amounts: string[]): LocalTxType => {
-	if (assetIds.length > 1 || amounts.length !== 1) {
-		throw new BaseError(
-			'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+export const checkLocalRelayInput = (assetIds: string[], amounts: string[], registry: Registry): LocalTxType => {
+    if (assetIds.length > 1 || amounts.length !== 1) {
+        throw new BaseError(
+            'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
+    const relayChainId = RELAY_CHAIN_IDS[0];
+    const relayChain = registry.currentRelayRegistry[relayChainId];
+    const relayChainNativeAsset = relayChain.tokens[0];
 
-	return LocalTxType.Balances;
+    const assetIsRelayNativeAsset = assetIds.length === 0 ? true: isRelayNativeAsset(registry, assetIds[0]);
+    if (!assetIsRelayNativeAsset) {
+        throw new BaseError(
+        `AssetId ${assetIds[0]} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
+        )
+    }
+
+    return LocalTxType.Balances;
 };

--- a/src/errors/checkLocalTxInput/checkLocalRelayInput.ts
+++ b/src/errors/checkLocalTxInput/checkLocalRelayInput.ts
@@ -1,29 +1,28 @@
-
 // Copyright 2024 Parity Technologies (UK) Ltd.
 
-import { RELAY_CHAINS_NATIVE_ASSET_LOCATION, RELAY_CHAIN_IDS } from '../../consts';
+import { RELAY_CHAIN_IDS, RELAY_CHAINS_NATIVE_ASSET_LOCATION } from '../../consts';
 import { isRelayNativeAsset } from '../../createXcmTypes/util/isRelayNativeAsset';
 import { Registry } from '../../registry';
 import { BaseError, BaseErrorsEnum } from '../BaseError';
 import { LocalTxType } from './types';
 
 export const checkLocalRelayInput = (assetIds: string[], amounts: string[], registry: Registry): LocalTxType => {
-    if (assetIds.length > 1 || amounts.length !== 1) {
-        throw new BaseError(
-            'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
-    const relayChainId = RELAY_CHAIN_IDS[0];
-    const relayChain = registry.currentRelayRegistry[relayChainId];
-    const relayChainNativeAsset = relayChain.tokens[0];
+	if (assetIds.length > 1 || amounts.length !== 1) {
+		throw new BaseError(
+			'Local transactions must have the `assetIds` input be a length of 1 or 0, and the `amounts` input be a length of 1',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
+	const relayChainId = RELAY_CHAIN_IDS[0];
+	const relayChain = registry.currentRelayRegistry[relayChainId];
+	const relayChainNativeAsset = relayChain.tokens[0];
 
-    const assetIsRelayNativeAsset = assetIds.length === 0 ? true: isRelayNativeAsset(registry, assetIds[0]);
-    if (!assetIsRelayNativeAsset) {
-        throw new BaseError(
-        `AssetId ${assetIds[0]} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
-        )
-    }
+	const assetIsRelayNativeAsset = assetIds.length === 0 ? true : isRelayNativeAsset(registry, assetIds[0]);
+	if (!assetIsRelayNativeAsset) {
+		throw new BaseError(
+			`AssetId ${assetIds[0]} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
+		);
+	}
 
-    return LocalTxType.Balances;
+	return LocalTxType.Balances;
 };

--- a/src/errors/checkLocalTxInput/checkLocalTxInput.spec.ts
+++ b/src/errors/checkLocalTxInput/checkLocalTxInput.spec.ts
@@ -44,7 +44,7 @@ describe('checkLocalTxInput', () => {
 	it('Should correctly throw an error with an incorrect assetId', async () => {
 		await expect(async () => {
 			await checkLocalTxInput(systemAssetsApi.api, ['TST'], ['10000'], specName, registry, 2, false, false);
-		}).rejects.toThrow('assetId TST is not a valid symbol or integer asset id for statemine');
+		}).rejects.toThrow('assetId TST is not a valid symbol, integer asset id or location for statemine');
 	});
 	it("Should correctly throw an error when the integer assetId doesn't exist", async () => {
 		await expect(async () => {

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -3,1066 +3,1067 @@
 import { AssetTransferApi } from '../AssetTransferApi';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
 import { Registry } from '../registry';
-import { adjustedMockMoonriverParachainApi } from '../testHelpers/adjustedMockMoonriverParachainApi';
-import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApiV1004000';
-import { mockSystemApi } from '../testHelpers/mockSystemApi';
+import { adjustedMockMoonriverParachainApiV2302 } from '../testHelpers/adjustedMockMoonriverParachainApiV2302';
+import { adjustedMockWestendAssetHubApiV1004000 } from '../testHelpers/adjustedMockWestendAssetHubApiV1004000';
+import { mockWestendAssetHubApiV1004000 } from '../testHelpers/mockWestendAssetHubApiV1004000';
 import { Direction } from '../types';
 import {
-	checkAssetIdInput,
-	checkAssetIdsAreOfSameAssetIdType,
-	checkAssetIdsHaveNoDuplicates,
-	checkAssetIdsLengthIsValid,
-	checkAssetsAmountMatch,
-	checkBridgeTxInputs,
-	checkIfNativeRelayChainAssetPresentInMultiAssetIdList,
-	checkLiquidTokenTransferDirectionValidity,
-	checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain,
-	checkParaAssets,
-	checkParaPrimaryAssetAmountsLength,
-	checkParaPrimaryAssetAssetIdsLength,
-	checkPaysWithFeeDestAssetIdIsInAssets,
-	checkRelayAmountsLength,
-	checkRelayAssetIdLength,
-	checkXcmVersionIsValidForBridgeTx,
-	checkXcmVersionIsValidForPaysWithFeeDest,
-	CheckXTokensPalletOriginIsNonForeignAssetTx,
+    checkAssetIdInput,
+    checkAssetIdsAreOfSameAssetIdType,
+    checkAssetIdsHaveNoDuplicates,
+    checkAssetIdsLengthIsValid,
+    checkAssetsAmountMatch,
+    checkIfNativeRelayChainAssetPresentInMultiAssetIdList,
+    checkLiquidTokenTransferDirectionValidity,
+    checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain,
+    checkParaAssets,
+    checkParaPrimaryAssetAmountsLength,
+    checkParaPrimaryAssetAssetIdsLength,
+    checkPaysWithFeeDestAssetIdIsInAssets,
+    checkRelayAmountsLength,
+    checkRelayAssetIdLength,
+    checkSystemToBridgeInputs,
+    checkXcmVersionIsValidForPaysWithFeeDest,
+    checkXcmVersionIsValidForSystemToBridge,
+    CheckXTokensPalletOriginIsNonForeignAssetTx,
 } from './checkXcmTxInputs';
 
-const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, {
-	registryType: 'NPM',
+const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApiV2302, 'moonriver', 2, {
+    registryType: 'NPM',
 });
 const runTests = async (tests: Test[]) => {
-	for (const test of tests) {
-		const [specName, testInputs, direction, errorMessage] = test;
-		const registry = new Registry(specName, {});
-		const currentRegistry = registry.currentRelayRegistry;
+    for (const test of tests) {
+        const [specName, testInputs, direction, errorMessage] = test;
+        const registry = new Registry(specName, {});
+        const currentRegistry = registry.currentRelayRegistry;
 
-		await expect(async () => {
-			await checkAssetIdInput(
-				parachainAssetsApi.api,
-				testInputs,
-				currentRegistry,
-				specName,
-				direction,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).rejects.toThrow(errorMessage);
-	}
+        await expect(async () => {
+            await checkAssetIdInput(
+                parachainAssetsApi.api,
+                testInputs,
+                currentRegistry,
+                specName,
+                direction,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).rejects.toThrow(errorMessage);
+    }
 };
 
 describe('checkRelayAssetIdLength', () => {
-	it('Should error with an incorrect assetId length for inputs to or from relay chains', () => {
-		const err = () => checkRelayAssetIdLength(['dot', 'usdt']);
+    it('Should error with an incorrect assetId length for inputs to or from relay chains', () => {
+        const err = () => checkRelayAssetIdLength(['dot', 'usdt']);
 
-		expect(err).toThrow("`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.");
-	});
+        expect(err).toThrow("`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.");
+    });
 });
 
 describe('checkRelayAmountsLength', () => {
-	it('Should error with an incorrect amounts length', () => {
-		const err = () => checkRelayAmountsLength(['1000000000', '10000000000']);
-		expect(err).toThrow('`amounts` should be of length 1 when sending to or from a relay chain');
-	});
+    it('Should error with an incorrect amounts length', () => {
+        const err = () => checkRelayAmountsLength(['1000000000', '10000000000']);
+        expect(err).toThrow('`amounts` should be of length 1 when sending to or from a relay chain');
+    });
 });
 
 describe('checkAssetsAmountMatch', () => {
-	it("Should error when inputted assetId's dont match amounts length", () => {
-		const err = () => checkAssetsAmountMatch(['1'], ['10', '10']);
+    it("Should error when inputted assetId's dont match amounts length", () => {
+        const err = () => checkAssetsAmountMatch(['1'], ['10', '10']);
 
-		expect(err).toThrow(
-			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
-		);
-	});
+        expect(err).toThrow(
+            '`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
+        );
+    });
 });
 
 describe('checkParaPrimaryAssetAssetIdsLength', () => {
-	it('Should error with an incorrect assetId length when sending a primary parachain native asset', () => {
-		const err = () => checkParaPrimaryAssetAssetIdsLength(['movr', 'usdt']);
+    it('Should error with an incorrect assetId length when sending a primary parachain native asset', () => {
+        const err = () => checkParaPrimaryAssetAssetIdsLength(['movr', 'usdt']);
 
-		expect(err).toThrow('`assetIds` should be of length 1 when sending a primary native parachain asset');
-	});
+        expect(err).toThrow('`assetIds` should be of length 1 when sending a primary native parachain asset');
+    });
 });
 
 describe('checkParaPrimaryAssetAmountsLength', () => {
-	it('Should error with an incorrect amounts length when sending a primary parachain native asset', () => {
-		const err = () => checkParaPrimaryAssetAmountsLength(['1000000', '200000']);
+    it('Should error with an incorrect amounts length when sending a primary parachain native asset', () => {
+        const err = () => checkParaPrimaryAssetAmountsLength(['1000000', '200000']);
 
-		expect(err).toThrow('`amounts` should be of length 1 when sending a primary native parachain asset');
-	});
+        expect(err).toThrow('`amounts` should be of length 1 when sending a primary native parachain asset');
+    });
 });
 
 type Test = [specName: string, inputs: string[], xcmDirection: Direction, errorMessage: string];
 
 describe('checkAssetIds', () => {
-	it('Should error when an assetId is found that is a blank space', async () => {
-		const tests: Test[] = [['Statemine', [' ', 'KSM'], Direction.SystemToRelay, `assetId cannot be blank spaces.`]];
+    it('Should error when an assetId is found that is a blank space', async () => {
+        const tests: Test[] = [['Statemine', [' ', 'KSM'], Direction.SystemToRelay, `assetId cannot be blank spaces.`]];
 
-		await runTests(tests);
-	});
+        await runTests(tests);
+    });
 
-	it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', async () => {
-		const tests: Test[] = [
-			[
-				'Polkadot',
-				['1', 'DOT'],
-				Direction.RelayToSystem,
-				`(RelayToSystem) asset 1 is not polkadot's native asset. Expected DOT`,
-			],
-			[
-				'Kusama',
-				['DOT', 'KSM'],
-				Direction.RelayToSystem,
-				`(RelayToSystem) asset DOT is not kusama's native asset. Expected KSM`,
-			],
-			[
-				'Westend',
-				['WND', '100000'],
-				Direction.RelayToSystem,
-				`(RelayToSystem) asset 100000 is not westend's native asset. Expected WND`,
-			],
-		];
+    it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', async () => {
+        const tests: Test[] = [
+            [
+                'Polkadot',
+                ['1', 'DOT'],
+                Direction.RelayToSystem,
+                `(RelayToSystem) assetId 1 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"0","interior":{"Here":""}}`,
+            ],
+            [
+                'Kusama',
+                ['DOT', 'KSM'],
+                Direction.RelayToSystem,
+                `(RelayToSystem) assetId DOT is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"0","interior":{"Here":""}}`,
+            ],
+            [
+                'Westend',
+                ['WND', '100000'],
+                Direction.RelayToSystem,
+                `(RelayToSystem) assetId 100000 is not the native asset of westend relay chain. Expected an assetId of WND or asset location {"parents":"0","interior":{"Here":""}}`,
+            ],
+        ];
 
-		await runTests(tests);
-	});
+        await runTests(tests);
+    });
 
-	it('Should error when direction is RelayToPara and assetId does not match relay chains native token', async () => {
-		const tests: Test[] = [
-			[
-				'Polkadot',
-				['1', 'DOT'],
-				Direction.RelayToPara,
-				`(RelayToPara) asset 1 is not polkadot's native asset. Expected DOT`,
-			],
-			[
-				'Kusama',
-				['DOT', 'KSM'],
-				Direction.RelayToPara,
-				`(RelayToPara) asset DOT is not kusama's native asset. Expected KSM`,
-			],
-		];
+    it('Should error when direction is RelayToPara and assetId does not match relay chains native token', async () => {
+        const tests: Test[] = [
+            [
+                'Polkadot',
+                ['1', 'DOT'],
+                Direction.RelayToPara,
+                `(RelayToPara) assetId 1 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"0","interior":{"Here":""}}`,
+            ],
+            [
+                'Kusama',
+                ['DOT', 'KSM'],
+                Direction.RelayToPara,
+                `(RelayToPara) assetId DOT is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"0","interior":{"Here":""}}`,
+            ],
+        ];
 
-		await runTests(tests);
-	});
+        await runTests(tests);
+    });
 
-	it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', async () => {
-		const tests: Test[] = [
-			['Statemint', ['0'], Direction.SystemToRelay, `(SystemToRelay) assetId 0 not native to polkadot`],
-			['Statemine', ['MOVR', 'KSM'], Direction.SystemToRelay, `(SystemToRelay) assetId MOVR not native to kusama`],
-			['Westmint', ['WND', '250'], Direction.SystemToRelay, `(SystemToRelay) assetId 250 not native to westend`],
-		];
+    it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', async () => {
+        const tests: Test[] = [
+            ['Statemint', ['0'], Direction.SystemToRelay, `(SystemToRelay) assetId 0 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"1","interior":{"Here":""}}`],
+            ['Statemine', ['MOVR', 'KSM'], Direction.SystemToRelay, `(SystemToRelay) assetId MOVR is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"1","interior":{"Here":""}}`],
+            ['Westmint', ['WND', '250'], Direction.SystemToRelay, `(SystemToRelay) assetId 250 is not the native asset of westend relay chain. Expected an assetId of WND or asset location {"parents":"1","interior":{"Here":""}}`],
+        ];
 
-		await runTests(tests);
-	});
+        await runTests(tests);
+    });
 
-	it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', async () => {
-		const tests: Test[] = [
-			[
-				'Statemine',
-				['KSM', '8', 'stateMineDoge'],
-				Direction.SystemToPara,
-				`(SystemToPara) assetId stateMineDoge not found for system parachain Statemine`,
-			],
-		];
+    it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', async () => {
+        const tests: Test[] = [
+            [
+                'Statemine',
+                ['KSM', '8', 'stateMineDoge'],
+                Direction.SystemToPara,
+                `(SystemToPara) assetId stateMineDoge not found for system parachain Statemine`,
+            ],
+        ];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
 
-			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
+            await expect(async () => {
+                await checkAssetIdInput(
+                    mockWestendAssetHubApiV1004000,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
 
-	it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', async () => {
-		const tests: Test[] = [
-			[
-				'Statemint',
-				['1337', 'xcDOT'],
-				Direction.SystemToPara,
-				`(SystemToPara) assetId xcDOT not found for system parachain Statemint`,
-			],
-			[
-				'Statemine',
-				['KSM', 'xcMOVR'],
-				Direction.SystemToPara,
-				`(SystemToPara) assetId xcMOVR not found for system parachain Statemine`,
-			],
-			[
-				'Westmint',
-				['WND', 'Test Westend'],
-				Direction.SystemToPara,
-				`(SystemToPara) assetId Test Westend not found for system parachain Westmint`,
-			],
-		];
+    it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', async () => {
+        const tests: Test[] = [
+            [
+                'Statemint',
+                ['1337', 'xcDOT'],
+                Direction.SystemToPara,
+                `(SystemToPara) assetId xcDOT not found for system parachain Statemint`,
+            ],
+            [
+                'Statemine',
+                ['KSM', 'xcMOVR'],
+                Direction.SystemToPara,
+                `(SystemToPara) assetId xcMOVR not found for system parachain Statemine`,
+            ],
+            [
+                'Westmint',
+                ['WND', 'Test Westend'],
+                Direction.SystemToPara,
+                `(SystemToPara) assetId Test Westend not found for system parachain Westmint`,
+            ],
+        ];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
 
-			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
+            await expect(async () => {
+                await checkAssetIdInput(
+                    mockWestendAssetHubApiV1004000,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
 
-	it('Should error when an asset id is provided that matches multiple asset symbols in the assets registry', async () => {
-		const tests: Test[] = [['Statemine', ['USDT'], Direction.SystemToPara, `Multiple assets found with symbol USDT`]];
+    it('Should error when an asset id is provided that matches multiple asset symbols in the assets registry', async () => {
+        const tests: Test[] = [['Statemine', ['USDT'], Direction.SystemToPara, `Multiple assets found with symbol USDT`]];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
 
-			await expect(async () => {
-				await checkAssetIdInput(
-					parachainAssetsApi.api,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
+            await expect(async () => {
+                await checkAssetIdInput(
+                    parachainAssetsApi.api,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
 
-	it('Should error when direction is SystemToSystem and the string assetId is not found in the system parachains tokens or assets', async () => {
-		const tests: Test[] = [
-			[
-				'Statemint',
-				['1337', 'xcDOT'],
-				Direction.SystemToSystem,
-				`(SystemToSystem) assetId xcDOT not found for system parachain Statemint`,
-			],
-			[
-				'Statemine',
-				['KSM', 'xcMOVR'],
-				Direction.SystemToSystem,
-				`(SystemToSystem) assetId xcMOVR not found for system parachain Statemine`,
-			],
-			[
-				'Westmint',
-				['WND', 'Test Westend'],
-				Direction.SystemToSystem,
-				`(SystemToSystem) assetId Test Westend not found for system parachain Westmint`,
-			],
-		];
+    it('Should error when direction is SystemToSystem and the string assetId is not found in the system parachains tokens or assets', async () => {
+        const tests: Test[] = [
+            [
+                'Statemint',
+                ['1337', 'xcDOT'],
+                Direction.SystemToSystem,
+                `(SystemToSystem) assetId xcDOT not found for system parachain Statemint`,
+            ],
+            [
+                'Statemine',
+                ['KSM', 'xcMOVR'],
+                Direction.SystemToSystem,
+                `(SystemToSystem) assetId xcMOVR not found for system parachain Statemine`,
+            ],
+            [
+                'Westmint',
+                ['WND', 'Test Westend'],
+                Direction.SystemToSystem,
+                `(SystemToSystem) assetId Test Westend not found for system parachain Westmint`,
+            ],
+        ];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
 
-			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
-	it('Should error when direction is SystemToPara and the multilocation assetId is not found in the system parachains foreignAssets or chain state', async () => {
-		const tests: Test[] = [
-			[
-				'Statemine',
-				['{"parents":"2","interior":{"X1": {"Parachain":"2125000"}}}'],
-				Direction.SystemToPara,
-				`(SystemToPara) assetId {"parents":"2","interior":{"X1": {"Parachain":"2125000"}}} not found for system parachain Statemine`,
-			],
-		];
+            await expect(async () => {
+                await checkAssetIdInput(
+                    mockWestendAssetHubApiV1004000,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
+    it('Should error when direction is SystemToPara and the multilocation assetId is not found in the system parachains foreignAssets or chain state', async () => {
+        const tests: Test[] = [
+            [
+                'Statemine',
+                ['{"parents":"2","interior":{"X1": {"Parachain":"2125000"}}}'],
+                Direction.SystemToPara,
+                `(SystemToPara) assetId {"parents":"2","interior":{"X1": {"Parachain":"2125000"}}} not found for system parachain Statemine`,
+            ],
+        ];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
 
-			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
-	it('Should correctly error when direction is ParaToSystem and the provided integer assetId is not found in the system parachains assetIds', async () => {
-		const tests: Test[] = [
-			[
-				'moonriver',
-				['311091173110107856861649819128533077277', '200'],
-				Direction.ParaToSystem,
-				`(ParaToSystem) integer assetId 200 not found in moonriver`,
-			],
-		];
+            await expect(async () => {
+                await checkAssetIdInput(
+                    mockWestendAssetHubApiV1004000,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
+    it('Should correctly error when direction is ParaToSystem and the provided integer assetId is not found in the system parachains assetIds', async () => {
+        const tests: Test[] = [
+            [
+                'moonriver',
+                ['311091173110107856861649819128533077277', '200'],
+                Direction.ParaToSystem,
+                `(ParaToSystem) integer assetId 200 not found in moonriver`,
+            ],
+        ];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
-			await expect(async () => {
-				await checkAssetIdInput(
-					parachainAssetsApi.api,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
-	it('Should correctly error when direction is ParaToSystem and the string assetId has no match in the parachains asset symbols', async () => {
-		const tests: Test[] = [
-			[
-				'moonriver',
-				['xcKSMFake', 'USDT'],
-				Direction.ParaToSystem,
-				`(ParaToSystem) symbol assetId xcKSMFake not found for parachain moonriver`,
-			],
-			[
-				'moonriver',
-				['xcUSDT', 'ASTR'],
-				Direction.ParaToSystem,
-				`(ParaToSystem) symbol assetId ASTR not found for parachain moonriver`,
-			],
-		];
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
+            await expect(async () => {
+                await checkAssetIdInput(
+                    parachainAssetsApi.api,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
+    it('Should correctly error when direction is ParaToSystem and the string assetId has no match in the parachains asset symbols', async () => {
+        const tests: Test[] = [
+            [
+                'moonriver',
+                ['xcKSMFake', 'USDT'],
+                Direction.ParaToSystem,
+                `(ParaToSystem) symbol assetId xcKSMFake not found for parachain moonriver`,
+            ],
+            [
+                'moonriver',
+                ['xcUSDT', 'ASTR'],
+                Direction.ParaToSystem,
+                `(ParaToSystem) symbol assetId ASTR not found for parachain moonriver`,
+            ],
+        ];
 
-		for (const test of tests) {
-			const [specName, testInputs, direction, errorMessage] = test;
-			const registry = new Registry(specName, {});
-			const currentRegistry = registry.currentRelayRegistry;
+        for (const test of tests) {
+            const [specName, testInputs, direction, errorMessage] = test;
+            const registry = new Registry(specName, {});
+            const currentRegistry = registry.currentRelayRegistry;
 
-			await expect(async () => {
-				await checkAssetIdInput(
-					parachainAssetsApi.api,
-					testInputs,
-					currentRegistry,
-					specName,
-					direction,
-					registry,
-					2,
-					false,
-					false,
-				);
-			}).rejects.toThrow(errorMessage);
-		}
-	});
-	it('Should error for an invalid erc20 token.', async () => {
-		const registry = new Registry('moonriver', {});
-		const currentRegistry = registry.currentRelayRegistry;
+            await expect(async () => {
+                await checkAssetIdInput(
+                    parachainAssetsApi.api,
+                    testInputs,
+                    currentRegistry,
+                    specName,
+                    direction,
+                    registry,
+                    2,
+                    false,
+                    false,
+                );
+            }).rejects.toThrow(errorMessage);
+        }
+    });
+    it('Should error for an invalid erc20 token.', async () => {
+        const registry = new Registry('moonriver', {});
+        const currentRegistry = registry.currentRelayRegistry;
 
-		await expect(async () => {
-			await checkAssetIdInput(
-				parachainAssetsApi.api,
-				['0x1234'],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToSystem,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).rejects.toThrow('(ParaToSystem) assetId 0x1234, is not a valid erc20 token.');
-	});
-	it('Should error when an invalid token is passed into a liquidTokenTransfer', async () => {
-		const registry = new Registry('westmint', {});
-		const currentRegistry = registry.currentRelayRegistry;
-		const isLiquidTokenTransfer = true;
+        await expect(async () => {
+            await checkAssetIdInput(
+                parachainAssetsApi.api,
+                ['0x1234'],
+                currentRegistry,
+                'moonriver',
+                Direction.ParaToSystem,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).rejects.toThrow('(ParaToSystem) assetId 0x1234, is not a valid erc20 token.');
+    });
+    it('Should error when an invalid token is passed into a liquidTokenTransfer', async () => {
+        const registry = new Registry('westmint', {});
+        const currentRegistry = registry.currentRelayRegistry;
+        const isLiquidTokenTransfer = true;
 
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['TEST'],
-				currentRegistry,
-				'westmint',
-				Direction.SystemToPara,
-				registry,
-				2,
-				false,
-				isLiquidTokenTransfer,
-			);
-		}).rejects.toThrow('Liquid Tokens must be valid Integers');
-	});
-	it('Should error when a token does not exist in the registry or node', async () => {
-		const registry = new Registry('westmint', {});
-		const currentRegistry = registry.currentRelayRegistry;
-		const isLiquidTokenTransfer = true;
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockWestendAssetHubApiV1004000,
+                ['TEST'],
+                currentRegistry,
+                'westmint',
+                Direction.SystemToPara,
+                registry,
+                2,
+                false,
+                isLiquidTokenTransfer,
+            );
+        }).rejects.toThrow('Liquid Tokens must be valid Integers');
+    });
+    it('Should error when a token does not exist in the registry or node', async () => {
+        const registry = new Registry('westmint', {});
+        const currentRegistry = registry.currentRelayRegistry;
+        const isLiquidTokenTransfer = true;
 
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['999111'],
-				currentRegistry,
-				'westmint',
-				Direction.SystemToPara,
-				registry,
-				2,
-				false,
-				isLiquidTokenTransfer,
-			);
-		}).rejects.toThrow(
-			'No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.',
-		);
-	});
-	it('Should not error when a valid liquid token exists', async () => {
-		const registry = new Registry('westmint', {});
-		const currentRegistry = registry.currentRelayRegistry;
-		const isLiquidTokenTransfer = true;
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockWestendAssetHubApiV1004000,
+                ['999111'],
+                currentRegistry,
+                'westmint',
+                Direction.SystemToPara,
+                registry,
+                2,
+                false,
+                isLiquidTokenTransfer,
+            );
+        }).rejects.toThrow(
+            'No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.',
+        );
+    });
+    it('Should not error when a valid liquid token exists', async () => {
+        const registry = new Registry('westmint', {});
+        const currentRegistry = registry.currentRelayRegistry;
+        const isLiquidTokenTransfer = true;
 
-		// eslint-disable-next-line @typescript-eslint/await-thenable
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['0'],
-				currentRegistry,
-				'westmint',
-				Direction.SystemToPara,
-				registry,
-				2,
-				false,
-				isLiquidTokenTransfer,
-			);
-		}).not.toThrow();
-	});
-	it('Should not throw an error for ParaToRelay when its a valid', async () => {
-		const registry = new Registry('moonriver', {});
-		const currentRegistry = registry.currentRelayRegistry;
-		// eslint-disable-next-line @typescript-eslint/await-thenable
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['KSM'],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).not.toThrow();
-		// eslint-disable-next-line @typescript-eslint/await-thenable
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['42259045809535163221576417993425387648'],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).not.toThrow();
-		// eslint-disable-next-line @typescript-eslint/await-thenable
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				[''],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).not.toThrow();
-		// eslint-disable-next-line @typescript-eslint/await-thenable
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				[],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).not.toThrow();
-	});
-	it('Should error when an invalid assetId is inputted for ParaToRelay', async () => {
-		const registry = new Registry('karura', {});
-		const currentRegistry = registry.currentRelayRegistry;
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockWestendAssetHubApiV1004000,
+                ['0'],
+                currentRegistry,
+                'westmint',
+                Direction.SystemToPara,
+                registry,
+                2,
+                false,
+                isLiquidTokenTransfer,
+            );
+        }).not.toThrow();
+    });
+    it('Should not throw an error for ParaToRelay when its a valid', async () => {
+        const registry = new Registry('moonriver', {});
+        const currentRegistry = registry.currentRelayRegistry;
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockMoonriverParachainApiV2302,
+                ['KSM'],
+                currentRegistry,
+                'moonriver',
+                Direction.ParaToRelay,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).not.toThrow();
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockMoonriverParachainApiV2302,
+                ['42259045809535163221576417993425387648'],
+                currentRegistry,
+                'moonriver',
+                Direction.ParaToRelay,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).not.toThrow();
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockMoonriverParachainApiV2302,
+                [''],
+                currentRegistry,
+                'moonriver',
+                Direction.ParaToRelay,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).not.toThrow();
+        // eslint-disable-next-line @typescript-eslint/await-thenable
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockMoonriverParachainApiV2302,
+                [],
+                currentRegistry,
+                'moonriver',
+                Direction.ParaToRelay,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).not.toThrow();
+    });
+    it('Should error when an invalid assetId is inputted for ParaToRelay', async () => {
+        const registry = new Registry('karura', {});
+        const currentRegistry = registry.currentRelayRegistry;
 
-		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['TEST'],
-				currentRegistry,
-				'crust-collator',
-				Direction.ParaToRelay,
-				registry,
-				2,
-				false,
-				false,
-			);
-		}).rejects.toThrow("The current input for assetId's does not meet our specifications for ParaToRelay transfers.");
-	});
+        await expect(async () => {
+            await checkAssetIdInput(
+                adjustedMockMoonriverParachainApiV2302,
+                ['TEST'],
+                currentRegistry,
+                'crust-collator',
+                Direction.ParaToRelay,
+                registry,
+                2,
+                false,
+                false,
+            );
+        }).rejects.toThrow("The current input for assetId's does not meet our specifications for ParaToRelay transfers.");
+    });
 });
 
 describe('checkIfNativeRelayChainAssetPresentInMultiAssetIdList', () => {
-	it('Should error when the relay native asset and system assets are in the same assetIds list when direction is SystemToSystem', () => {
-		const expectErrorMessage =
-			'Found the relay chains native asset in list [ksm,usdc]. `assetIds` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.';
-		const assetIds = ['ksm', 'usdc'];
-		const specName = 'statemine';
-		const registry = new Registry(specName, {});
+    it('Should error when the relay native asset and system assets are in the same assetIds list when direction is SystemToSystem', () => {
+        const expectErrorMessage =
+            'Found the relay chains native asset in list [ksm,usdc]. `assetIds` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.';
+        const assetIds = ['ksm', 'usdc'];
+        const specName = 'statemine';
+        const registry = new Registry(specName, {});
 
-		const err = () => checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
-		expect(err).toThrow(expectErrorMessage);
-	});
+        const err = () => checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
+        expect(err).toThrow(expectErrorMessage);
+    });
 });
 
 describe('checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain', () => {
-	it('Should correctly error when isForeignAssetsTransfer and both non native and foreign multilocations are in assetIds for direction SystemToPara', () => {
-		const expectedErrorMessage =
-			'(SystemToPara) found both foreign and native multilocations in {"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}},{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}. multilocation XCMs must only include either native or foreign assets of the destination chain.';
-		const xcmDirection = Direction.SystemToPara;
-		const destChainId = '2023';
-		const multiLocationAssetIds = [
-			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
-			'{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
-		];
+    it('Should correctly error when isForeignAssetsTransfer and both non native and foreign multilocations are in assetIds for direction SystemToPara', () => {
+        const expectedErrorMessage =
+            '(SystemToPara) found both foreign and native multilocations in {"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}},{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}. multilocation XCMs must only include either native or foreign assets of the destination chain.';
+        const xcmDirection = Direction.SystemToPara;
+        const destChainId = '2023';
+        const multiLocationAssetIds = [
+            '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
+            '{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
+        ];
 
-		const err = () =>
-			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
+        const err = () =>
+            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
 
-		expect(err).toThrow(expectedErrorMessage);
-	});
+        expect(err).toThrow(expectedErrorMessage);
+    });
 
-	it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only native multilocations are in assetIds for direction SystemToPara', () => {
-		const xcmDirection = Direction.SystemToPara;
-		const destChainId = '2125';
-		const multiLocationAssetIds = [
-			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
-			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "1"}]}}',
-		];
+    it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only native multilocations are in assetIds for direction SystemToPara', () => {
+        const xcmDirection = Direction.SystemToPara;
+        const destChainId = '2125';
+        const multiLocationAssetIds = [
+            '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
+            '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "1"}]}}',
+        ];
 
-		const err = () =>
-			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
+        const err = () =>
+            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
 
-		expect(err).not.toThrow();
-	});
+        expect(err).not.toThrow();
+    });
 
-	it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only foreign multilocations are in assetIds for direction SystemToPara', () => {
-		const xcmDirection = Direction.SystemToPara;
-		const destChainId = '2125';
-		const multiLocationAssetIds = [
-			'{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
-			'{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "1"}]}}',
-		];
+    it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only foreign multilocations are in assetIds for direction SystemToPara', () => {
+        const xcmDirection = Direction.SystemToPara;
+        const destChainId = '2125';
+        const multiLocationAssetIds = [
+            '{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
+            '{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "1"}]}}',
+        ];
 
-		const err = () =>
-			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
+        const err = () =>
+            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
 
-		expect(err).not.toThrow();
-	});
+        expect(err).not.toThrow();
+    });
 });
 
 describe('checkAssetIdsLengthIsValid', () => {
-	it('Should correctly error when more than 2 assetIds are passed in', () => {
-		const assetIds = ['ksm', '1984', '10'];
-		const assetTransferType = 'RemoteReserve';
-		const xcmPallet = XcmPalletName.polkadotXcm;
+    it('Should correctly error when more than 2 assetIds are passed in', () => {
+        const assetIds = ['ksm', '1984', '10'];
+        const assetTransferType = 'RemoteReserve';
+        const xcmPallet = XcmPalletName.polkadotXcm;
 
-		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-		expect(err).toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
-	});
-	it('Should correctly not error when 2 or fewer assetIds are passed in and assetTransferType is defined', () => {
-		const assetIds = ['ksm', '1984'];
-		const assetTransferType = 'RemoteReserve';
-		const xcmPallet = XcmPalletName.polkadotXcm;
+        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+        expect(err).toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
+    });
+    it('Should correctly not error when 2 or fewer assetIds are passed in and assetTransferType is defined', () => {
+        const assetIds = ['ksm', '1984'];
+        const assetTransferType = 'RemoteReserve';
+        const xcmPallet = XcmPalletName.polkadotXcm;
 
-		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-		expect(err).not.toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
-	});
-	it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `xcmPallet` call', () => {
-		const assetIds = [
-			`{"parents":"1","interior":{"Here":""}}`,
-			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
-		];
-		const assetTransferType = undefined;
-		const xcmPallet = XcmPalletName.xcmPallet;
+        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+        expect(err).not.toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
+    });
+    it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `xcmPallet` call', () => {
+        const assetIds = [
+            `{"parents":"1","interior":{"Here":""}}`,
+            `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
+        ];
+        const assetTransferType = undefined;
+        const xcmPallet = XcmPalletName.xcmPallet;
 
-		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-		expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
-	});
-	it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `polkadotXcm` call', () => {
-		const assetIds = [
-			`{"parents":"1","interior":{"Here":""}}`,
-			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
-		];
-		const assetTransferType = undefined;
-		const xcmPallet = XcmPalletName.polkadotXcm;
+        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+        expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
+    });
+    it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `polkadotXcm` call', () => {
+        const assetIds = [
+            `{"parents":"1","interior":{"Here":""}}`,
+            `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
+        ];
+        const assetTransferType = undefined;
+        const xcmPallet = XcmPalletName.polkadotXcm;
 
-		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-		expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
-	});
-	it('Should correctly not throw an error when provided more than 1 asset id for a `transferAssetsUsingTypeAndThen` call', () => {
-		const assetIds = [
-			`{"parents":"1","interior":{"Here":""}}`,
-			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
-		];
-		const assetTransferType = 'RemoteReserve';
-		const xcmPallet = XcmPalletName.polkadotXcm;
+        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+        expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
+    });
+    it('Should correctly not throw an error when provided more than 1 asset id for a `transferAssetsUsingTypeAndThen` call', () => {
+        const assetIds = [
+            `{"parents":"1","interior":{"Here":""}}`,
+            `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
+        ];
+        const assetTransferType = 'RemoteReserve';
+        const xcmPallet = XcmPalletName.polkadotXcm;
 
-		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-		expect(err).not.toThrow();
-	});
+        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+        expect(err).not.toThrow();
+    });
 });
 
 describe('checkAssetIdsHaveNoDuplicates', () => {
-	it('Should correctly error if duplicate empty string relay assetIds are found', () => {
-		const assetIds = ['', ''];
+    it('Should correctly error if duplicate empty string relay assetIds are found', () => {
+        const assetIds = ['', ''];
 
-		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-		expect(err).toThrow('AssetIds must be unique. Found duplicate native relay assets as empty strings');
-	});
-	it('Should correctly error if duplicate integer assetIds are found', () => {
-		const assetIds = ['10', '10'];
+        expect(err).toThrow('AssetIds must be unique. Found duplicate native relay assets as empty strings');
+    });
+    it('Should correctly error if duplicate integer assetIds are found', () => {
+        const assetIds = ['10', '10'];
 
-		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-		expect(err).toThrow('AssetIds must be unique. Found duplicate assetId 10');
-	});
-	it('Should correctly error if duplicate integer assetIds are found', () => {
-		const assetIds = ['usdt', 'USDT'];
+        expect(err).toThrow('AssetIds must be unique. Found duplicate assetId 10');
+    });
+    it('Should correctly error if duplicate integer assetIds are found', () => {
+        const assetIds = ['usdt', 'USDT'];
 
-		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-		expect(err).toThrow('AssetIds must be unique. Found duplicate assetId USDT');
-	});
-	it('Should correctly error if duplicate multilocation assetIds are found', () => {
-		const assetIds = [
-			'{"parents": "1","interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
-			'{"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
-		];
+        expect(err).toThrow('AssetIds must be unique. Found duplicate assetId USDT');
+    });
+    it('Should correctly error if duplicate multilocation assetIds are found', () => {
+        const assetIds = [
+            '{"parents": "1","interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
+            '{"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
+        ];
 
-		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-		expect(err).toThrow(
-			`AssetIds must be unique. Found duplicate assetId {"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}`,
-		);
-	});
+        expect(err).toThrow(
+            `AssetIds must be unique. Found duplicate assetId {"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}`,
+        );
+    });
 });
 
 describe('checkAssetIdsAreOfSameAssetIdType', () => {
-	it('Should correctly error when an integer assetId and multilocation assetId are passed in together', () => {
-		const assetIds = ['1984', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
+    it('Should correctly error when an integer assetId and multilocation assetId are passed in together', () => {
+        const assetIds = ['1984', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+        const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-		expect(err).toThrow(
-			`Found both native asset with assetID 1984 and foreign asset with assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Native assets and foreign assets can't be transferred within the same call.`,
-		);
-	});
+        expect(err).toThrow(
+            `Found both native asset with assetID 1984 and foreign asset with assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Native assets and foreign assets can't be transferred within the same call.`,
+        );
+    });
 
-	it('Should correctly error when a symbol assetId and multilocation assetId are passed in together', () => {
-		const assetIds = ['ksm', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
+    it('Should correctly error when a symbol assetId and multilocation assetId are passed in together', () => {
+        const assetIds = ['ksm', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+        const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-		expect(err).toThrow(
-			'Found both symbol ksm and multilocation assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Asset Ids must be symbol and integer or multilocation exclusively.',
-		);
-	});
+        expect(err).toThrow(
+            'Found both symbol ksm and multilocation assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Asset Ids must be symbol and integer or multilocation exclusively.',
+        );
+    });
 
-	it('Should correctly error when the default relay asset value and multilocation assetId are passed in together', () => {
-		const assetIds = ['', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
+    it('Should correctly error when the default relay asset value and multilocation assetId are passed in together', () => {
+        const assetIds = ['', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+        const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-		expect(err).toThrow(
-			`Found both default relay native asset and foreign asset with assetId: {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Relay native asset and foreign assets can't be transferred within the same call.`,
-		);
-	});
+        expect(err).toThrow(
+            `Found both default relay native asset and foreign asset with assetId: {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Relay native asset and foreign assets can't be transferred within the same call.`,
+        );
+    });
 });
 
 describe('checkXcmVersionIsValidForPaysWithFeeDest', () => {
-	it('Should correctly throw an error if paysWithFeeDest is provided and xcmVersion is less than 3', () => {
-		const xcmVersion = 2;
-		const paysWithFeeDest = '1984';
+    it('Should correctly throw an error if paysWithFeeDest is provided and xcmVersion is less than 3', () => {
+        const xcmVersion = 2;
+        const paysWithFeeDest = '1984';
 
-		const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
+        const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
 
-		expect(err).toThrow('paysWithFeeDest requires XCM version 3 or greater');
-	});
-	it('Should correctly not throw an error if paysWithFeeDest is provided and xcmVersion is at least 3', () => {
-		const xcmVersion = 3;
-		const paysWithFeeDest = '1984';
+        expect(err).toThrow('paysWithFeeDest requires XCM version 3 or greater');
+    });
+    it('Should correctly not throw an error if paysWithFeeDest is provided and xcmVersion is at least 3', () => {
+        const xcmVersion = 3;
+        const paysWithFeeDest = '1984';
 
-		const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
+        const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
 
-		expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
-	});
+        expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
+    });
 
-	it('Should correctly not throw an error if xcmDirection is ParaToSystem or ParaToPara', () => {
-		const xcmVersion = 3;
-		const paysWithFeeDest = '1984';
+    it('Should correctly not throw an error if xcmDirection is ParaToSystem or ParaToPara', () => {
+        const xcmVersion = 3;
+        const paysWithFeeDest = '1984';
 
-		const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.ParaToSystem, xcmVersion, paysWithFeeDest);
+        const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.ParaToSystem, xcmVersion, paysWithFeeDest);
 
-		expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
-	});
+        expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
+    });
 });
 
 describe('CheckXTokensPalletOriginIsNonForeignAssetTx', () => {
-	it('Should correctly throw an error when xcm pallet is xTokens and isForeignAssetsTransfer is true', () => {
-		type Test = [isForeignAssetTransfer: boolean, xcmPallet: XcmPalletName, xcmDirection: Direction];
+    it('Should correctly throw an error when xcm pallet is xTokens and isForeignAssetsTransfer is true', () => {
+        type Test = [isForeignAssetTransfer: boolean, xcmPallet: XcmPalletName, xcmDirection: Direction];
 
-		const tests: Test[] = [
-			[true, XcmPalletName.xTokens, Direction.ParaToSystem],
-			[true, XcmPalletName.xTokens, Direction.ParaToPara],
-		];
+        const tests: Test[] = [
+            [true, XcmPalletName.xTokens, Direction.ParaToSystem],
+            [true, XcmPalletName.xTokens, Direction.ParaToPara],
+        ];
 
-		for (const test of tests) {
-			const [isForeignAssetsTransfer, xcmPallet, xcmDirection] = test;
+        for (const test of tests) {
+            const [isForeignAssetsTransfer, xcmPallet, xcmDirection] = test;
 
-			const err = () => {
-				CheckXTokensPalletOriginIsNonForeignAssetTx(xcmDirection, xcmPallet, isForeignAssetsTransfer);
-			};
+            const err = () => {
+                CheckXTokensPalletOriginIsNonForeignAssetTx(xcmDirection, xcmPallet, isForeignAssetsTransfer);
+            };
 
-			expect(err).toThrow(`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`);
-		}
-	});
+            expect(err).toThrow(`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`);
+        }
+    });
 });
 
 describe('checkLiquidTokenTransferDirectionValidity', () => {
-	it('Should correctly throw an error when inputs dont match the specification', () => {
-		const err = () => checkLiquidTokenTransferDirectionValidity(Direction.ParaToSystem, true);
+    it('Should correctly throw an error when inputs dont match the specification', () => {
+        const err = () => checkLiquidTokenTransferDirectionValidity(Direction.ParaToSystem, true);
 
-		expect(err).toThrow('isLiquidTokenTransfer may not be true for the xcmDirection: ParaToSystem.');
-	});
+        expect(err).toThrow('isLiquidTokenTransfer may not be true for the xcmDirection: ParaToSystem.');
+    });
 });
 
-describe('checkXcmVersionIsValidForBridgeTx', () => {
-	it('Should correctly throw an error when the xcm version is less than 3 for SystemToBridge direction', () => {
-		const xcmVersion = 2;
-		const err = () => checkXcmVersionIsValidForBridgeTx(xcmVersion);
+describe('checkXcmVersionIsValidForSystemToBridge', () => {
+    it('Should correctly throw an error when the xcm version is less than 3 for SystemToBridge direction', () => {
+        const xcmVersion = 2;
+        const err = () => checkXcmVersionIsValidForSystemToBridge(xcmVersion);
 
-		expect(err).toThrow('Bridge transactions require XCM version 3 or greater');
-	});
+        expect(err).toThrow('SystemToBridge transactions require XCM version 3 or greater');
+    });
 });
 
-describe('checkBridgeTxInputs', () => {
-	it('Should correctly error when no paysWithFeeDest value is provided but assetTransferType is', () => {
-		const paysWithFeeDest = undefined;
-		const assetTransferType = 'RemoteReserve';
-		const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-		const feesTransferType = 'RemoteReserve';
-		const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+describe('checkSystemToBridgeInputs', () => {
+    it('Should correctly error when no paysWithFeeDest value is provided but assetTransferType is', () => {
+        const paysWithFeeDest = undefined;
+        const assetTransferType = 'RemoteReserve';
+        const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+        const feesTransferType = 'RemoteReserve';
+        const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
 
-		const err = () =>
-			checkBridgeTxInputs(
-				paysWithFeeDest,
-				assetTransferType,
-				remoteReserveAssetTransferTypeLocation,
-				feesTransferType,
-				remoteReserveFeesTransferTypeLocation,
-			);
+        const err = () =>
+            checkSystemToBridgeInputs(
+                paysWithFeeDest,
+                assetTransferType,
+                remoteReserveAssetTransferTypeLocation,
+                feesTransferType,
+                remoteReserveFeesTransferTypeLocation,
+            );
 
-		expect(err).toThrow('paysWithFeeDest input is required for bridge transactions when assetTransferType is provided');
-	});
-	it('Should correctly throw an error when assetTransferType is RemoteReserve and no remoteReserveAssetTransferTypeLocation value is provided', () => {
-		const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-		const assetTransferType = 'RemoteReserve';
-		const remoteReserveAssetTransferTypeLocation = undefined;
-		const feesTransferType = 'RemoteReserve';
-		const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+        expect(err).toThrow('paysWithFeeDest input is required for bridge transactions when assetTransferType is provided');
+    });
+    it('Should correctly throw an error when assetTransferType is RemoteReserve and no remoteReserveAssetTransferTypeLocation value is provided', () => {
+        const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+        const assetTransferType = 'RemoteReserve';
+        const remoteReserveAssetTransferTypeLocation = undefined;
+        const feesTransferType = 'RemoteReserve';
+        const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
 
-		const err = () =>
-			checkBridgeTxInputs(
-				paysWithFeeDest,
-				assetTransferType,
-				remoteReserveAssetTransferTypeLocation,
-				feesTransferType,
-				remoteReserveFeesTransferTypeLocation,
-			);
+        const err = () =>
+            checkSystemToBridgeInputs(
+                paysWithFeeDest,
+                assetTransferType,
+                remoteReserveAssetTransferTypeLocation,
+                feesTransferType,
+                remoteReserveFeesTransferTypeLocation,
+            );
 
-		expect(err).toThrow(
-			'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
-		);
-	});
-	it('Should correctly throw an error when feesTransferType is RemoteReserve and no remoteReserveFeesTransferTypeLocation value is provided', () => {
-		const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-		const assetTransferType = 'RemoteReserve';
-		const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-		const feesTransferType = 'RemoteReserve';
-		const remoteReserveFeesTransferTypeLocation = undefined;
+        expect(err).toThrow(
+            'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
+        );
+    });
+    it('Should correctly throw an error when feesTransferType is RemoteReserve and no remoteReserveFeesTransferTypeLocation value is provided', () => {
+        const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+        const assetTransferType = 'RemoteReserve';
+        const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+        const feesTransferType = 'RemoteReserve';
+        const remoteReserveFeesTransferTypeLocation = undefined;
 
-		const err = () =>
-			checkBridgeTxInputs(
-				paysWithFeeDest,
-				assetTransferType,
-				remoteReserveAssetTransferTypeLocation,
-				feesTransferType,
-				remoteReserveFeesTransferTypeLocation,
-			);
+        const err = () =>
+            checkSystemToBridgeInputs(
+                paysWithFeeDest,
+                assetTransferType,
+                remoteReserveAssetTransferTypeLocation,
+                feesTransferType,
+                remoteReserveFeesTransferTypeLocation,
+            );
 
-		expect(err).toThrow(
-			'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
-		);
-	});
+        expect(err).toThrow(
+            'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
+        );
+    });
 });
+
 describe('checkPaysWithFeeDestAssetIdIsInAssets', () => {
-	it('Should correctly error when a paysWithFeeDestAsset is not found in the assetIds list', () => {
-		const assetIds = [`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}`];
-		const paysWithFeeDest = `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`;
+    it('Should correctly error when a paysWithFeeDestAsset is not found in the assetIds list', () => {
+        const assetIds = [`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}`];
+        const paysWithFeeDest = `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`;
 
-		const err = () => checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
+        const err = () => checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
 
-		expect(err).toThrow(
-			'paysWithFeeDest asset must be present in assets to be transferred. Did not find {"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}} in {"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}',
-		);
-	});
+        expect(err).toThrow(
+            'paysWithFeeDest asset must be present in assets to be transferred. Did not find {"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}} in {"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}',
+        );
+    });
 });
 
 describe('checkParaAssets', () => {
-	it('Should correctly resolve when a valid symbol assetId is provided', async () => {
-		const assetId = 'xcUSDt';
-		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
-		let didNotError = true;
+    it('Should correctly resolve when a valid symbol assetId is provided', async () => {
+        const assetId = 'xcUSDt';
+        const specName = 'moonriver';
+        const registry = new Registry(specName, {});
+        let didNotError = true;
 
-		try {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
-		} catch (err) {
-			didNotError = false;
-		}
+        try {
+            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
+        } catch (err) {
+            didNotError = false;
+        }
 
-		expect(didNotError).toBeTruthy();
-	});
-	it('Should correctly resolve when a valid integer assetId is provided', async () => {
-		const assetId = '311091173110107856861649819128533077277';
-		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
-		let didNotError = true;
+        expect(didNotError).toBeTruthy();
+    });
+    it('Should correctly resolve when a valid integer assetId is provided', async () => {
+        const assetId = '311091173110107856861649819128533077277';
+        const specName = 'moonriver';
+        const registry = new Registry(specName, {});
+        let didNotError = true;
 
-		try {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
-		} catch (err) {
-			didNotError = false;
-		}
+        try {
+            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
+        } catch (err) {
+            didNotError = false;
+        }
 
-		expect(didNotError).toBeTruthy();
-	});
-	it('Should correctly error when an invalid symbol assetId is provided', async () => {
-		const assetId = 'xcUSDfake';
-		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+        expect(didNotError).toBeTruthy();
+    });
+    it('Should correctly error when an invalid symbol assetId is provided', async () => {
+        const assetId = 'xcUSDfake';
+        const specName = 'moonriver';
+        const registry = new Registry(specName, {});
 
-		await expect(async () => {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
-		}).rejects.toThrow('(ParaToSystem) symbol assetId xcUSDfake not found for parachain moonriver');
-	});
-	it('Should correctly error when an invalid integer assetId is provided', async () => {
-		const assetId = '2096586909097964981698161';
-		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+        await expect(async () => {
+            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
+        }).rejects.toThrow('(ParaToSystem) symbol assetId xcUSDfake not found for parachain moonriver');
+    });
+    it('Should correctly error when an invalid integer assetId is provided', async () => {
+        const assetId = '2096586909097964981698161';
+        const specName = 'moonriver';
+        const registry = new Registry(specName, {});
 
-		await expect(async () => {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
-		}).rejects.toThrow('(ParaToSystem) integer assetId 2096586909097964981698161 not found in moonriver');
-	});
-	it('Should correctly error when a valid assetId is not found in the xcAsset registry', async () => {
-		const assetId = '999999999999999999999999999999999999999';
-		const specName = 'moonriver';
-		const registry = new Registry(specName, {});
+        await expect(async () => {
+            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
+        }).rejects.toThrow('(ParaToSystem) integer assetId 2096586909097964981698161 not found in moonriver');
+    });
+    it('Should correctly error when a valid assetId is not found in the xcAsset registry', async () => {
+        const assetId = '999999999999999999999999999999999999999';
+        const specName = 'moonriver';
+        const registry = new Registry(specName, {});
 
-		await expect(async () => {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
-		}).rejects.toThrow('unable to identify xcAsset with ID 999999999999999999999999999999999999999');
-	});
+        await expect(async () => {
+            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
+        }).rejects.toThrow('unable to identify xcAsset with ID 999999999999999999999999999999999999999');
+    });
 
-	describe('cache', () => {
-		it('Should correctly cache an asset that is not found in the registry after being queried for origin System', async () => {
-			const registry = new Registry('statemine', {});
-			const chainInfo = {
-				'1000': {
-					assetsInfo: {},
-					poolPairsInfo: {},
-					specName: '',
-					tokens: [],
-					foreignAssetsInfo: {},
-				},
-			};
+    describe('cache', () => {
+        it('Should correctly cache an asset that is not found in the registry after being queried for origin System', async () => {
+            const registry = new Registry('statemine', {});
+            const chainInfo = {
+                '1000': {
+                    assetsInfo: {},
+                    poolPairsInfo: {},
+                    specName: '',
+                    tokens: [],
+                    foreignAssetsInfo: {},
+                },
+            };
 
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['1984'],
-				chainInfo,
-				'statemine',
-				Direction.SystemToPara,
-				registry,
-				2,
-				false,
-				false,
-			);
+            await checkAssetIdInput(
+                adjustedMockWestendAssetHubApiV1004000,
+                ['1984'],
+                chainInfo,
+                'statemine',
+                Direction.SystemToPara,
+                registry,
+                2,
+                false,
+                false,
+            );
 
-			expect(registry.cacheLookupAsset('1984')).toEqual('USDt');
-		});
-		it('Should correctly cache an asset that is not found in the registry after being queried for origin Para', async () => {
-			const registry = new Registry('moonriver', {});
-			const chainInfo = {
-				'2023': {
-					assetsInfo: {},
-					poolPairsInfo: {},
-					specName: '',
-					tokens: [],
-					foreignAssetsInfo: {},
-				},
-			};
+            expect(registry.cacheLookupAsset('1984')).toEqual('USDt');
+        });
+        it('Should correctly cache an asset that is not found in the registry after being queried for origin Para', async () => {
+            const registry = new Registry('moonriver', {});
+            const chainInfo = {
+                '2023': {
+                    assetsInfo: {},
+                    poolPairsInfo: {},
+                    specName: '',
+                    tokens: [],
+                    foreignAssetsInfo: {},
+                },
+            };
 
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['xcUSDT'],
-				chainInfo,
-				'moonriver',
-				Direction.ParaToSystem,
-				registry,
-				2,
-				false,
-				false,
-			);
+            await checkAssetIdInput(
+                adjustedMockMoonriverParachainApiV2302,
+                ['xcUSDT'],
+                chainInfo,
+                'moonriver',
+                Direction.ParaToSystem,
+                registry,
+                2,
+                false,
+                false,
+            );
 
-			expect(registry.cacheLookupAsset('xcUSDT')).toEqual('311091173110107856861649819128533077277');
-		});
+            expect(registry.cacheLookupAsset('xcUSDT')).toEqual('311091173110107856861649819128533077277');
+        });
 
-		it('Should correctly cache a foreign asset that is not found in the registry after being queried', async () => {
-			const registry = new Registry('statemine', {
-				injectedRegistry: {
-					kusama: {
-						'1000': {
-							assetsInfo: {},
-							poolPairsInfo: {},
-							specName: '',
-							tokens: [],
-							foreignAssetsInfo: {},
-						},
-					},
-				},
-			});
-			const chainInfo = {
-				'1000': {
-					assetsInfo: {},
-					poolPairsInfo: {},
-					specName: '',
-					tokens: [],
-					foreignAssetsInfo: {},
-				},
-			};
+        it('Should correctly cache a foreign asset that is not found in the registry after being queried', async () => {
+            const registry = new Registry('statemine', {
+                injectedRegistry: {
+                    kusama: {
+                        '1000': {
+                            assetsInfo: {},
+                            poolPairsInfo: {},
+                            specName: '',
+                            tokens: [],
+                            foreignAssetsInfo: {},
+                        },
+                    },
+                },
+            });
+            const chainInfo = {
+                '1000': {
+                    assetsInfo: {},
+                    poolPairsInfo: {},
+                    specName: '',
+                    tokens: [],
+                    foreignAssetsInfo: {},
+                },
+            };
 
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}'],
-				chainInfo,
-				'statemine',
-				Direction.SystemToPara,
-				registry,
-				2,
-				true,
-				false,
-			);
+            await checkAssetIdInput(
+                adjustedMockWestendAssetHubApiV1004000,
+                ['{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}'],
+                chainInfo,
+                'statemine',
+                Direction.SystemToPara,
+                registry,
+                2,
+                true,
+                false,
+            );
 
-			expect(registry.cacheLookupForeignAsset('GDZ')).toEqual({
-				multiLocation: '{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}',
-				name: 'Godzilla',
-				symbol: 'GDZ',
-			});
-		});
+            expect(registry.cacheLookupForeignAsset('GDZ')).toEqual({
+                multiLocation: '{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}',
+                name: 'Godzilla',
+                symbol: 'GDZ',
+            });
+        });
 
-		it('Should correctly cache a liquid asset that is not found in the registry after being queried', async () => {
-			const registry = new Registry('statemine', {
-				injectedRegistry: {
-					kusama: {
-						'1000': {
-							assetsInfo: {},
-							poolPairsInfo: {},
-							specName: '',
-							tokens: [],
-							foreignAssetsInfo: {},
-						},
-					},
-				},
-			});
-			const chainInfo = {
-				'1000': {
-					assetsInfo: {},
-					poolPairsInfo: {},
-					specName: '',
-					tokens: [],
-					foreignAssetsInfo: {},
-				},
-			};
+        it('Should correctly cache a liquid asset that is not found in the registry after being queried', async () => {
+            const registry = new Registry('statemine', {
+                injectedRegistry: {
+                    kusama: {
+                        '1000': {
+                            assetsInfo: {},
+                            poolPairsInfo: {},
+                            specName: '',
+                            tokens: [],
+                            foreignAssetsInfo: {},
+                        },
+                    },
+                },
+            });
+            const chainInfo = {
+                '1000': {
+                    assetsInfo: {},
+                    poolPairsInfo: {},
+                    specName: '',
+                    tokens: [],
+                    foreignAssetsInfo: {},
+                },
+            };
 
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['0'],
-				chainInfo,
-				'statemine',
-				Direction.SystemToPara,
-				registry,
-				2,
-				false,
-				true,
-			);
+            await checkAssetIdInput(
+                adjustedMockWestendAssetHubApiV1004000,
+                ['0'],
+                chainInfo,
+                'statemine',
+                Direction.SystemToPara,
+                registry,
+                2,
+                false,
+                true,
+            );
 
-			expect(registry.cacheLookupPoolAsset('0')).toEqual({
-				lpToken: '0',
-				pairInfo:
-					'[{"parents":"0","interior":{"Here":""}},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"100"}]}}]',
-			});
-		});
-	});
+            expect(registry.cacheLookupPoolAsset('0')).toEqual({
+                lpToken: '0',
+                pairInfo:
+                    '[{"parents":"0","interior":{"Here":""}},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"100"}]}}]',
+            });
+        });
+    });
 });

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -3,1067 +3,1082 @@
 import { AssetTransferApi } from '../AssetTransferApi';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
 import { Registry } from '../registry';
-import { adjustedMockMoonriverParachainApiV2302 } from '../testHelpers/adjustedMockMoonriverParachainApiV2302';
-import { adjustedMockWestendAssetHubApiV1004000 } from '../testHelpers/adjustedMockWestendAssetHubApiV1004000';
-import { mockWestendAssetHubApiV1004000 } from '../testHelpers/mockWestendAssetHubApiV1004000';
+import { adjustedMockMoonriverParachainApi } from '../testHelpers/adjustedMockMoonriverParachainApi';
+import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApiV1004000';
+import { mockSystemApi } from '../testHelpers/mockSystemApi';
 import { Direction } from '../types';
 import {
-    checkAssetIdInput,
-    checkAssetIdsAreOfSameAssetIdType,
-    checkAssetIdsHaveNoDuplicates,
-    checkAssetIdsLengthIsValid,
-    checkAssetsAmountMatch,
-    checkIfNativeRelayChainAssetPresentInMultiAssetIdList,
-    checkLiquidTokenTransferDirectionValidity,
-    checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain,
-    checkParaAssets,
-    checkParaPrimaryAssetAmountsLength,
-    checkParaPrimaryAssetAssetIdsLength,
-    checkPaysWithFeeDestAssetIdIsInAssets,
-    checkRelayAmountsLength,
-    checkRelayAssetIdLength,
-    checkSystemToBridgeInputs,
-    checkXcmVersionIsValidForPaysWithFeeDest,
-    checkXcmVersionIsValidForSystemToBridge,
-    CheckXTokensPalletOriginIsNonForeignAssetTx,
+	checkAssetIdInput,
+	checkAssetIdsAreOfSameAssetIdType,
+	checkAssetIdsHaveNoDuplicates,
+	checkAssetIdsLengthIsValid,
+	checkAssetsAmountMatch,
+	checkBridgeTxInputs,
+	checkIfNativeRelayChainAssetPresentInMultiAssetIdList,
+	checkLiquidTokenTransferDirectionValidity,
+	checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain,
+	checkParaAssets,
+	checkParaPrimaryAssetAmountsLength,
+	checkParaPrimaryAssetAssetIdsLength,
+	checkPaysWithFeeDestAssetIdIsInAssets,
+	checkRelayAmountsLength,
+	checkRelayAssetIdLength,
+	checkXcmVersionIsValidForBridgeTx,
+	checkXcmVersionIsValidForPaysWithFeeDest,
+	CheckXTokensPalletOriginIsNonForeignAssetTx,
 } from './checkXcmTxInputs';
 
-const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApiV2302, 'moonriver', 2, {
-    registryType: 'NPM',
+const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, {
+	registryType: 'NPM',
 });
 const runTests = async (tests: Test[]) => {
-    for (const test of tests) {
-        const [specName, testInputs, direction, errorMessage] = test;
-        const registry = new Registry(specName, {});
-        const currentRegistry = registry.currentRelayRegistry;
+	for (const test of tests) {
+		const [specName, testInputs, direction, errorMessage] = test;
+		const registry = new Registry(specName, {});
+		const currentRegistry = registry.currentRelayRegistry;
 
-        await expect(async () => {
-            await checkAssetIdInput(
-                parachainAssetsApi.api,
-                testInputs,
-                currentRegistry,
-                specName,
-                direction,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).rejects.toThrow(errorMessage);
-    }
+		await expect(async () => {
+			await checkAssetIdInput(
+				parachainAssetsApi.api,
+				testInputs,
+				currentRegistry,
+				specName,
+				direction,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).rejects.toThrow(errorMessage);
+	}
 };
 
 describe('checkRelayAssetIdLength', () => {
-    it('Should error with an incorrect assetId length for inputs to or from relay chains', () => {
-        const err = () => checkRelayAssetIdLength(['dot', 'usdt']);
+	it('Should error with an incorrect assetId length for inputs to or from relay chains', () => {
+		const err = () => checkRelayAssetIdLength(['dot', 'usdt']);
 
-        expect(err).toThrow("`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.");
-    });
+		expect(err).toThrow("`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.");
+	});
 });
 
 describe('checkRelayAmountsLength', () => {
-    it('Should error with an incorrect amounts length', () => {
-        const err = () => checkRelayAmountsLength(['1000000000', '10000000000']);
-        expect(err).toThrow('`amounts` should be of length 1 when sending to or from a relay chain');
-    });
+	it('Should error with an incorrect amounts length', () => {
+		const err = () => checkRelayAmountsLength(['1000000000', '10000000000']);
+		expect(err).toThrow('`amounts` should be of length 1 when sending to or from a relay chain');
+	});
 });
 
 describe('checkAssetsAmountMatch', () => {
-    it("Should error when inputted assetId's dont match amounts length", () => {
-        const err = () => checkAssetsAmountMatch(['1'], ['10', '10']);
+	it("Should error when inputted assetId's dont match amounts length", () => {
+		const err = () => checkAssetsAmountMatch(['1'], ['10', '10']);
 
-        expect(err).toThrow(
-            '`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
-        );
-    });
+		expect(err).toThrow(
+			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
+		);
+	});
 });
 
 describe('checkParaPrimaryAssetAssetIdsLength', () => {
-    it('Should error with an incorrect assetId length when sending a primary parachain native asset', () => {
-        const err = () => checkParaPrimaryAssetAssetIdsLength(['movr', 'usdt']);
+	it('Should error with an incorrect assetId length when sending a primary parachain native asset', () => {
+		const err = () => checkParaPrimaryAssetAssetIdsLength(['movr', 'usdt']);
 
-        expect(err).toThrow('`assetIds` should be of length 1 when sending a primary native parachain asset');
-    });
+		expect(err).toThrow('`assetIds` should be of length 1 when sending a primary native parachain asset');
+	});
 });
 
 describe('checkParaPrimaryAssetAmountsLength', () => {
-    it('Should error with an incorrect amounts length when sending a primary parachain native asset', () => {
-        const err = () => checkParaPrimaryAssetAmountsLength(['1000000', '200000']);
+	it('Should error with an incorrect amounts length when sending a primary parachain native asset', () => {
+		const err = () => checkParaPrimaryAssetAmountsLength(['1000000', '200000']);
 
-        expect(err).toThrow('`amounts` should be of length 1 when sending a primary native parachain asset');
-    });
+		expect(err).toThrow('`amounts` should be of length 1 when sending a primary native parachain asset');
+	});
 });
 
 type Test = [specName: string, inputs: string[], xcmDirection: Direction, errorMessage: string];
 
 describe('checkAssetIds', () => {
-    it('Should error when an assetId is found that is a blank space', async () => {
-        const tests: Test[] = [['Statemine', [' ', 'KSM'], Direction.SystemToRelay, `assetId cannot be blank spaces.`]];
+	it('Should error when an assetId is found that is a blank space', async () => {
+		const tests: Test[] = [['Statemine', [' ', 'KSM'], Direction.SystemToRelay, `assetId cannot be blank spaces.`]];
 
-        await runTests(tests);
-    });
+		await runTests(tests);
+	});
 
-    it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', async () => {
-        const tests: Test[] = [
-            [
-                'Polkadot',
-                ['1', 'DOT'],
-                Direction.RelayToSystem,
-                `(RelayToSystem) assetId 1 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"0","interior":{"Here":""}}`,
-            ],
-            [
-                'Kusama',
-                ['DOT', 'KSM'],
-                Direction.RelayToSystem,
-                `(RelayToSystem) assetId DOT is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"0","interior":{"Here":""}}`,
-            ],
-            [
-                'Westend',
-                ['WND', '100000'],
-                Direction.RelayToSystem,
-                `(RelayToSystem) assetId 100000 is not the native asset of westend relay chain. Expected an assetId of WND or asset location {"parents":"0","interior":{"Here":""}}`,
-            ],
-        ];
+	it('Should error when direction is RelayToSystem and assetId does not match relay chains native token', async () => {
+		const tests: Test[] = [
+			[
+				'Polkadot',
+				['1', 'DOT'],
+				Direction.RelayToSystem,
+				`(RelayToSystem) assetId 1 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"0","interior":{"Here":""}}`,
+			],
+			[
+				'Kusama',
+				['DOT', 'KSM'],
+				Direction.RelayToSystem,
+				`(RelayToSystem) assetId DOT is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"0","interior":{"Here":""}}`,
+			],
+			[
+				'Westend',
+				['WND', '100000'],
+				Direction.RelayToSystem,
+				`(RelayToSystem) assetId 100000 is not the native asset of westend relay chain. Expected an assetId of WND or asset location {"parents":"0","interior":{"Here":""}}`,
+			],
+		];
 
-        await runTests(tests);
-    });
+		await runTests(tests);
+	});
 
-    it('Should error when direction is RelayToPara and assetId does not match relay chains native token', async () => {
-        const tests: Test[] = [
-            [
-                'Polkadot',
-                ['1', 'DOT'],
-                Direction.RelayToPara,
-                `(RelayToPara) assetId 1 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"0","interior":{"Here":""}}`,
-            ],
-            [
-                'Kusama',
-                ['DOT', 'KSM'],
-                Direction.RelayToPara,
-                `(RelayToPara) assetId DOT is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"0","interior":{"Here":""}}`,
-            ],
-        ];
+	it('Should error when direction is RelayToPara and assetId does not match relay chains native token', async () => {
+		const tests: Test[] = [
+			[
+				'Polkadot',
+				['1', 'DOT'],
+				Direction.RelayToPara,
+				`(RelayToPara) assetId 1 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"0","interior":{"Here":""}}`,
+			],
+			[
+				'Kusama',
+				['DOT', 'KSM'],
+				Direction.RelayToPara,
+				`(RelayToPara) assetId DOT is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"0","interior":{"Here":""}}`,
+			],
+		];
 
-        await runTests(tests);
-    });
+		await runTests(tests);
+	});
 
-    it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', async () => {
-        const tests: Test[] = [
-            ['Statemint', ['0'], Direction.SystemToRelay, `(SystemToRelay) assetId 0 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"1","interior":{"Here":""}}`],
-            ['Statemine', ['MOVR', 'KSM'], Direction.SystemToRelay, `(SystemToRelay) assetId MOVR is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"1","interior":{"Here":""}}`],
-            ['Westmint', ['WND', '250'], Direction.SystemToRelay, `(SystemToRelay) assetId 250 is not the native asset of westend relay chain. Expected an assetId of WND or asset location {"parents":"1","interior":{"Here":""}}`],
-        ];
+	it('Should error when direction is SystemToRelay and an assetId is not native to the relay chain', async () => {
+		const tests: Test[] = [
+			[
+				'Statemint',
+				['0'],
+				Direction.SystemToRelay,
+				`(SystemToRelay) assetId 0 is not the native asset of polkadot relay chain. Expected an assetId of DOT or asset location {"parents":"1","interior":{"Here":""}}`,
+			],
+			[
+				'Statemine',
+				['MOVR', 'KSM'],
+				Direction.SystemToRelay,
+				`(SystemToRelay) assetId MOVR is not the native asset of kusama relay chain. Expected an assetId of KSM or asset location {"parents":"1","interior":{"Here":""}}`,
+			],
+			[
+				'Westmint',
+				['WND', '250'],
+				Direction.SystemToRelay,
+				`(SystemToRelay) assetId 250 is not the native asset of westend relay chain. Expected an assetId of WND or asset location {"parents":"1","interior":{"Here":""}}`,
+			],
+		];
 
-        await runTests(tests);
-    });
+		await runTests(tests);
+	});
 
-    it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', async () => {
-        const tests: Test[] = [
-            [
-                'Statemine',
-                ['KSM', '8', 'stateMineDoge'],
-                Direction.SystemToPara,
-                `(SystemToPara) assetId stateMineDoge not found for system parachain Statemine`,
-            ],
-        ];
+	it('Should error when direction is SystemToPara and integer assetId is not found in system parachains assets', async () => {
+		const tests: Test[] = [
+			[
+				'Statemine',
+				['KSM', '8', 'stateMineDoge'],
+				Direction.SystemToPara,
+				`(SystemToPara) assetId stateMineDoge not found for system parachain Statemine`,
+			],
+		];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
-            await expect(async () => {
-                await checkAssetIdInput(
-                    mockWestendAssetHubApiV1004000,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
+			await expect(async () => {
+				await checkAssetIdInput(
+					mockSystemApi,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
 
-    it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', async () => {
-        const tests: Test[] = [
-            [
-                'Statemint',
-                ['1337', 'xcDOT'],
-                Direction.SystemToPara,
-                `(SystemToPara) assetId xcDOT not found for system parachain Statemint`,
-            ],
-            [
-                'Statemine',
-                ['KSM', 'xcMOVR'],
-                Direction.SystemToPara,
-                `(SystemToPara) assetId xcMOVR not found for system parachain Statemine`,
-            ],
-            [
-                'Westmint',
-                ['WND', 'Test Westend'],
-                Direction.SystemToPara,
-                `(SystemToPara) assetId Test Westend not found for system parachain Westmint`,
-            ],
-        ];
+	it('Should error when direction is SystemToPara and the string assetId is not found in the system parachains tokens or assets', async () => {
+		const tests: Test[] = [
+			[
+				'Statemint',
+				['1337', 'xcDOT'],
+				Direction.SystemToPara,
+				`(SystemToPara) assetId xcDOT not found for system parachain Statemint`,
+			],
+			[
+				'Statemine',
+				['KSM', 'xcMOVR'],
+				Direction.SystemToPara,
+				`(SystemToPara) assetId xcMOVR not found for system parachain Statemine`,
+			],
+			[
+				'Westmint',
+				['WND', 'Test Westend'],
+				Direction.SystemToPara,
+				`(SystemToPara) assetId Test Westend not found for system parachain Westmint`,
+			],
+		];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
-            await expect(async () => {
-                await checkAssetIdInput(
-                    mockWestendAssetHubApiV1004000,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
+			await expect(async () => {
+				await checkAssetIdInput(
+					mockSystemApi,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
 
-    it('Should error when an asset id is provided that matches multiple asset symbols in the assets registry', async () => {
-        const tests: Test[] = [['Statemine', ['USDT'], Direction.SystemToPara, `Multiple assets found with symbol USDT`]];
+	it('Should error when an asset id is provided that matches multiple asset symbols in the assets registry', async () => {
+		const tests: Test[] = [['Statemine', ['USDT'], Direction.SystemToPara, `Multiple assets found with symbol USDT`]];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
-            await expect(async () => {
-                await checkAssetIdInput(
-                    parachainAssetsApi.api,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
+			await expect(async () => {
+				await checkAssetIdInput(
+					parachainAssetsApi.api,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
 
-    it('Should error when direction is SystemToSystem and the string assetId is not found in the system parachains tokens or assets', async () => {
-        const tests: Test[] = [
-            [
-                'Statemint',
-                ['1337', 'xcDOT'],
-                Direction.SystemToSystem,
-                `(SystemToSystem) assetId xcDOT not found for system parachain Statemint`,
-            ],
-            [
-                'Statemine',
-                ['KSM', 'xcMOVR'],
-                Direction.SystemToSystem,
-                `(SystemToSystem) assetId xcMOVR not found for system parachain Statemine`,
-            ],
-            [
-                'Westmint',
-                ['WND', 'Test Westend'],
-                Direction.SystemToSystem,
-                `(SystemToSystem) assetId Test Westend not found for system parachain Westmint`,
-            ],
-        ];
+	it('Should error when direction is SystemToSystem and the string assetId is not found in the system parachains tokens or assets', async () => {
+		const tests: Test[] = [
+			[
+				'Statemint',
+				['1337', 'xcDOT'],
+				Direction.SystemToSystem,
+				`(SystemToSystem) assetId xcDOT not found for system parachain Statemint`,
+			],
+			[
+				'Statemine',
+				['KSM', 'xcMOVR'],
+				Direction.SystemToSystem,
+				`(SystemToSystem) assetId xcMOVR not found for system parachain Statemine`,
+			],
+			[
+				'Westmint',
+				['WND', 'Test Westend'],
+				Direction.SystemToSystem,
+				`(SystemToSystem) assetId Test Westend not found for system parachain Westmint`,
+			],
+		];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
-            await expect(async () => {
-                await checkAssetIdInput(
-                    mockWestendAssetHubApiV1004000,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
-    it('Should error when direction is SystemToPara and the multilocation assetId is not found in the system parachains foreignAssets or chain state', async () => {
-        const tests: Test[] = [
-            [
-                'Statemine',
-                ['{"parents":"2","interior":{"X1": {"Parachain":"2125000"}}}'],
-                Direction.SystemToPara,
-                `(SystemToPara) assetId {"parents":"2","interior":{"X1": {"Parachain":"2125000"}}} not found for system parachain Statemine`,
-            ],
-        ];
+			await expect(async () => {
+				await checkAssetIdInput(
+					mockSystemApi,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
+	it('Should error when direction is SystemToPara and the multilocation assetId is not found in the system parachains foreignAssets or chain state', async () => {
+		const tests: Test[] = [
+			[
+				'Statemine',
+				['{"parents":"2","interior":{"X1": {"Parachain":"2125000"}}}'],
+				Direction.SystemToPara,
+				`(SystemToPara) assetId {"parents":"2","interior":{"X1": {"Parachain":"2125000"}}} not found for system parachain Statemine`,
+			],
+		];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
-            await expect(async () => {
-                await checkAssetIdInput(
-                    mockWestendAssetHubApiV1004000,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
-    it('Should correctly error when direction is ParaToSystem and the provided integer assetId is not found in the system parachains assetIds', async () => {
-        const tests: Test[] = [
-            [
-                'moonriver',
-                ['311091173110107856861649819128533077277', '200'],
-                Direction.ParaToSystem,
-                `(ParaToSystem) integer assetId 200 not found in moonriver`,
-            ],
-        ];
+			await expect(async () => {
+				await checkAssetIdInput(
+					mockSystemApi,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
+	it('Should correctly error when direction is ParaToSystem and the provided integer assetId is not found in the system parachains assetIds', async () => {
+		const tests: Test[] = [
+			[
+				'moonriver',
+				['311091173110107856861649819128533077277', '200'],
+				Direction.ParaToSystem,
+				`(ParaToSystem) integer assetId 200 not found in moonriver`,
+			],
+		];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
-            await expect(async () => {
-                await checkAssetIdInput(
-                    parachainAssetsApi.api,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
-    it('Should correctly error when direction is ParaToSystem and the string assetId has no match in the parachains asset symbols', async () => {
-        const tests: Test[] = [
-            [
-                'moonriver',
-                ['xcKSMFake', 'USDT'],
-                Direction.ParaToSystem,
-                `(ParaToSystem) symbol assetId xcKSMFake not found for parachain moonriver`,
-            ],
-            [
-                'moonriver',
-                ['xcUSDT', 'ASTR'],
-                Direction.ParaToSystem,
-                `(ParaToSystem) symbol assetId ASTR not found for parachain moonriver`,
-            ],
-        ];
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
+			await expect(async () => {
+				await checkAssetIdInput(
+					parachainAssetsApi.api,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
+	it('Should correctly error when direction is ParaToSystem and the string assetId has no match in the parachains asset symbols', async () => {
+		const tests: Test[] = [
+			[
+				'moonriver',
+				['xcKSMFake', 'USDT'],
+				Direction.ParaToSystem,
+				`(ParaToSystem) symbol assetId xcKSMFake not found for parachain moonriver`,
+			],
+			[
+				'moonriver',
+				['xcUSDT', 'ASTR'],
+				Direction.ParaToSystem,
+				`(ParaToSystem) symbol assetId ASTR not found for parachain moonriver`,
+			],
+		];
 
-        for (const test of tests) {
-            const [specName, testInputs, direction, errorMessage] = test;
-            const registry = new Registry(specName, {});
-            const currentRegistry = registry.currentRelayRegistry;
+		for (const test of tests) {
+			const [specName, testInputs, direction, errorMessage] = test;
+			const registry = new Registry(specName, {});
+			const currentRegistry = registry.currentRelayRegistry;
 
-            await expect(async () => {
-                await checkAssetIdInput(
-                    parachainAssetsApi.api,
-                    testInputs,
-                    currentRegistry,
-                    specName,
-                    direction,
-                    registry,
-                    2,
-                    false,
-                    false,
-                );
-            }).rejects.toThrow(errorMessage);
-        }
-    });
-    it('Should error for an invalid erc20 token.', async () => {
-        const registry = new Registry('moonriver', {});
-        const currentRegistry = registry.currentRelayRegistry;
+			await expect(async () => {
+				await checkAssetIdInput(
+					parachainAssetsApi.api,
+					testInputs,
+					currentRegistry,
+					specName,
+					direction,
+					registry,
+					2,
+					false,
+					false,
+				);
+			}).rejects.toThrow(errorMessage);
+		}
+	});
+	it('Should error for an invalid erc20 token.', async () => {
+		const registry = new Registry('moonriver', {});
+		const currentRegistry = registry.currentRelayRegistry;
 
-        await expect(async () => {
-            await checkAssetIdInput(
-                parachainAssetsApi.api,
-                ['0x1234'],
-                currentRegistry,
-                'moonriver',
-                Direction.ParaToSystem,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).rejects.toThrow('(ParaToSystem) assetId 0x1234, is not a valid erc20 token.');
-    });
-    it('Should error when an invalid token is passed into a liquidTokenTransfer', async () => {
-        const registry = new Registry('westmint', {});
-        const currentRegistry = registry.currentRelayRegistry;
-        const isLiquidTokenTransfer = true;
+		await expect(async () => {
+			await checkAssetIdInput(
+				parachainAssetsApi.api,
+				['0x1234'],
+				currentRegistry,
+				'moonriver',
+				Direction.ParaToSystem,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).rejects.toThrow('(ParaToSystem) assetId 0x1234, is not a valid erc20 token.');
+	});
+	it('Should error when an invalid token is passed into a liquidTokenTransfer', async () => {
+		const registry = new Registry('westmint', {});
+		const currentRegistry = registry.currentRelayRegistry;
+		const isLiquidTokenTransfer = true;
 
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockWestendAssetHubApiV1004000,
-                ['TEST'],
-                currentRegistry,
-                'westmint',
-                Direction.SystemToPara,
-                registry,
-                2,
-                false,
-                isLiquidTokenTransfer,
-            );
-        }).rejects.toThrow('Liquid Tokens must be valid Integers');
-    });
-    it('Should error when a token does not exist in the registry or node', async () => {
-        const registry = new Registry('westmint', {});
-        const currentRegistry = registry.currentRelayRegistry;
-        const isLiquidTokenTransfer = true;
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockSystemApi,
+				['TEST'],
+				currentRegistry,
+				'westmint',
+				Direction.SystemToPara,
+				registry,
+				2,
+				false,
+				isLiquidTokenTransfer,
+			);
+		}).rejects.toThrow('Liquid Tokens must be valid Integers');
+	});
+	it('Should error when a token does not exist in the registry or node', async () => {
+		const registry = new Registry('westmint', {});
+		const currentRegistry = registry.currentRelayRegistry;
+		const isLiquidTokenTransfer = true;
 
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockWestendAssetHubApiV1004000,
-                ['999111'],
-                currentRegistry,
-                'westmint',
-                Direction.SystemToPara,
-                registry,
-                2,
-                false,
-                isLiquidTokenTransfer,
-            );
-        }).rejects.toThrow(
-            'No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.',
-        );
-    });
-    it('Should not error when a valid liquid token exists', async () => {
-        const registry = new Registry('westmint', {});
-        const currentRegistry = registry.currentRelayRegistry;
-        const isLiquidTokenTransfer = true;
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockSystemApi,
+				['999111'],
+				currentRegistry,
+				'westmint',
+				Direction.SystemToPara,
+				registry,
+				2,
+				false,
+				isLiquidTokenTransfer,
+			);
+		}).rejects.toThrow(
+			'No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.',
+		);
+	});
+	it('Should not error when a valid liquid token exists', async () => {
+		const registry = new Registry('westmint', {});
+		const currentRegistry = registry.currentRelayRegistry;
+		const isLiquidTokenTransfer = true;
 
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockWestendAssetHubApiV1004000,
-                ['0'],
-                currentRegistry,
-                'westmint',
-                Direction.SystemToPara,
-                registry,
-                2,
-                false,
-                isLiquidTokenTransfer,
-            );
-        }).not.toThrow();
-    });
-    it('Should not throw an error for ParaToRelay when its a valid', async () => {
-        const registry = new Registry('moonriver', {});
-        const currentRegistry = registry.currentRelayRegistry;
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockMoonriverParachainApiV2302,
-                ['KSM'],
-                currentRegistry,
-                'moonriver',
-                Direction.ParaToRelay,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).not.toThrow();
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockMoonriverParachainApiV2302,
-                ['42259045809535163221576417993425387648'],
-                currentRegistry,
-                'moonriver',
-                Direction.ParaToRelay,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).not.toThrow();
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockMoonriverParachainApiV2302,
-                [''],
-                currentRegistry,
-                'moonriver',
-                Direction.ParaToRelay,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).not.toThrow();
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockMoonriverParachainApiV2302,
-                [],
-                currentRegistry,
-                'moonriver',
-                Direction.ParaToRelay,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).not.toThrow();
-    });
-    it('Should error when an invalid assetId is inputted for ParaToRelay', async () => {
-        const registry = new Registry('karura', {});
-        const currentRegistry = registry.currentRelayRegistry;
+		// eslint-disable-next-line @typescript-eslint/await-thenable
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockSystemApi,
+				['0'],
+				currentRegistry,
+				'westmint',
+				Direction.SystemToPara,
+				registry,
+				2,
+				false,
+				isLiquidTokenTransfer,
+			);
+		}).not.toThrow();
+	});
+	it('Should not throw an error for ParaToRelay when its a valid', async () => {
+		const registry = new Registry('moonriver', {});
+		const currentRegistry = registry.currentRelayRegistry;
+		// eslint-disable-next-line @typescript-eslint/await-thenable
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockMoonriverParachainApi,
+				['KSM'],
+				currentRegistry,
+				'moonriver',
+				Direction.ParaToRelay,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).not.toThrow();
+		// eslint-disable-next-line @typescript-eslint/await-thenable
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockMoonriverParachainApi,
+				['42259045809535163221576417993425387648'],
+				currentRegistry,
+				'moonriver',
+				Direction.ParaToRelay,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).not.toThrow();
+		// eslint-disable-next-line @typescript-eslint/await-thenable
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockMoonriverParachainApi,
+				[''],
+				currentRegistry,
+				'moonriver',
+				Direction.ParaToRelay,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).not.toThrow();
+		// eslint-disable-next-line @typescript-eslint/await-thenable
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockMoonriverParachainApi,
+				[],
+				currentRegistry,
+				'moonriver',
+				Direction.ParaToRelay,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).not.toThrow();
+	});
+	it('Should error when an invalid assetId is inputted for ParaToRelay', async () => {
+		const registry = new Registry('karura', {});
+		const currentRegistry = registry.currentRelayRegistry;
 
-        await expect(async () => {
-            await checkAssetIdInput(
-                adjustedMockMoonriverParachainApiV2302,
-                ['TEST'],
-                currentRegistry,
-                'crust-collator',
-                Direction.ParaToRelay,
-                registry,
-                2,
-                false,
-                false,
-            );
-        }).rejects.toThrow("The current input for assetId's does not meet our specifications for ParaToRelay transfers.");
-    });
+		await expect(async () => {
+			await checkAssetIdInput(
+				adjustedMockMoonriverParachainApi,
+				['TEST'],
+				currentRegistry,
+				'crust-collator',
+				Direction.ParaToRelay,
+				registry,
+				2,
+				false,
+				false,
+			);
+		}).rejects.toThrow("The current input for assetId's does not meet our specifications for ParaToRelay transfers.");
+	});
 });
 
 describe('checkIfNativeRelayChainAssetPresentInMultiAssetIdList', () => {
-    it('Should error when the relay native asset and system assets are in the same assetIds list when direction is SystemToSystem', () => {
-        const expectErrorMessage =
-            'Found the relay chains native asset in list [ksm,usdc]. `assetIds` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.';
-        const assetIds = ['ksm', 'usdc'];
-        const specName = 'statemine';
-        const registry = new Registry(specName, {});
+	it('Should error when the relay native asset and system assets are in the same assetIds list when direction is SystemToSystem', () => {
+		const expectErrorMessage =
+			'Found the relay chains native asset in list [ksm,usdc]. `assetIds` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.';
+		const assetIds = ['ksm', 'usdc'];
+		const specName = 'statemine';
+		const registry = new Registry(specName, {});
 
-        const err = () => checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
-        expect(err).toThrow(expectErrorMessage);
-    });
+		const err = () => checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
+		expect(err).toThrow(expectErrorMessage);
+	});
 });
 
 describe('checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain', () => {
-    it('Should correctly error when isForeignAssetsTransfer and both non native and foreign multilocations are in assetIds for direction SystemToPara', () => {
-        const expectedErrorMessage =
-            '(SystemToPara) found both foreign and native multilocations in {"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}},{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}. multilocation XCMs must only include either native or foreign assets of the destination chain.';
-        const xcmDirection = Direction.SystemToPara;
-        const destChainId = '2023';
-        const multiLocationAssetIds = [
-            '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
-            '{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
-        ];
+	it('Should correctly error when isForeignAssetsTransfer and both non native and foreign multilocations are in assetIds for direction SystemToPara', () => {
+		const expectedErrorMessage =
+			'(SystemToPara) found both foreign and native multilocations in {"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}},{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}. multilocation XCMs must only include either native or foreign assets of the destination chain.';
+		const xcmDirection = Direction.SystemToPara;
+		const destChainId = '2023';
+		const multiLocationAssetIds = [
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
+		];
 
-        const err = () =>
-            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
+		const err = () =>
+			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
 
-        expect(err).toThrow(expectedErrorMessage);
-    });
+		expect(err).toThrow(expectedErrorMessage);
+	});
 
-    it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only native multilocations are in assetIds for direction SystemToPara', () => {
-        const xcmDirection = Direction.SystemToPara;
-        const destChainId = '2125';
-        const multiLocationAssetIds = [
-            '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
-            '{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "1"}]}}',
-        ];
+	it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only native multilocations are in assetIds for direction SystemToPara', () => {
+		const xcmDirection = Direction.SystemToPara;
+		const destChainId = '2125';
+		const multiLocationAssetIds = [
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "0"}]}}',
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2125"}, {"GeneralIndex": "1"}]}}',
+		];
 
-        const err = () =>
-            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
+		const err = () =>
+			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
 
-        expect(err).not.toThrow();
-    });
+		expect(err).not.toThrow();
+	});
 
-    it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only foreign multilocations are in assetIds for direction SystemToPara', () => {
-        const xcmDirection = Direction.SystemToPara;
-        const destChainId = '2125';
-        const multiLocationAssetIds = [
-            '{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
-            '{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "1"}]}}',
-        ];
+	it('Should correctly avoid throwing an error when isForeignAssetsTransfer and only foreign multilocations are in assetIds for direction SystemToPara', () => {
+		const xcmDirection = Direction.SystemToPara;
+		const destChainId = '2125';
+		const multiLocationAssetIds = [
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "0"}]}}',
+			'{"parents":"1","interior":{"X2": [{"Parachain":"2023"}, {"GeneralIndex": "1"}]}}',
+		];
 
-        const err = () =>
-            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
+		const err = () =>
+			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(xcmDirection, destChainId, multiLocationAssetIds);
 
-        expect(err).not.toThrow();
-    });
+		expect(err).not.toThrow();
+	});
 });
 
 describe('checkAssetIdsLengthIsValid', () => {
-    it('Should correctly error when more than 2 assetIds are passed in', () => {
-        const assetIds = ['ksm', '1984', '10'];
-        const assetTransferType = 'RemoteReserve';
-        const xcmPallet = XcmPalletName.polkadotXcm;
+	it('Should correctly error when more than 2 assetIds are passed in', () => {
+		const assetIds = ['ksm', '1984', '10'];
+		const assetTransferType = 'RemoteReserve';
+		const xcmPallet = XcmPalletName.polkadotXcm;
 
-        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-        expect(err).toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
-    });
-    it('Should correctly not error when 2 or fewer assetIds are passed in and assetTransferType is defined', () => {
-        const assetIds = ['ksm', '1984'];
-        const assetTransferType = 'RemoteReserve';
-        const xcmPallet = XcmPalletName.polkadotXcm;
+		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+		expect(err).toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
+	});
+	it('Should correctly not error when 2 or fewer assetIds are passed in and assetTransferType is defined', () => {
+		const assetIds = ['ksm', '1984'];
+		const assetTransferType = 'RemoteReserve';
+		const xcmPallet = XcmPalletName.polkadotXcm;
 
-        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-        expect(err).not.toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
-    });
-    it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `xcmPallet` call', () => {
-        const assetIds = [
-            `{"parents":"1","interior":{"Here":""}}`,
-            `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
-        ];
-        const assetTransferType = undefined;
-        const xcmPallet = XcmPalletName.xcmPallet;
+		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+		expect(err).not.toThrow('Maximum number of assets allowed for transfer is 2. Found 3 assetIds');
+	});
+	it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `xcmPallet` call', () => {
+		const assetIds = [
+			`{"parents":"1","interior":{"Here":""}}`,
+			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
+		];
+		const assetTransferType = undefined;
+		const xcmPallet = XcmPalletName.xcmPallet;
 
-        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-        expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
-    });
-    it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `polkadotXcm` call', () => {
-        const assetIds = [
-            `{"parents":"1","interior":{"Here":""}}`,
-            `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
-        ];
-        const assetTransferType = undefined;
-        const xcmPallet = XcmPalletName.polkadotXcm;
+		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+		expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
+	});
+	it('Should correctly throw an error when provided more than 1 asset id for a non `transferAssetsUsingTypeAndThen` `polkadotXcm` call', () => {
+		const assetIds = [
+			`{"parents":"1","interior":{"Here":""}}`,
+			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
+		];
+		const assetTransferType = undefined;
+		const xcmPallet = XcmPalletName.polkadotXcm;
 
-        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-        expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
-    });
-    it('Should correctly not throw an error when provided more than 1 asset id for a `transferAssetsUsingTypeAndThen` call', () => {
-        const assetIds = [
-            `{"parents":"1","interior":{"Here":""}}`,
-            `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
-        ];
-        const assetTransferType = 'RemoteReserve';
-        const xcmPallet = XcmPalletName.polkadotXcm;
+		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+		expect(err).toThrow('transferAssets transactions cannot contain more than 1 asset location id. Found 2 assetIds');
+	});
+	it('Should correctly not throw an error when provided more than 1 asset id for a `transferAssetsUsingTypeAndThen` call', () => {
+		const assetIds = [
+			`{"parents":"1","interior":{"Here":""}}`,
+			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Westend"}}}`,
+		];
+		const assetTransferType = 'RemoteReserve';
+		const xcmPallet = XcmPalletName.polkadotXcm;
 
-        const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
-        expect(err).not.toThrow();
-    });
+		const err = () => checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+		expect(err).not.toThrow();
+	});
 });
 
 describe('checkAssetIdsHaveNoDuplicates', () => {
-    it('Should correctly error if duplicate empty string relay assetIds are found', () => {
-        const assetIds = ['', ''];
+	it('Should correctly error if duplicate empty string relay assetIds are found', () => {
+		const assetIds = ['', ''];
 
-        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-        expect(err).toThrow('AssetIds must be unique. Found duplicate native relay assets as empty strings');
-    });
-    it('Should correctly error if duplicate integer assetIds are found', () => {
-        const assetIds = ['10', '10'];
+		expect(err).toThrow('AssetIds must be unique. Found duplicate native relay assets as empty strings');
+	});
+	it('Should correctly error if duplicate integer assetIds are found', () => {
+		const assetIds = ['10', '10'];
 
-        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-        expect(err).toThrow('AssetIds must be unique. Found duplicate assetId 10');
-    });
-    it('Should correctly error if duplicate integer assetIds are found', () => {
-        const assetIds = ['usdt', 'USDT'];
+		expect(err).toThrow('AssetIds must be unique. Found duplicate assetId 10');
+	});
+	it('Should correctly error if duplicate integer assetIds are found', () => {
+		const assetIds = ['usdt', 'USDT'];
 
-        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-        expect(err).toThrow('AssetIds must be unique. Found duplicate assetId USDT');
-    });
-    it('Should correctly error if duplicate multilocation assetIds are found', () => {
-        const assetIds = [
-            '{"parents": "1","interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
-            '{"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
-        ];
+		expect(err).toThrow('AssetIds must be unique. Found duplicate assetId USDT');
+	});
+	it('Should correctly error if duplicate multilocation assetIds are found', () => {
+		const assetIds = [
+			'{"parents": "1","interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
+			'{"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}',
+		];
 
-        const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
+		const err = () => checkAssetIdsHaveNoDuplicates(assetIds);
 
-        expect(err).toThrow(
-            `AssetIds must be unique. Found duplicate assetId {"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}`,
-        );
-    });
+		expect(err).toThrow(
+			`AssetIds must be unique. Found duplicate assetId {"parents": "1", "interior":{"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}`,
+		);
+	});
 });
 
 describe('checkAssetIdsAreOfSameAssetIdType', () => {
-    it('Should correctly error when an integer assetId and multilocation assetId are passed in together', () => {
-        const assetIds = ['1984', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
+	it('Should correctly error when an integer assetId and multilocation assetId are passed in together', () => {
+		const assetIds = ['1984', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-        const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-        expect(err).toThrow(
-            `Found both native asset with assetID 1984 and foreign asset with assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Native assets and foreign assets can't be transferred within the same call.`,
-        );
-    });
+		expect(err).toThrow(
+			`Found both native asset with assetID 1984 and foreign asset with assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Native assets and foreign assets can't be transferred within the same call.`,
+		);
+	});
 
-    it('Should correctly error when a symbol assetId and multilocation assetId are passed in together', () => {
-        const assetIds = ['ksm', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
+	it('Should correctly error when a symbol assetId and multilocation assetId are passed in together', () => {
+		const assetIds = ['ksm', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-        const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-        expect(err).toThrow(
-            'Found both symbol ksm and multilocation assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Asset Ids must be symbol and integer or multilocation exclusively.',
-        );
-    });
+		expect(err).toThrow(
+			'Found both symbol ksm and multilocation assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Asset Ids must be symbol and integer or multilocation exclusively.',
+		);
+	});
 
-    it('Should correctly error when the default relay asset value and multilocation assetId are passed in together', () => {
-        const assetIds = ['', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
+	it('Should correctly error when the default relay asset value and multilocation assetId are passed in together', () => {
+		const assetIds = ['', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-        const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-        expect(err).toThrow(
-            `Found both default relay native asset and foreign asset with assetId: {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Relay native asset and foreign assets can't be transferred within the same call.`,
-        );
-    });
+		expect(err).toThrow(
+			`Found both default relay native asset and foreign asset with assetId: {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Relay native asset and foreign assets can't be transferred within the same call.`,
+		);
+	});
 });
 
 describe('checkXcmVersionIsValidForPaysWithFeeDest', () => {
-    it('Should correctly throw an error if paysWithFeeDest is provided and xcmVersion is less than 3', () => {
-        const xcmVersion = 2;
-        const paysWithFeeDest = '1984';
+	it('Should correctly throw an error if paysWithFeeDest is provided and xcmVersion is less than 3', () => {
+		const xcmVersion = 2;
+		const paysWithFeeDest = '1984';
 
-        const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
+		const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
 
-        expect(err).toThrow('paysWithFeeDest requires XCM version 3 or greater');
-    });
-    it('Should correctly not throw an error if paysWithFeeDest is provided and xcmVersion is at least 3', () => {
-        const xcmVersion = 3;
-        const paysWithFeeDest = '1984';
+		expect(err).toThrow('paysWithFeeDest requires XCM version 3 or greater');
+	});
+	it('Should correctly not throw an error if paysWithFeeDest is provided and xcmVersion is at least 3', () => {
+		const xcmVersion = 3;
+		const paysWithFeeDest = '1984';
 
-        const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
+		const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.SystemToPara, xcmVersion, paysWithFeeDest);
 
-        expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
-    });
+		expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
+	});
 
-    it('Should correctly not throw an error if xcmDirection is ParaToSystem or ParaToPara', () => {
-        const xcmVersion = 3;
-        const paysWithFeeDest = '1984';
+	it('Should correctly not throw an error if xcmDirection is ParaToSystem or ParaToPara', () => {
+		const xcmVersion = 3;
+		const paysWithFeeDest = '1984';
 
-        const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.ParaToSystem, xcmVersion, paysWithFeeDest);
+		const err = () => checkXcmVersionIsValidForPaysWithFeeDest(Direction.ParaToSystem, xcmVersion, paysWithFeeDest);
 
-        expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
-    });
+		expect(err).not.toThrow('paysWithFeeDest requires XCM version 3 or greater');
+	});
 });
 
 describe('CheckXTokensPalletOriginIsNonForeignAssetTx', () => {
-    it('Should correctly throw an error when xcm pallet is xTokens and isForeignAssetsTransfer is true', () => {
-        type Test = [isForeignAssetTransfer: boolean, xcmPallet: XcmPalletName, xcmDirection: Direction];
+	it('Should correctly throw an error when xcm pallet is xTokens and isForeignAssetsTransfer is true', () => {
+		type Test = [isForeignAssetTransfer: boolean, xcmPallet: XcmPalletName, xcmDirection: Direction];
 
-        const tests: Test[] = [
-            [true, XcmPalletName.xTokens, Direction.ParaToSystem],
-            [true, XcmPalletName.xTokens, Direction.ParaToPara],
-        ];
+		const tests: Test[] = [
+			[true, XcmPalletName.xTokens, Direction.ParaToSystem],
+			[true, XcmPalletName.xTokens, Direction.ParaToPara],
+		];
 
-        for (const test of tests) {
-            const [isForeignAssetsTransfer, xcmPallet, xcmDirection] = test;
+		for (const test of tests) {
+			const [isForeignAssetsTransfer, xcmPallet, xcmDirection] = test;
 
-            const err = () => {
-                CheckXTokensPalletOriginIsNonForeignAssetTx(xcmDirection, xcmPallet, isForeignAssetsTransfer);
-            };
+			const err = () => {
+				CheckXTokensPalletOriginIsNonForeignAssetTx(xcmDirection, xcmPallet, isForeignAssetsTransfer);
+			};
 
-            expect(err).toThrow(`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`);
-        }
-    });
+			expect(err).toThrow(`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`);
+		}
+	});
 });
 
 describe('checkLiquidTokenTransferDirectionValidity', () => {
-    it('Should correctly throw an error when inputs dont match the specification', () => {
-        const err = () => checkLiquidTokenTransferDirectionValidity(Direction.ParaToSystem, true);
+	it('Should correctly throw an error when inputs dont match the specification', () => {
+		const err = () => checkLiquidTokenTransferDirectionValidity(Direction.ParaToSystem, true);
 
-        expect(err).toThrow('isLiquidTokenTransfer may not be true for the xcmDirection: ParaToSystem.');
-    });
+		expect(err).toThrow('isLiquidTokenTransfer may not be true for the xcmDirection: ParaToSystem.');
+	});
 });
 
-describe('checkXcmVersionIsValidForSystemToBridge', () => {
-    it('Should correctly throw an error when the xcm version is less than 3 for SystemToBridge direction', () => {
-        const xcmVersion = 2;
-        const err = () => checkXcmVersionIsValidForSystemToBridge(xcmVersion);
+describe('checkXcmVersionIsValidForBridgeTx', () => {
+	it('Should correctly throw an error when the xcm version is less than 3 for SystemToBridge direction', () => {
+		const xcmVersion = 2;
+		const err = () => checkXcmVersionIsValidForBridgeTx(xcmVersion);
 
-        expect(err).toThrow('SystemToBridge transactions require XCM version 3 or greater');
-    });
+		expect(err).toThrow('Bridge transactions require XCM version 3 or greater');
+	});
 });
 
-describe('checkSystemToBridgeInputs', () => {
-    it('Should correctly error when no paysWithFeeDest value is provided but assetTransferType is', () => {
-        const paysWithFeeDest = undefined;
-        const assetTransferType = 'RemoteReserve';
-        const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-        const feesTransferType = 'RemoteReserve';
-        const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+describe('checkBridgeTxInputs', () => {
+	it('Should correctly error when no paysWithFeeDest value is provided but assetTransferType is', () => {
+		const paysWithFeeDest = undefined;
+		const assetTransferType = 'RemoteReserve';
+		const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+		const feesTransferType = 'RemoteReserve';
+		const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
 
-        const err = () =>
-            checkSystemToBridgeInputs(
-                paysWithFeeDest,
-                assetTransferType,
-                remoteReserveAssetTransferTypeLocation,
-                feesTransferType,
-                remoteReserveFeesTransferTypeLocation,
-            );
+		const err = () =>
+			checkBridgeTxInputs(
+				paysWithFeeDest,
+				assetTransferType,
+				remoteReserveAssetTransferTypeLocation,
+				feesTransferType,
+				remoteReserveFeesTransferTypeLocation,
+			);
 
-        expect(err).toThrow('paysWithFeeDest input is required for bridge transactions when assetTransferType is provided');
-    });
-    it('Should correctly throw an error when assetTransferType is RemoteReserve and no remoteReserveAssetTransferTypeLocation value is provided', () => {
-        const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-        const assetTransferType = 'RemoteReserve';
-        const remoteReserveAssetTransferTypeLocation = undefined;
-        const feesTransferType = 'RemoteReserve';
-        const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+		expect(err).toThrow('paysWithFeeDest input is required for bridge transactions when assetTransferType is provided');
+	});
+	it('Should correctly throw an error when assetTransferType is RemoteReserve and no remoteReserveAssetTransferTypeLocation value is provided', () => {
+		const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+		const assetTransferType = 'RemoteReserve';
+		const remoteReserveAssetTransferTypeLocation = undefined;
+		const feesTransferType = 'RemoteReserve';
+		const remoteReserveFeesTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
 
-        const err = () =>
-            checkSystemToBridgeInputs(
-                paysWithFeeDest,
-                assetTransferType,
-                remoteReserveAssetTransferTypeLocation,
-                feesTransferType,
-                remoteReserveFeesTransferTypeLocation,
-            );
+		const err = () =>
+			checkBridgeTxInputs(
+				paysWithFeeDest,
+				assetTransferType,
+				remoteReserveAssetTransferTypeLocation,
+				feesTransferType,
+				remoteReserveFeesTransferTypeLocation,
+			);
 
-        expect(err).toThrow(
-            'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
-        );
-    });
-    it('Should correctly throw an error when feesTransferType is RemoteReserve and no remoteReserveFeesTransferTypeLocation value is provided', () => {
-        const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-        const assetTransferType = 'RemoteReserve';
-        const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
-        const feesTransferType = 'RemoteReserve';
-        const remoteReserveFeesTransferTypeLocation = undefined;
+		expect(err).toThrow(
+			'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
+		);
+	});
+	it('Should correctly throw an error when feesTransferType is RemoteReserve and no remoteReserveFeesTransferTypeLocation value is provided', () => {
+		const paysWithFeeDest = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+		const assetTransferType = 'RemoteReserve';
+		const remoteReserveAssetTransferTypeLocation = '{"parents":"1","interior":{"X1":{"Parachain":"3369"}}}';
+		const feesTransferType = 'RemoteReserve';
+		const remoteReserveFeesTransferTypeLocation = undefined;
 
-        const err = () =>
-            checkSystemToBridgeInputs(
-                paysWithFeeDest,
-                assetTransferType,
-                remoteReserveAssetTransferTypeLocation,
-                feesTransferType,
-                remoteReserveFeesTransferTypeLocation,
-            );
+		const err = () =>
+			checkBridgeTxInputs(
+				paysWithFeeDest,
+				assetTransferType,
+				remoteReserveAssetTransferTypeLocation,
+				feesTransferType,
+				remoteReserveFeesTransferTypeLocation,
+			);
 
-        expect(err).toThrow(
-            'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
-        );
-    });
+		expect(err).toThrow(
+			'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
+		);
+	});
 });
 
 describe('checkPaysWithFeeDestAssetIdIsInAssets', () => {
-    it('Should correctly error when a paysWithFeeDestAsset is not found in the assetIds list', () => {
-        const assetIds = [`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}`];
-        const paysWithFeeDest = `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`;
+	it('Should correctly error when a paysWithFeeDestAsset is not found in the assetIds list', () => {
+		const assetIds = [`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}`];
+		const paysWithFeeDest = `{"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}}`;
 
-        const err = () => checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
+		const err = () => checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
 
-        expect(err).toThrow(
-            'paysWithFeeDest asset must be present in assets to be transferred. Did not find {"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}} in {"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}',
-        );
-    });
+		expect(err).toThrow(
+			'paysWithFeeDest asset must be present in assets to be transferred. Did not find {"parents":"2","interior":{"X2":[{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}},{"AccountKey20":{"network":null,"key":"0xfff9976782d46cc05630d1f6ebab18b2324d6b14"}}]}} in {"parents":"2","interior":{"X1":{"GlobalConsensus":"Rococo"}}}',
+		);
+	});
 });
 
 describe('checkParaAssets', () => {
-    it('Should correctly resolve when a valid symbol assetId is provided', async () => {
-        const assetId = 'xcUSDt';
-        const specName = 'moonriver';
-        const registry = new Registry(specName, {});
-        let didNotError = true;
+	it('Should correctly resolve when a valid symbol assetId is provided', async () => {
+		const assetId = 'xcUSDt';
+		const specName = 'moonriver';
+		const registry = new Registry(specName, {});
+		let didNotError = true;
 
-        try {
-            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
-        } catch (err) {
-            didNotError = false;
-        }
+		try {
+			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+		} catch (err) {
+			didNotError = false;
+		}
 
-        expect(didNotError).toBeTruthy();
-    });
-    it('Should correctly resolve when a valid integer assetId is provided', async () => {
-        const assetId = '311091173110107856861649819128533077277';
-        const specName = 'moonriver';
-        const registry = new Registry(specName, {});
-        let didNotError = true;
+		expect(didNotError).toBeTruthy();
+	});
+	it('Should correctly resolve when a valid integer assetId is provided', async () => {
+		const assetId = '311091173110107856861649819128533077277';
+		const specName = 'moonriver';
+		const registry = new Registry(specName, {});
+		let didNotError = true;
 
-        try {
-            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
-        } catch (err) {
-            didNotError = false;
-        }
+		try {
+			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+		} catch (err) {
+			didNotError = false;
+		}
 
-        expect(didNotError).toBeTruthy();
-    });
-    it('Should correctly error when an invalid symbol assetId is provided', async () => {
-        const assetId = 'xcUSDfake';
-        const specName = 'moonriver';
-        const registry = new Registry(specName, {});
+		expect(didNotError).toBeTruthy();
+	});
+	it('Should correctly error when an invalid symbol assetId is provided', async () => {
+		const assetId = 'xcUSDfake';
+		const specName = 'moonriver';
+		const registry = new Registry(specName, {});
 
-        await expect(async () => {
-            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
-        }).rejects.toThrow('(ParaToSystem) symbol assetId xcUSDfake not found for parachain moonriver');
-    });
-    it('Should correctly error when an invalid integer assetId is provided', async () => {
-        const assetId = '2096586909097964981698161';
-        const specName = 'moonriver';
-        const registry = new Registry(specName, {});
+		await expect(async () => {
+			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+		}).rejects.toThrow('(ParaToSystem) symbol assetId xcUSDfake not found for parachain moonriver');
+	});
+	it('Should correctly error when an invalid integer assetId is provided', async () => {
+		const assetId = '2096586909097964981698161';
+		const specName = 'moonriver';
+		const registry = new Registry(specName, {});
 
-        await expect(async () => {
-            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
-        }).rejects.toThrow('(ParaToSystem) integer assetId 2096586909097964981698161 not found in moonriver');
-    });
-    it('Should correctly error when a valid assetId is not found in the xcAsset registry', async () => {
-        const assetId = '999999999999999999999999999999999999999';
-        const specName = 'moonriver';
-        const registry = new Registry(specName, {});
+		await expect(async () => {
+			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+		}).rejects.toThrow('(ParaToSystem) integer assetId 2096586909097964981698161 not found in moonriver');
+	});
+	it('Should correctly error when a valid assetId is not found in the xcAsset registry', async () => {
+		const assetId = '999999999999999999999999999999999999999';
+		const specName = 'moonriver';
+		const registry = new Registry(specName, {});
 
-        await expect(async () => {
-            await checkParaAssets(adjustedMockMoonriverParachainApiV2302, assetId, specName, registry, Direction.ParaToSystem);
-        }).rejects.toThrow('unable to identify xcAsset with ID 999999999999999999999999999999999999999');
-    });
+		await expect(async () => {
+			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+		}).rejects.toThrow('unable to identify xcAsset with ID 999999999999999999999999999999999999999');
+	});
 
-    describe('cache', () => {
-        it('Should correctly cache an asset that is not found in the registry after being queried for origin System', async () => {
-            const registry = new Registry('statemine', {});
-            const chainInfo = {
-                '1000': {
-                    assetsInfo: {},
-                    poolPairsInfo: {},
-                    specName: '',
-                    tokens: [],
-                    foreignAssetsInfo: {},
-                },
-            };
+	describe('cache', () => {
+		it('Should correctly cache an asset that is not found in the registry after being queried for origin System', async () => {
+			const registry = new Registry('statemine', {});
+			const chainInfo = {
+				'1000': {
+					assetsInfo: {},
+					poolPairsInfo: {},
+					specName: '',
+					tokens: [],
+					foreignAssetsInfo: {},
+				},
+			};
 
-            await checkAssetIdInput(
-                adjustedMockWestendAssetHubApiV1004000,
-                ['1984'],
-                chainInfo,
-                'statemine',
-                Direction.SystemToPara,
-                registry,
-                2,
-                false,
-                false,
-            );
+			await checkAssetIdInput(
+				adjustedMockSystemApi,
+				['1984'],
+				chainInfo,
+				'statemine',
+				Direction.SystemToPara,
+				registry,
+				2,
+				false,
+				false,
+			);
 
-            expect(registry.cacheLookupAsset('1984')).toEqual('USDt');
-        });
-        it('Should correctly cache an asset that is not found in the registry after being queried for origin Para', async () => {
-            const registry = new Registry('moonriver', {});
-            const chainInfo = {
-                '2023': {
-                    assetsInfo: {},
-                    poolPairsInfo: {},
-                    specName: '',
-                    tokens: [],
-                    foreignAssetsInfo: {},
-                },
-            };
+			expect(registry.cacheLookupAsset('1984')).toEqual('USDt');
+		});
+		it('Should correctly cache an asset that is not found in the registry after being queried for origin Para', async () => {
+			const registry = new Registry('moonriver', {});
+			const chainInfo = {
+				'2023': {
+					assetsInfo: {},
+					poolPairsInfo: {},
+					specName: '',
+					tokens: [],
+					foreignAssetsInfo: {},
+				},
+			};
 
-            await checkAssetIdInput(
-                adjustedMockMoonriverParachainApiV2302,
-                ['xcUSDT'],
-                chainInfo,
-                'moonriver',
-                Direction.ParaToSystem,
-                registry,
-                2,
-                false,
-                false,
-            );
+			await checkAssetIdInput(
+				adjustedMockMoonriverParachainApi,
+				['xcUSDT'],
+				chainInfo,
+				'moonriver',
+				Direction.ParaToSystem,
+				registry,
+				2,
+				false,
+				false,
+			);
 
-            expect(registry.cacheLookupAsset('xcUSDT')).toEqual('311091173110107856861649819128533077277');
-        });
+			expect(registry.cacheLookupAsset('xcUSDT')).toEqual('311091173110107856861649819128533077277');
+		});
 
-        it('Should correctly cache a foreign asset that is not found in the registry after being queried', async () => {
-            const registry = new Registry('statemine', {
-                injectedRegistry: {
-                    kusama: {
-                        '1000': {
-                            assetsInfo: {},
-                            poolPairsInfo: {},
-                            specName: '',
-                            tokens: [],
-                            foreignAssetsInfo: {},
-                        },
-                    },
-                },
-            });
-            const chainInfo = {
-                '1000': {
-                    assetsInfo: {},
-                    poolPairsInfo: {},
-                    specName: '',
-                    tokens: [],
-                    foreignAssetsInfo: {},
-                },
-            };
+		it('Should correctly cache a foreign asset that is not found in the registry after being queried', async () => {
+			const registry = new Registry('statemine', {
+				injectedRegistry: {
+					kusama: {
+						'1000': {
+							assetsInfo: {},
+							poolPairsInfo: {},
+							specName: '',
+							tokens: [],
+							foreignAssetsInfo: {},
+						},
+					},
+				},
+			});
+			const chainInfo = {
+				'1000': {
+					assetsInfo: {},
+					poolPairsInfo: {},
+					specName: '',
+					tokens: [],
+					foreignAssetsInfo: {},
+				},
+			};
 
-            await checkAssetIdInput(
-                adjustedMockWestendAssetHubApiV1004000,
-                ['{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}'],
-                chainInfo,
-                'statemine',
-                Direction.SystemToPara,
-                registry,
-                2,
-                true,
-                false,
-            );
+			await checkAssetIdInput(
+				adjustedMockSystemApi,
+				['{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}'],
+				chainInfo,
+				'statemine',
+				Direction.SystemToPara,
+				registry,
+				2,
+				true,
+				false,
+			);
 
-            expect(registry.cacheLookupForeignAsset('GDZ')).toEqual({
-                multiLocation: '{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}',
-                name: 'Godzilla',
-                symbol: 'GDZ',
-            });
-        });
+			expect(registry.cacheLookupForeignAsset('GDZ')).toEqual({
+				multiLocation: '{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}',
+				name: 'Godzilla',
+				symbol: 'GDZ',
+			});
+		});
 
-        it('Should correctly cache a liquid asset that is not found in the registry after being queried', async () => {
-            const registry = new Registry('statemine', {
-                injectedRegistry: {
-                    kusama: {
-                        '1000': {
-                            assetsInfo: {},
-                            poolPairsInfo: {},
-                            specName: '',
-                            tokens: [],
-                            foreignAssetsInfo: {},
-                        },
-                    },
-                },
-            });
-            const chainInfo = {
-                '1000': {
-                    assetsInfo: {},
-                    poolPairsInfo: {},
-                    specName: '',
-                    tokens: [],
-                    foreignAssetsInfo: {},
-                },
-            };
+		it('Should correctly cache a liquid asset that is not found in the registry after being queried', async () => {
+			const registry = new Registry('statemine', {
+				injectedRegistry: {
+					kusama: {
+						'1000': {
+							assetsInfo: {},
+							poolPairsInfo: {},
+							specName: '',
+							tokens: [],
+							foreignAssetsInfo: {},
+						},
+					},
+				},
+			});
+			const chainInfo = {
+				'1000': {
+					assetsInfo: {},
+					poolPairsInfo: {},
+					specName: '',
+					tokens: [],
+					foreignAssetsInfo: {},
+				},
+			};
 
-            await checkAssetIdInput(
-                adjustedMockWestendAssetHubApiV1004000,
-                ['0'],
-                chainInfo,
-                'statemine',
-                Direction.SystemToPara,
-                registry,
-                2,
-                false,
-                true,
-            );
+			await checkAssetIdInput(
+				adjustedMockSystemApi,
+				['0'],
+				chainInfo,
+				'statemine',
+				Direction.SystemToPara,
+				registry,
+				2,
+				false,
+				true,
+			);
 
-            expect(registry.cacheLookupPoolAsset('0')).toEqual({
-                lpToken: '0',
-                pairInfo:
-                    '[{"parents":"0","interior":{"Here":""}},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"100"}]}}]',
-            });
-        });
-    });
+			expect(registry.cacheLookupPoolAsset('0')).toEqual({
+				lpToken: '0',
+				pairInfo:
+					'[{"parents":"0","interior":{"Here":""}},{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"100"}]}}]',
+			});
+		});
+	});
 });

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -1,10 +1,16 @@
-// Copyright 2024 Parity Technologies (UK) Ltd.
+// Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
 import { isHex } from '@polkadot/util';
 import { isEthereumAddress } from '@polkadot/util-crypto';
+import { isRelayNativeAsset } from '../createXcmTypes/util/isRelayNativeAsset';
 
-import { SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION, MAX_ASSETS_FOR_TRANSFER, RELAY_CHAINS_NATIVE_ASSET_LOCATION, RELAY_CHAIN_IDS } from '../consts';
+import {
+	MAX_ASSETS_FOR_TRANSFER,
+	RELAY_CHAIN_IDS,
+	RELAY_CHAINS_NATIVE_ASSET_LOCATION,
+	SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION,
+} from '../consts';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
 import { foreignAssetMultiLocationIsInCacheOrRegistry } from '../createXcmTypes/util/foreignAssetMultiLocationIsInCacheOrRegistry';
 import { foreignAssetsMultiLocationExists } from '../createXcmTypes/util/foreignAssetsMultiLocationExists';
@@ -18,7 +24,6 @@ import { AssetInfo, Direction } from '../types';
 import { validateNumber } from '../validate';
 import { BaseError, BaseErrorsEnum } from './BaseError';
 import type { CheckXcmTxInputsOpts } from './types';
-import { isRelayNativeAsset } from '../createXcmTypes/util/isRelayNativeAsset';
 
 /**
  * Ensure when sending tx's to or from the relay chain that the length of the assetIds array
@@ -27,12 +32,12 @@ import { isRelayNativeAsset } from '../createXcmTypes/util/isRelayNativeAsset';
  * @param assetIds
  */
 export const checkRelayAssetIdLength = (assetIds: string[]) => {
-    if (assetIds.length > 1) {
-        throw new BaseError(
-            "`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.",
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (assetIds.length > 1) {
+		throw new BaseError(
+			"`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.",
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -42,12 +47,12 @@ export const checkRelayAssetIdLength = (assetIds: string[]) => {
  * @param amounts
  */
 export const checkRelayAmountsLength = (amounts: string[]) => {
-    if (amounts.length !== 1) {
-        throw new BaseError(
-            '`amounts` should be of length 1 when sending to or from a relay chain',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (amounts.length !== 1) {
+		throw new BaseError(
+			'`amounts` should be of length 1 when sending to or from a relay chain',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -56,12 +61,12 @@ export const checkRelayAmountsLength = (amounts: string[]) => {
  * @param assetIds
  */
 export const checkParaPrimaryAssetAssetIdsLength = (assetIds: string[]) => {
-    if (assetIds.length > 1) {
-        throw new BaseError(
-            '`assetIds` should be of length 1 when sending a primary native parachain asset',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (assetIds.length > 1) {
+		throw new BaseError(
+			'`assetIds` should be of length 1 when sending a primary native parachain asset',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -71,12 +76,12 @@ export const checkParaPrimaryAssetAssetIdsLength = (assetIds: string[]) => {
  * @param amounts
  */
 export const checkParaPrimaryAssetAmountsLength = (amounts: string[]) => {
-    if (amounts.length !== 1) {
-        throw new BaseError(
-            '`amounts` should be of length 1 when sending a primary native parachain asset',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (amounts.length !== 1) {
+		throw new BaseError(
+			'`amounts` should be of length 1 when sending a primary native parachain asset',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -85,9 +90,9 @@ export const checkParaPrimaryAssetAmountsLength = (amounts: string[]) => {
  * @param assetIds
  */
 export const checkMultiLocationIdLength = (assetIds: string[]) => {
-    if (assetIds.length === 0) {
-        throw new BaseError('multilocation `assetIds` cannot be empty', BaseErrorsEnum.InvalidInput);
-    }
+	if (assetIds.length === 0) {
+		throw new BaseError('multilocation `assetIds` cannot be empty', BaseErrorsEnum.InvalidInput);
+	}
 };
 
 /**
@@ -96,9 +101,9 @@ export const checkMultiLocationIdLength = (assetIds: string[]) => {
  * @param amounts
  */
 export const checkMultiLocationAmountsLength = (amounts: string[]) => {
-    if (amounts.length === 0) {
-        throw new BaseError('multilocation `amounts` cannot be empty', BaseErrorsEnum.InvalidInput);
-    }
+	if (amounts.length === 0) {
+		throw new BaseError('multilocation `amounts` cannot be empty', BaseErrorsEnum.InvalidInput);
+	}
 };
 
 /**
@@ -108,16 +113,16 @@ export const checkMultiLocationAmountsLength = (amounts: string[]) => {
  * @param amounts
  */
 export const checkAssetsAmountMatch = (
-    assetIds: string[],
-    amounts: string[],
-    isParachainPrimaryNativeAsset?: boolean,
+	assetIds: string[],
+	amounts: string[],
+	isParachainPrimaryNativeAsset?: boolean,
 ) => {
-    if (!isParachainPrimaryNativeAsset && assetIds.length !== amounts.length) {
-        throw new BaseError(
-            '`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (!isParachainPrimaryNativeAsset && assetIds.length !== amounts.length) {
+		throw new BaseError(
+			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -127,16 +132,16 @@ export const checkAssetsAmountMatch = (
  * @param isForeignAssetsTransfer
  */
 export const CheckXTokensPalletOriginIsNonForeignAssetTx = (
-    xcmDirection: Direction,
-    xcmPallet: XcmPalletName,
-    isForeignAssetsTransfer: boolean,
+	xcmDirection: Direction,
+	xcmPallet: XcmPalletName,
+	isForeignAssetsTransfer: boolean,
 ) => {
-    if ((xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens) && isForeignAssetsTransfer) {
-        throw new BaseError(
-            `(${xcmDirection}) xTokens pallet does not support foreign asset transfers`,
-            BaseErrorsEnum.InvalidPallet,
-        );
-    }
+	if ((xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens) && isForeignAssetsTransfer) {
+		throw new BaseError(
+			`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`,
+			BaseErrorsEnum.InvalidPallet,
+		);
+	}
 };
 
 /**
@@ -146,10 +151,10 @@ export const CheckXTokensPalletOriginIsNonForeignAssetTx = (
  * @param assetId
  */
 const checkIfAssetIdIsBlankSpace = (assetId: string) => {
-    // check if assetId is a blank space, if it is, throw an error
-    if (assetId.length > 0 && assetId.trim() === '') {
-        throw new BaseError(`assetId cannot be blank spaces.`, BaseErrorsEnum.InvalidInput);
-    }
+	// check if assetId is a blank space, if it is, throw an error
+	if (assetId.length > 0 && assetId.trim() === '') {
+		throw new BaseError(`assetId cannot be blank spaces.`, BaseErrorsEnum.InvalidInput);
+	}
 };
 
 /**
@@ -160,20 +165,20 @@ const checkIfAssetIdIsBlankSpace = (assetId: string) => {
  * @returns boolean
  */
 export const containsNativeRelayAsset = (assetIds: string[], relayChainAsset: string): boolean => {
-    // We assume when the assetId's input is empty that the native token is to be transferred.
-    if (assetIds.length === 0) {
-        return true;
-    }
+	// We assume when the assetId's input is empty that the native token is to be transferred.
+	if (assetIds.length === 0) {
+		return true;
+	}
 
-    for (let i = 0; i < assetIds.length; i++) {
-        const assetId = assetIds[i];
+	for (let i = 0; i < assetIds.length; i++) {
+		const assetId = assetIds[i];
 
-        if (assetId.toLowerCase() === relayChainAsset.toLowerCase()) {
-            return true;
-        }
-    }
+		if (assetId.toLowerCase() === relayChainAsset.toLowerCase()) {
+			return true;
+		}
+	}
 
-    return false;
+	return false;
 };
 
 /**
@@ -184,15 +189,15 @@ export const containsNativeRelayAsset = (assetIds: string[], relayChainAsset: st
  * @param registry Registry
  */
 export const checkIfNativeRelayChainAssetPresentInMultiAssetIdList = (assetIds: string[], registry: Registry) => {
-    const relayChainID = RELAY_CHAIN_IDS[0];
-    const nativeRelayChainAsset = registry.currentRelayRegistry[relayChainID].tokens[0];
+	const relayChainID = RELAY_CHAIN_IDS[0];
+	const nativeRelayChainAsset = registry.currentRelayRegistry[relayChainID].tokens[0];
 
-    if (assetIds.length > 1 && containsNativeRelayAsset(assetIds, nativeRelayChainAsset)) {
-        throw new BaseError(
-            `Found the relay chains native asset in list [${assetIds.toString()}]. \`assetIds\` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.`,
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (assetIds.length > 1 && containsNativeRelayAsset(assetIds, nativeRelayChainAsset)) {
+		throw new BaseError(
+			`Found the relay chains native asset in list [${assetIds.toString()}]. \`assetIds\` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.`,
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -206,32 +211,32 @@ export const checkIfNativeRelayChainAssetPresentInMultiAssetIdList = (assetIds: 
  * @returns boolean
  */
 export const checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain = (
-    xcmDirection: Direction,
-    destChainId: string,
-    multiLocationAssetIds: string[],
+	xcmDirection: Direction,
+	destChainId: string,
+	multiLocationAssetIds: string[],
 ) => {
-    if (multiLocationAssetIds.length > 1) {
-        let foreignMultiLocationAssetFound = false;
-        let nativeMultiLocationAssetFound = false;
+	if (multiLocationAssetIds.length > 1) {
+		let foreignMultiLocationAssetFound = false;
+		let nativeMultiLocationAssetFound = false;
 
-        // iterate through list and determine if each asset is native to the dest parachain
-        for (const multilocation of multiLocationAssetIds) {
-            const isNativeToDestChain = multiLocationAssetIsParachainsNativeAsset(destChainId, multilocation);
+		// iterate through list and determine if each asset is native to the dest parachain
+		for (const multilocation of multiLocationAssetIds) {
+			const isNativeToDestChain = multiLocationAssetIsParachainsNativeAsset(destChainId, multilocation);
 
-            if (isNativeToDestChain) {
-                nativeMultiLocationAssetFound = true;
-            } else {
-                foreignMultiLocationAssetFound = true;
-            }
+			if (isNativeToDestChain) {
+				nativeMultiLocationAssetFound = true;
+			} else {
+				foreignMultiLocationAssetFound = true;
+			}
 
-            if (nativeMultiLocationAssetFound && foreignMultiLocationAssetFound) {
-                throw new BaseError(
-                    `(${xcmDirection}) found both foreign and native multilocations in ${multiLocationAssetIds.toString()}. multilocation XCMs must only include either native or foreign assets of the destination chain.`,
-                    BaseErrorsEnum.InvalidInput,
-                );
-            }
-        }
-    }
+			if (nativeMultiLocationAssetFound && foreignMultiLocationAssetFound) {
+				throw new BaseError(
+					`(${xcmDirection}) found both foreign and native multilocations in ${multiLocationAssetIds.toString()}. multilocation XCMs must only include either native or foreign assets of the destination chain.`,
+					BaseErrorsEnum.InvalidInput,
+				);
+			}
+		}
+	}
 };
 
 /**
@@ -241,23 +246,23 @@ export const checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain = (
  * @param relayChainInfo
  */
 const checkRelayToSystemAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>, registry: Registry) => {
-    const relayChainId = RELAY_CHAIN_IDS[0];
-    const relayChain = relayChainInfo[relayChainId];
-    const relayChainNativeAsset = relayChain.tokens[0];
+	const relayChainId = RELAY_CHAIN_IDS[0];
+	const relayChain = relayChainInfo[relayChainId];
+	const relayChainNativeAsset = relayChain.tokens[0];
 
-    // relay chain can only send its native asset
-    // ensure the asset being sent is the native asset of the relay chain
-    // no need to check if id is a number, if it is, it fails the check by default
+	// relay chain can only send its native asset
+	// ensure the asset being sent is the native asset of the relay chain
+	// no need to check if id is a number, if it is, it fails the check by default
 
-    // ensure assetId is relay chain's native token
-    let assetIsRelayChainNativeAsset = isRelayNativeAsset(registry, assetId);
+	// ensure assetId is relay chain's native token
+	const assetIsRelayChainNativeAsset = isRelayNativeAsset(registry, assetId);
 
-    if (!assetIsRelayChainNativeAsset) {
-        throw new BaseError(
-            `(RelayToSystem) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
-            BaseErrorsEnum.InvalidAsset,
-        );
-    }
+	if (!assetIsRelayChainNativeAsset) {
+		throw new BaseError(
+			`(RelayToSystem) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
+			BaseErrorsEnum.InvalidAsset,
+		);
+	}
 };
 
 /**
@@ -267,32 +272,32 @@ const checkRelayToSystemAssetId = (assetId: string, relayChainInfo: ChainInfo<Ch
  * @param relayChainInfo
  */
 const checkRelayToParaAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>) => {
-    const relayChainId = RELAY_CHAIN_IDS[0];
-    const relayChain = relayChainInfo[relayChainId];
-    const relayChainNativeAsset = relayChain.tokens[0];
+	const relayChainId = RELAY_CHAIN_IDS[0];
+	const relayChain = relayChainInfo[relayChainId];
+	const relayChainNativeAsset = relayChain.tokens[0];
 
-    // relay chain can only send its native asset
-    // ensure the asset being sent is the native asset of the relay chain
-    // no need to check if id is a number, if it is, it fails the check by default
-    let assetIsRelayChainNativeAsset = false;
+	// relay chain can only send its native asset
+	// ensure the asset being sent is the native asset of the relay chain
+	// no need to check if id is a number, if it is, it fails the check by default
+	let assetIsRelayChainNativeAsset = false;
 
-    // if an empty string is passed, treat it as the native relay asset
-    if (assetId === '') {
-        assetIsRelayChainNativeAsset = true;
-    }
+	// if an empty string is passed, treat it as the native relay asset
+	if (assetId === '') {
+		assetIsRelayChainNativeAsset = true;
+	}
 
-    if (typeof assetId === 'string') {
-        if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
-            assetIsRelayChainNativeAsset = true;
-        }
-    }
+	if (typeof assetId === 'string') {
+		if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
+			assetIsRelayChainNativeAsset = true;
+		}
+	}
 
-    if (!assetIsRelayChainNativeAsset) {
-        throw new BaseError(
-            `(RelayToPara) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
-            BaseErrorsEnum.InvalidAsset,
-        );
-    }
+	if (!assetIsRelayChainNativeAsset) {
+		throw new BaseError(
+			`(RelayToPara) asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`,
+			BaseErrorsEnum.InvalidAsset,
+		);
+	}
 };
 /**
  * This will check the given assetId and ensure that it is the native token of the relay chain
@@ -301,333 +306,333 @@ const checkRelayToParaAssetId = (assetId: string, relayChainInfo: ChainInfo<Chai
  * @param relayChainInfo
  */
 const checkSystemToRelayAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>, registry: Registry) => {
-    const relayChainId = RELAY_CHAIN_IDS[0];
-    const relayChain = relayChainInfo[relayChainId];
-    const relayChainNativeAsset = relayChain.tokens[0];
+	const relayChainId = RELAY_CHAIN_IDS[0];
+	const relayChain = relayChainInfo[relayChainId];
+	const relayChainNativeAsset = relayChain.tokens[0];
 
-    // ensure assetId is relay chain's native token
-    let matchedRelayChainNativeToken = isRelayNativeAsset(registry, assetId);
+	// ensure assetId is relay chain's native token
+	const matchedRelayChainNativeToken = isRelayNativeAsset(registry, assetId);
 
-    if (!matchedRelayChainNativeToken) {
-        throw new BaseError(
-            `(SystemToRelay) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION}`,
-            BaseErrorsEnum.InvalidAsset,
-        );
-    }
+	if (!matchedRelayChainNativeToken) {
+		throw new BaseError(
+			`(SystemToRelay) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION}`,
+			BaseErrorsEnum.InvalidAsset,
+		);
+	}
 };
 
 export const checkLiquidTokenValidity = async (
-    api: ApiPromise,
-    registry: Registry,
-    systemParachainInfo: ChainInfoKeys,
-    assetId: string,
+	api: ApiPromise,
+	registry: Registry,
+	systemParachainInfo: ChainInfoKeys,
+	assetId: string,
 ) => {
-    const isValidInt = validateNumber(assetId);
-    if (!isValidInt) {
-        throw new BaseError(`Liquid Tokens must be valid Integers`, BaseErrorsEnum.InvalidAsset);
-    }
+	const isValidInt = validateNumber(assetId);
+	if (!isValidInt) {
+		throw new BaseError(`Liquid Tokens must be valid Integers`, BaseErrorsEnum.InvalidAsset);
+	}
 
-    // check cache for pool asset
-    if (registry.cacheLookupPoolAsset(assetId)) {
-        return;
-    }
+	// check cache for pool asset
+	if (registry.cacheLookupPoolAsset(assetId)) {
+		return;
+	}
 
-    // check registry
-    const poolPairIds = Object.keys(systemParachainInfo.poolPairsInfo);
-    if (poolPairIds.includes(assetId)) {
-        return;
-    }
+	// check registry
+	const poolPairIds = Object.keys(systemParachainInfo.poolPairsInfo);
+	if (poolPairIds.includes(assetId)) {
+		return;
+	}
 
-    // query chain state
-    const poolAsset = await api.query.poolAssets.asset(assetId);
-    if (poolAsset.isSome) {
-        for (const poolPairsData of await api.query.assetConversion.pools.entries()) {
-            const poolAssetData = JSON.stringify(poolPairsData[0]).replace(/(\d),/g, '$1');
-            const poolAssetInfo = poolPairsData[1].unwrap();
+	// query chain state
+	const poolAsset = await api.query.poolAssets.asset(assetId);
+	if (poolAsset.isSome) {
+		for (const poolPairsData of await api.query.assetConversion.pools.entries()) {
+			const poolAssetData = JSON.stringify(poolPairsData[0]).replace(/(\d),/g, '$1');
+			const poolAssetInfo = poolPairsData[1].unwrap();
 
-            if (poolAssetInfo.lpToken.toString() === assetId) {
-                const asset: {
-                    lpToken: string;
-                    pairInfo: string;
-                } = {
-                    lpToken: assetId,
-                    pairInfo: poolAssetData,
-                };
+			if (poolAssetInfo.lpToken.toString() === assetId) {
+				const asset: {
+					lpToken: string;
+					pairInfo: string;
+				} = {
+					lpToken: assetId,
+					pairInfo: poolAssetData,
+				};
 
-                // cache the queried liquidToken asset
-                registry.setLiquidPoolTokenInCache(assetId, asset);
-            }
-        }
-        return;
-    }
+				// cache the queried liquidToken asset
+				registry.setLiquidPoolTokenInCache(assetId, asset);
+			}
+		}
+		return;
+	}
 
-    // liquid token not found in cache, registry or chain state
-    throw new BaseError(
-        `No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.`,
-        BaseErrorsEnum.InvalidAsset,
-    );
+	// liquid token not found in cache, registry or chain state
+	throw new BaseError(
+		`No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.`,
+		BaseErrorsEnum.InvalidAsset,
+	);
 };
 
 const checkSystemAssets = async (
-    api: ApiPromise,
-    assetId: string,
-    specName: string,
-    systemParachainInfo: ChainInfoKeys,
-    registry: Registry,
-    xcmDirection: string,
-    xcmVersion: number,
-    isForeignAssetsTransfer: boolean,
-    isLiquidTokenTransfer?: boolean,
+	api: ApiPromise,
+	assetId: string,
+	specName: string,
+	systemParachainInfo: ChainInfoKeys,
+	registry: Registry,
+	xcmDirection: string,
+	xcmVersion: number,
+	isForeignAssetsTransfer: boolean,
+	isLiquidTokenTransfer?: boolean,
 ) => {
-    const currentChainId = registry.lookupChainIdBySpecName(specName);
+	const currentChainId = registry.lookupChainIdBySpecName(specName);
 
-    if (isForeignAssetsTransfer) {
-        // check that the asset id is a valid multilocation
-        const multiLocationIsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(assetId, registry, xcmVersion);
+	if (isForeignAssetsTransfer) {
+		// check that the asset id is a valid multilocation
+		const multiLocationIsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(assetId, registry, xcmVersion);
 
-        if (!multiLocationIsInRegistry) {
-            const isValidForeignAsset = await foreignAssetsMultiLocationExists(api, registry, assetId);
+		if (!multiLocationIsInRegistry) {
+			const isValidForeignAsset = await foreignAssetsMultiLocationExists(api, registry, assetId);
 
-            if (!isValidForeignAsset) {
-                throw new BaseError(`MultiLocation ${assetId} not found`, BaseErrorsEnum.AssetNotFound);
-            }
-        }
-    } else if (isLiquidTokenTransfer) {
-        await checkLiquidTokenValidity(api, registry, systemParachainInfo, assetId);
-    } else {
-        const isValidInt = validateNumber(assetId);
+			if (!isValidForeignAsset) {
+				throw new BaseError(`MultiLocation ${assetId} not found`, BaseErrorsEnum.AssetNotFound);
+			}
+		}
+	} else if (isLiquidTokenTransfer) {
+		await checkLiquidTokenValidity(api, registry, systemParachainInfo, assetId);
+	} else {
+		const isValidInt = validateNumber(assetId);
 
-        if (isValidInt) {
-            let assetSymbol: string | undefined;
+		if (isValidInt) {
+			let assetSymbol: string | undefined;
 
-            // check the cache for the asset
-            // if not in cache, check the registry
-            if (registry.cacheLookupAsset(assetId)) {
-                assetSymbol = registry.cacheLookupAsset(assetId);
-            } else if (systemParachainInfo.assetsInfo[assetId]) {
-                assetSymbol = systemParachainInfo.assetsInfo[assetId];
-            }
+			// check the cache for the asset
+			// if not in cache, check the registry
+			if (registry.cacheLookupAsset(assetId)) {
+				assetSymbol = registry.cacheLookupAsset(assetId);
+			} else if (systemParachainInfo.assetsInfo[assetId]) {
+				assetSymbol = systemParachainInfo.assetsInfo[assetId];
+			}
 
-            if (!assetSymbol) {
-                // if asset is not in cache or registry, query the assets pallet to see if it has a value
-                const asset = await api.query.assets.asset(assetId);
+			if (!assetSymbol) {
+				// if asset is not in cache or registry, query the assets pallet to see if it has a value
+				const asset = await api.query.assets.asset(assetId);
 
-                // if asset is found in the assets pallet, return LocalTxType Assets
-                if (asset.isNone) {
-                    throw new BaseError(
-                        `(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
-                        BaseErrorsEnum.AssetNotFound,
-                    );
-                } else {
-                    const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
+				// if asset is found in the assets pallet, return LocalTxType Assets
+				if (asset.isNone) {
+					throw new BaseError(
+						`(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
+						BaseErrorsEnum.AssetNotFound,
+					);
+				} else {
+					const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
 
-                    const assetStr = assetSymbol as string;
-                    // add the asset to the cache
-                    registry.setAssetInCache(assetId, assetStr);
-                }
-            }
-        } else {
-            // not a valid number
-            // check if id is a valid token symbol of the system parachain chain
-            if (isRelayNativeAsset(registry, assetId)) {
-                return;
-            }
+					const assetStr = assetSymbol as string;
+					// add the asset to the cache
+					registry.setAssetInCache(assetId, assetStr);
+				}
+			}
+		} else {
+			// not a valid number
+			// check if id is a valid token symbol of the system parachain chain
+			if (assetId === '') {
+				return;
+			}
 
-            // ensure character string is valid symbol for the system chain
-            for (const token of systemParachainInfo.tokens) {
-                if (token.toLowerCase() === assetId.toLowerCase()) {
-                    return;
-                }
-            }
-            const cacheTokensMatched: AssetInfo[] = [];
-            // not found in tokens, check the cache
-            if (registry.cache[registry.relayChain][currentChainId]) {
-                for (const [id, symbol] of Object.entries(registry.cache[registry.relayChain][currentChainId].assetsInfo)) {
-                    if (symbol.toLowerCase() === assetId.toLowerCase()) {
-                        // match found in cache
-                        const assetInfo: AssetInfo = {
-                            id,
-                            symbol,
-                        };
-                        cacheTokensMatched.push(assetInfo);
-                    }
-                }
-            }
+			// ensure character string is valid symbol for the system chain
+			for (const token of systemParachainInfo.tokens) {
+				if (token.toLowerCase() === assetId.toLowerCase()) {
+					return;
+				}
+			}
+			const cacheTokensMatched: AssetInfo[] = [];
+			// not found in tokens, check the cache
+			if (registry.cache[registry.relayChain][currentChainId]) {
+				for (const [id, symbol] of Object.entries(registry.cache[registry.relayChain][currentChainId].assetsInfo)) {
+					if (symbol.toLowerCase() === assetId.toLowerCase()) {
+						// match found in cache
+						const assetInfo: AssetInfo = {
+							id,
+							symbol,
+						};
+						cacheTokensMatched.push(assetInfo);
+					}
+				}
+			}
 
-            // 1 valid match found in cache
-            if (cacheTokensMatched.length > 1) {
-                const assetMessageInfo = cacheTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
-                const message =
-                    `Multiple assets found with symbol ${assetId}::\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol`
-                        .trim()
-                        .replace(',', '\n');
+			// 1 valid match found in cache
+			if (cacheTokensMatched.length > 1) {
+				const assetMessageInfo = cacheTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
+				const message =
+					`Multiple assets found with symbol ${assetId}::\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol`
+						.trim()
+						.replace(',', '\n');
 
-                throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
-            } else if (cacheTokensMatched.length === 1) {
-                return;
-            }
+				throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
+			} else if (cacheTokensMatched.length === 1) {
+				return;
+			}
 
-            const assetsInfoTokensMatched: AssetInfo[] = [];
+			const assetsInfoTokensMatched: AssetInfo[] = [];
 
-            // if not found in system parachains tokens, or registry cache. Check assetsInfo
-            for (const [id, symbol] of Object.entries(systemParachainInfo.assetsInfo)) {
-                if (symbol.toLowerCase() === assetId.toLowerCase()) {
-                    const assetInfo: AssetInfo = {
-                        id,
-                        symbol,
-                    };
-                    assetsInfoTokensMatched.push(assetInfo);
-                }
-            }
+			// if not found in system parachains tokens, or registry cache. Check assetsInfo
+			for (const [id, symbol] of Object.entries(systemParachainInfo.assetsInfo)) {
+				if (symbol.toLowerCase() === assetId.toLowerCase()) {
+					const assetInfo: AssetInfo = {
+						id,
+						symbol,
+					};
+					assetsInfoTokensMatched.push(assetInfo);
+				}
+			}
 
-            // check if multiple matches found
-            // if more than 1 match is found throw an error and include details on the matched tokens
-            if (assetsInfoTokensMatched.length > 1) {
-                const assetMessageInfo = assetsInfoTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
-                const message =
-                    `Multiple assets found with symbol ${assetId}:\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol
-                `
-                        .trim()
-                        .replace(',', '\n');
+			// check if multiple matches found
+			// if more than 1 match is found throw an error and include details on the matched tokens
+			if (assetsInfoTokensMatched.length > 1) {
+				const assetMessageInfo = assetsInfoTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
+				const message =
+					`Multiple assets found with symbol ${assetId}:\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol
+				`
+						.trim()
+						.replace(',', '\n');
 
-                throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
-            } else if (assetsInfoTokensMatched.length === 1) {
-                return;
-            }
+				throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
+			} else if (assetsInfoTokensMatched.length === 1) {
+				return;
+			}
 
-            // if no native token for the system parachain was matched, throw an error
-            throw new BaseError(
-                `(${xcmDirection}) assetId ${assetId} not found for system parachain ${specName}`,
-                BaseErrorsEnum.AssetNotFound,
-            );
-        }
-    }
+			// if no native token for the system parachain was matched, throw an error
+			throw new BaseError(
+				`(${xcmDirection}) assetId ${assetId} not found for system parachain ${specName}`,
+				BaseErrorsEnum.AssetNotFound,
+			);
+		}
+	}
 };
 
 export const checkParaAssets = async (
-    api: ApiPromise,
-    assetId: string,
-    specName: string,
-    registry: Registry,
-    xcmDirection: Direction,
+	api: ApiPromise,
+	assetId: string,
+	specName: string,
+	registry: Registry,
+	xcmDirection: Direction,
 ) => {
-    if (isParachainPrimaryNativeAsset(registry, specName, xcmDirection, assetId)) {
-        return;
-    }
+	if (isParachainPrimaryNativeAsset(registry, specName, xcmDirection, assetId)) {
+		return;
+	}
 
-    const currentRelayChainSpecName = registry.relayChain;
-    const isValidInt = validateNumber(assetId);
-    const paraId = registry.lookupChainIdBySpecName(specName);
-    if (api.query.assets) {
-        if (isValidInt) {
-            if (!registry.cacheLookupAsset(assetId)) {
-                // query the parachains assets pallet to see if it has a value matching the assetId
-                const asset = await api.query.assets.asset(assetId);
+	const currentRelayChainSpecName = registry.relayChain;
+	const isValidInt = validateNumber(assetId);
+	const paraId = registry.lookupChainIdBySpecName(specName);
+	if (api.query.assets) {
+		if (isValidInt) {
+			if (!registry.cacheLookupAsset(assetId)) {
+				// query the parachains assets pallet to see if it has a value matching the assetId
+				const asset = await api.query.assets.asset(assetId);
 
-                if (asset.isNone) {
-                    throw new BaseError(
-                        `(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
-                        BaseErrorsEnum.AssetNotFound,
-                    );
-                } else {
-                    const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
-                    const assetSymbolStr = assetSymbol as string;
-                    // store xcAsset in registry cache
-                    registry.setAssetInCache(assetId, assetSymbolStr);
-                }
-            }
+				if (asset.isNone) {
+					throw new BaseError(
+						`(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
+						BaseErrorsEnum.AssetNotFound,
+					);
+				} else {
+					const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
+					const assetSymbolStr = assetSymbol as string;
+					// store xcAsset in registry cache
+					registry.setAssetInCache(assetId, assetSymbolStr);
+				}
+			}
 
-            // Below checks when the asset exists on chain but not in our xcAssets registry.
-            const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
+			// Below checks when the asset exists on chain but not in our xcAssets registry.
+			const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
 
-            if (!paraXcAssets || paraXcAssets.length === 0) {
-                throw new BaseError(
-                    `unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
-                    BaseErrorsEnum.InvalidPallet,
-                );
-            }
+			if (!paraXcAssets || paraXcAssets.length === 0) {
+				throw new BaseError(
+					`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
+					BaseErrorsEnum.InvalidPallet,
+				);
+			}
 
-            for (const info of paraXcAssets) {
-                if (typeof info.asset === 'string' && info.asset === assetId) {
-                    return;
-                }
-            }
+			for (const info of paraXcAssets) {
+				if (typeof info.asset === 'string' && info.asset === assetId) {
+					return;
+				}
+			}
 
-            throw new BaseError(`unable to identify xcAsset with ID ${assetId}`, BaseErrorsEnum.AssetNotFound);
-        } else {
-            // not a valid number
-            // check if id is a valid token symbol of the parachain chain
-            const parachainAssets = await api.query.assets.asset.entries();
+			throw new BaseError(`unable to identify xcAsset with ID ${assetId}`, BaseErrorsEnum.AssetNotFound);
+		} else {
+			// not a valid number
+			// check if id is a valid token symbol of the parachain chain
+			const parachainAssets = await api.query.assets.asset.entries();
 
-            for (let i = 0; i < parachainAssets.length; i++) {
-                const parachainAsset = parachainAssets[i];
-                const id = parachainAsset[0].args[0];
+			for (let i = 0; i < parachainAssets.length; i++) {
+				const parachainAsset = parachainAssets[i];
+				const id = parachainAsset[0].args[0];
 
-                const metadata = await api.query.assets.metadata(id);
-                const symbol = metadata.symbol.toHuman()?.toString();
-                if (symbol && symbol.toLowerCase() === assetId.toLowerCase()) {
-                    // store in registry cache
-                    registry.setAssetInCache(symbol, id.toString());
-                    return;
-                }
-            }
+				const metadata = await api.query.assets.metadata(id);
+				const symbol = metadata.symbol.toHuman()?.toString();
+				if (symbol && symbol.toLowerCase() === assetId.toLowerCase()) {
+					// store in registry cache
+					registry.setAssetInCache(symbol, id.toString());
+					return;
+				}
+			}
 
-            // not an asset native to the Parachain
-            // check xcAsset registry for the symbol
-            const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
+			// not an asset native to the Parachain
+			// check xcAsset registry for the symbol
+			const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
 
-            if (!paraXcAssets || paraXcAssets.length === 0) {
-                throw new BaseError(
-                    `unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
-                    BaseErrorsEnum.InvalidPallet,
-                );
-            }
+			if (!paraXcAssets || paraXcAssets.length === 0) {
+				throw new BaseError(
+					`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
+					BaseErrorsEnum.InvalidPallet,
+				);
+			}
 
-            for (const info of paraXcAssets) {
-                if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
-                    return;
-                }
-            }
+			for (const info of paraXcAssets) {
+				if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
+					return;
+				}
+			}
 
-            // if no native token for the parachain was matched, throw an error
-            throw new BaseError(
-                `(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
-                BaseErrorsEnum.AssetNotFound,
-            );
-        }
-    } else {
-        // Parachain doesn't support pallet assets
-        // check for assetId in registry
-        const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
+			// if no native token for the parachain was matched, throw an error
+			throw new BaseError(
+				`(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
+				BaseErrorsEnum.AssetNotFound,
+			);
+		}
+	} else {
+		// Parachain doesn't support pallet assets
+		// check for assetId in registry
+		const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
 
-        if (!paraXcAssets || paraXcAssets.length === 0) {
-            throw new BaseError(
-                `unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
-                BaseErrorsEnum.InvalidPallet,
-            );
-        }
-        // if integer asset Id check if valid registry asset
-        if (isValidInt) {
-            for (const info of paraXcAssets) {
-                if (typeof info.asset === 'string' && info.asset.toLowerCase() === assetId.toLowerCase()) {
-                    return;
-                }
-            }
-        } else {
-            // check for assetId symbol match
-            for (const info of paraXcAssets) {
-                if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
-                    return;
-                }
-            }
-        }
+		if (!paraXcAssets || paraXcAssets.length === 0) {
+			throw new BaseError(
+				`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
+				BaseErrorsEnum.InvalidPallet,
+			);
+		}
+		// if integer asset Id check if valid registry asset
+		if (isValidInt) {
+			for (const info of paraXcAssets) {
+				if (typeof info.asset === 'string' && info.asset.toLowerCase() === assetId.toLowerCase()) {
+					return;
+				}
+			}
+		} else {
+			// check for assetId symbol match
+			for (const info of paraXcAssets) {
+				if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
+					return;
+				}
+			}
+		}
 
-        // if no native token for the parachain was matched, throw an error
-        throw new BaseError(
-            `(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
-            BaseErrorsEnum.AssetNotFound,
-        );
-    }
+		// if no native token for the parachain was matched, throw an error
+		throw new BaseError(
+			`(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
+			BaseErrorsEnum.AssetNotFound,
+		);
+	}
 };
 
 /**
@@ -638,56 +643,56 @@ export const checkParaAssets = async (
  * @param relayChainInfo
  */
 const checkSystemToParaAssetId = async (
-    api: ApiPromise,
-    assetId: string,
-    specName: string,
-    relayChainInfo: ChainInfo<ChainInfoKeys>,
-    registry: Registry,
-    xcmDirection: Direction,
-    xcmVersion: number,
-    isForeignAssetsTransfer: boolean,
-    isLiquidTokenTransfer: boolean,
+	api: ApiPromise,
+	assetId: string,
+	specName: string,
+	relayChainInfo: ChainInfo<ChainInfoKeys>,
+	registry: Registry,
+	xcmDirection: Direction,
+	xcmVersion: number,
+	isForeignAssetsTransfer: boolean,
+	isLiquidTokenTransfer: boolean,
 ) => {
-    await checkIsValidSystemChainAssetId(
-        api,
-        assetId,
-        specName,
-        relayChainInfo,
-        registry,
-        xcmDirection,
-        xcmVersion,
-        isForeignAssetsTransfer,
-        isLiquidTokenTransfer,
-    );
+	await checkIsValidSystemChainAssetId(
+		api,
+		assetId,
+		specName,
+		relayChainInfo,
+		registry,
+		xcmDirection,
+		xcmVersion,
+		isForeignAssetsTransfer,
+		isLiquidTokenTransfer,
+	);
 };
 
 export const checkIsValidSystemChainAssetId = async (
-    api: ApiPromise,
-    assetId: string,
-    specName: string,
-    relayChainInfo: ChainInfo<ChainInfoKeys>,
-    registry: Registry,
-    xcmDirection: Direction,
-    xcmVersion: number,
-    isForeignAssetsTransfer: boolean,
-    isLiquidTokenTransfer: boolean,
+	api: ApiPromise,
+	assetId: string,
+	specName: string,
+	relayChainInfo: ChainInfo<ChainInfoKeys>,
+	registry: Registry,
+	xcmDirection: Direction,
+	xcmVersion: number,
+	isForeignAssetsTransfer: boolean,
+	isLiquidTokenTransfer: boolean,
 ) => {
-    const systemChainId = registry.lookupChainIdBySpecName(specName);
-    const systemParachainInfo = relayChainInfo[systemChainId];
+	const systemChainId = registry.lookupChainIdBySpecName(specName);
+	const systemParachainInfo = relayChainInfo[systemChainId];
 
-    if (typeof assetId === 'string') {
-        await checkSystemAssets(
-            api,
-            assetId,
-            specName,
-            systemParachainInfo,
-            registry,
-            xcmDirection,
-            xcmVersion,
-            isForeignAssetsTransfer,
-            isLiquidTokenTransfer,
-        );
-    }
+	if (typeof assetId === 'string') {
+		await checkSystemAssets(
+			api,
+			assetId,
+			specName,
+			systemParachainInfo,
+			registry,
+			xcmDirection,
+			xcmVersion,
+			isForeignAssetsTransfer,
+			isLiquidTokenTransfer,
+		);
+	}
 };
 
 /**
@@ -697,23 +702,23 @@ export const checkIsValidSystemChainAssetId = async (
  * @param registry
  */
 const checkParaOriginAssetId = async (api: ApiPromise, assetId: string, specName: string, registry: Registry) => {
-    if (typeof assetId === 'string') {
-        // An assetId may be a hex value to represent a GeneralKey for erc20 tokens.
-        // These will be represented as Foreign Assets in regard to its MultiLocation
-        if (isHex(assetId)) {
-            const ethAddr = isEthereumAddress(assetId);
-            if (!ethAddr) {
-                throw new BaseError(
-                    `(ParaToSystem) assetId ${assetId}, is not a valid erc20 token.`,
-                    BaseErrorsEnum.InvalidAsset,
-                );
-            }
+	if (typeof assetId === 'string') {
+		// An assetId may be a hex value to represent a GeneralKey for erc20 tokens.
+		// These will be represented as Foreign Assets in regard to its MultiLocation
+		if (isHex(assetId)) {
+			const ethAddr = isEthereumAddress(assetId);
+			if (!ethAddr) {
+				throw new BaseError(
+					`(ParaToSystem) assetId ${assetId}, is not a valid erc20 token.`,
+					BaseErrorsEnum.InvalidAsset,
+				);
+			}
 
-            return;
-        }
+			return;
+		}
 
-        await checkParaAssets(api, assetId, specName, registry, Direction.ParaToSystem);
-    }
+		await checkParaAssets(api, assetId, specName, registry, Direction.ParaToSystem);
+	}
 };
 
 /**
@@ -723,27 +728,27 @@ const checkParaOriginAssetId = async (api: ApiPromise, assetId: string, specName
  * @param relayChainInfo
  */
 const checkSystemToSystemAssetId = async (
-    api: ApiPromise,
-    assetId: string,
-    specName: string,
-    relayChainInfo: ChainInfo<ChainInfoKeys>,
-    registry: Registry,
-    xcmDirection: Direction,
-    xcmVersion: number,
-    isForeignAssetsTransfer: boolean,
-    isLiquidTokenTransfer: boolean,
+	api: ApiPromise,
+	assetId: string,
+	specName: string,
+	relayChainInfo: ChainInfo<ChainInfoKeys>,
+	registry: Registry,
+	xcmDirection: Direction,
+	xcmVersion: number,
+	isForeignAssetsTransfer: boolean,
+	isLiquidTokenTransfer: boolean,
 ) => {
-    await checkIsValidSystemChainAssetId(
-        api,
-        assetId,
-        specName,
-        relayChainInfo,
-        registry,
-        xcmDirection,
-        xcmVersion,
-        isForeignAssetsTransfer,
-        isLiquidTokenTransfer,
-    );
+	await checkIsValidSystemChainAssetId(
+		api,
+		assetId,
+		specName,
+		relayChainInfo,
+		registry,
+		xcmDirection,
+		xcmVersion,
+		isForeignAssetsTransfer,
+		isLiquidTokenTransfer,
+	);
 };
 
 /**
@@ -754,45 +759,45 @@ const checkSystemToSystemAssetId = async (
  * @param specName
  */
 const checkParaToRelayAssetId = (assetId: string, registry: Registry, specName: string) => {
-    const relayRegistry = registry.currentRelayRegistry;
-    const relayNativeToken = relayRegistry[0].tokens[0];
-    const nativeEqAssetId = relayNativeToken === assetId;
-    const curParaId = registry.lookupChainIdBySpecName(specName);
-    const curParaRegistry = relayRegistry[curParaId];
-    const { xcAssetsData } = curParaRegistry;
+	const relayRegistry = registry.currentRelayRegistry;
+	const relayNativeToken = relayRegistry[0].tokens[0];
+	const nativeEqAssetId = relayNativeToken === assetId;
+	const curParaId = registry.lookupChainIdBySpecName(specName);
+	const curParaRegistry = relayRegistry[curParaId];
+	const { xcAssetsData } = curParaRegistry;
 
-    let assetIsRelayChainNativeAsset = false;
-    if (assetId === '') {
-        assetIsRelayChainNativeAsset = true;
-    }
+	let assetIsRelayChainNativeAsset = false;
+	if (assetId === '') {
+		assetIsRelayChainNativeAsset = true;
+	}
 
-    // If the asset equals the relays native asset exit.
-    if (nativeEqAssetId) {
-        assetIsRelayChainNativeAsset = true;
-    }
+	// If the asset equals the relays native asset exit.
+	if (nativeEqAssetId) {
+		assetIsRelayChainNativeAsset = true;
+	}
 
-    const isValidInt = validateNumber(assetId);
-    if (isValidInt && xcAssetsData && xcAssetsData.length > 0) {
-        // We assume the first xcAsset will represent the relay chain
-        // since they are all sorted in the registry.
-        if (xcAssetsData[0].asset === assetId) {
-            assetIsRelayChainNativeAsset = true;
-        }
-    }
+	const isValidInt = validateNumber(assetId);
+	if (isValidInt && xcAssetsData && xcAssetsData.length > 0) {
+		// We assume the first xcAsset will represent the relay chain
+		// since they are all sorted in the registry.
+		if (xcAssetsData[0].asset === assetId) {
+			assetIsRelayChainNativeAsset = true;
+		}
+	}
 
-    const paraIncludesRelayNativeInTokens = curParaRegistry.tokens.includes(relayNativeToken);
-    const paraIncludesRelayNativeInXcAssets = xcAssetsData && xcAssetsData[0].symbol === relayNativeToken;
+	const paraIncludesRelayNativeInTokens = curParaRegistry.tokens.includes(relayNativeToken);
+	const paraIncludesRelayNativeInXcAssets = xcAssetsData && xcAssetsData[0].symbol === relayNativeToken;
 
-    if (paraIncludesRelayNativeInTokens || paraIncludesRelayNativeInXcAssets) {
-        assetIsRelayChainNativeAsset = true;
-    }
+	if (paraIncludesRelayNativeInTokens || paraIncludesRelayNativeInXcAssets) {
+		assetIsRelayChainNativeAsset = true;
+	}
 
-    if (!assetIsRelayChainNativeAsset) {
-        throw new BaseError(
-            "The current input for assetId's does not meet our specifications for ParaToRelay transfers.",
-            BaseErrorsEnum.InvalidAsset,
-        );
-    }
+	if (!assetIsRelayChainNativeAsset) {
+		throw new BaseError(
+			"The current input for assetId's does not meet our specifications for ParaToRelay transfers.",
+			BaseErrorsEnum.InvalidAsset,
+		);
+	}
 };
 
 /**
@@ -801,27 +806,27 @@ const checkParaToRelayAssetId = (assetId: string, registry: Registry, specName: 
  * @param assetIds
  */
 export const checkAssetIdsLengthIsValid = (
-    assetIds: string[],
-    xcmPalletName: XcmPalletName,
-    assetTransferType: string | undefined,
+	assetIds: string[],
+	xcmPalletName: XcmPalletName,
+	assetTransferType: string | undefined,
 ) => {
-    if (assetIds.length > MAX_ASSETS_FOR_TRANSFER) {
-        throw new BaseError(
-            `Maximum number of assets allowed for transfer is 2. Found ${assetIds.length} assetIds`,
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (assetIds.length > MAX_ASSETS_FOR_TRANSFER) {
+		throw new BaseError(
+			`Maximum number of assets allowed for transfer is 2. Found ${assetIds.length} assetIds`,
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 
-    if (
-        assetIds.length > 1 &&
-        !assetTransferType &&
-        (xcmPalletName === XcmPalletName.polkadotXcm || xcmPalletName === XcmPalletName.xcmPallet)
-    ) {
-        throw new BaseError(
-            `transferAssets transactions cannot contain more than 1 asset location id. Found ${assetIds.length} assetIds`,
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (
+		assetIds.length > 1 &&
+		!assetTransferType &&
+		(xcmPalletName === XcmPalletName.polkadotXcm || xcmPalletName === XcmPalletName.xcmPallet)
+	) {
+		throw new BaseError(
+			`transferAssets transactions cannot contain more than 1 asset location id. Found ${assetIds.length} assetIds`,
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -830,38 +835,38 @@ export const checkAssetIdsLengthIsValid = (
  * @param assetIds
  */
 export const checkAssetIdsHaveNoDuplicates = (assetIds: string[]) => {
-    const duplicateAssetIds: string[] = [];
+	const duplicateAssetIds: string[] = [];
 
-    if (assetIds.length > 1) {
-        for (let i = 0; i < assetIds.length; i++) {
-            const asset1 = assetIds[i];
+	if (assetIds.length > 1) {
+		for (let i = 0; i < assetIds.length; i++) {
+			const asset1 = assetIds[i];
 
-            for (let j = 0; j < assetIds.length; j++) {
-                if (i === j) {
-                    continue;
-                }
+			for (let j = 0; j < assetIds.length; j++) {
+				if (i === j) {
+					continue;
+				}
 
-                const asset2 = assetIds[j];
-                if (asset1.trim().toLowerCase().replace(/ /g, '') === asset2.trim().toLowerCase().replace(/ /g, '')) {
-                    duplicateAssetIds.push(asset2);
-                }
-            }
-        }
+				const asset2 = assetIds[j];
+				if (asset1.trim().toLowerCase().replace(/ /g, '') === asset2.trim().toLowerCase().replace(/ /g, '')) {
+					duplicateAssetIds.push(asset2);
+				}
+			}
+		}
 
-        if (duplicateAssetIds.length > 0) {
-            if (assetIds[0] === '') {
-                throw new BaseError(
-                    `AssetIds must be unique. Found duplicate native relay assets as empty strings`,
-                    BaseErrorsEnum.InvalidInput,
-                );
-            }
+		if (duplicateAssetIds.length > 0) {
+			if (assetIds[0] === '') {
+				throw new BaseError(
+					`AssetIds must be unique. Found duplicate native relay assets as empty strings`,
+					BaseErrorsEnum.InvalidInput,
+				);
+			}
 
-            throw new BaseError(
-                `AssetIds must be unique. Found duplicate assetId ${duplicateAssetIds[0]}`,
-                BaseErrorsEnum.InvalidInput,
-            );
-        }
-    }
+			throw new BaseError(
+				`AssetIds must be unique. Found duplicate assetId ${duplicateAssetIds[0]}`,
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
+	}
 };
 
 /**
@@ -870,68 +875,65 @@ export const checkAssetIdsHaveNoDuplicates = (assetIds: string[]) => {
  * @param assetIds
  */
 export const checkAssetIdsAreOfSameAssetIdType = (assetIds: string[]) => {
-    if (assetIds.length > 1) {
-        let relayDefaultValueFound = false;
-        let symbolAssetIdFound = '';
-        let integerAssetIdFound = '';
-        let multiLocationAssetIdFound = '';
+	if (assetIds.length > 1) {
+		let relayDefaultValueFound = false;
+		let symbolAssetIdFound = '';
+		let integerAssetIdFound = '';
+		let multiLocationAssetIdFound = '';
 
-        for (const assetId of assetIds) {
-            if (assetId === '') {
-                relayDefaultValueFound = true;
-                continue;
-            }
+		for (const assetId of assetIds) {
+			if (assetId === '') {
+				relayDefaultValueFound = true;
+				continue;
+			}
 
-            const isValidInt = validateNumber(assetId);
-            if (isValidInt) {
-                integerAssetIdFound = assetId;
-            } else if (assetId.toLowerCase().includes('parents')) {
-                multiLocationAssetIdFound = assetId;
-            } else {
-                symbolAssetIdFound = assetId;
-            }
-        }
+			const isValidInt = validateNumber(assetId);
+			if (isValidInt) {
+				integerAssetIdFound = assetId;
+			} else if (assetId.toLowerCase().includes('parents')) {
+				multiLocationAssetIdFound = assetId;
+			} else {
+				symbolAssetIdFound = assetId;
+			}
+		}
 
-        if (relayDefaultValueFound && multiLocationAssetIdFound) {
-            throw new BaseError(
-                `Found both default relay native asset and foreign asset with assetId: ${multiLocationAssetIdFound}. Relay native asset and foreign assets can't be transferred within the same call.`,
-                BaseErrorsEnum.InvalidInput,
-            );
-        }
+		if (relayDefaultValueFound && multiLocationAssetIdFound) {
+			throw new BaseError(
+				`Found both default relay native asset and foreign asset with assetId: ${multiLocationAssetIdFound}. Relay native asset and foreign assets can't be transferred within the same call.`,
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
 
-        if (integerAssetIdFound && multiLocationAssetIdFound) {
-            throw new BaseError(
-                `Found both native asset with assetID ${integerAssetIdFound} and foreign asset with assetId ${multiLocationAssetIdFound}. Native assets and foreign assets can't be transferred within the same call.`,
-                BaseErrorsEnum.InvalidInput,
-            );
-        }
+		if (integerAssetIdFound && multiLocationAssetIdFound) {
+			throw new BaseError(
+				`Found both native asset with assetID ${integerAssetIdFound} and foreign asset with assetId ${multiLocationAssetIdFound}. Native assets and foreign assets can't be transferred within the same call.`,
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
 
-        if (symbolAssetIdFound && multiLocationAssetIdFound) {
-            throw new BaseError(
-                `Found both symbol ${symbolAssetIdFound} and multilocation assetId ${multiLocationAssetIdFound}. Asset Ids must be symbol and integer or multilocation exclusively.`,
-                BaseErrorsEnum.InvalidInput,
-            );
-        }
-    }
+		if (symbolAssetIdFound && multiLocationAssetIdFound) {
+			throw new BaseError(
+				`Found both symbol ${symbolAssetIdFound} and multilocation assetId ${multiLocationAssetIdFound}. Asset Ids must be symbol and integer or multilocation exclusively.`,
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
+	}
 };
 
 /**
- * Checks to ensure that the xcmVersion is at least 3 for a SystemToBridge transaction
+ * Checks to ensure that the xcmVersion is at least 3 for Bridge transactions
  *
  * @param xcmDirection
  * @param xcmVersion
  */
-export const checkXcmVersionIsValidForSystemToBridge = (xcmVersion: number) => {
-    if (xcmVersion && xcmVersion < 3) {
-        throw new BaseError(
-            'SystemToBridge transactions require XCM version 3 or greater',
-            BaseErrorsEnum.InvalidXcmVersion,
-        );
-    }
+export const checkXcmVersionIsValidForBridgeTx = (xcmVersion: number) => {
+	if (xcmVersion && xcmVersion < 3) {
+		throw new BaseError('Bridge transactions require XCM version 3 or greater', BaseErrorsEnum.InvalidXcmVersion);
+	}
 };
 
 /**
- * Checks to ensure that required inputs are provided for SystemToBridge transactions
+ * Checks to ensure that required inputs are provided for Bridge transactions
  *
  * @param paysWithFeeDest
  * @param assetTransferType
@@ -939,43 +941,43 @@ export const checkXcmVersionIsValidForSystemToBridge = (xcmVersion: number) => {
  * @param feesTransferType
  * @param remoteReserveFeesTransferTypeLocation
  */
-export const checkSystemToBridgeInputs = (
-    paysWithFeeDest: string | undefined,
-    assetTransferType: string | undefined,
-    remoteReserveAssetTransferTypeLocation: string | undefined,
-    feesTransferType: string | undefined,
-    remoteReserveFeesTransferTypeLocation: string | undefined,
+export const checkBridgeTxInputs = (
+	paysWithFeeDest: string | undefined,
+	assetTransferType: string | undefined,
+	remoteReserveAssetTransferTypeLocation: string | undefined,
+	feesTransferType: string | undefined,
+	remoteReserveFeesTransferTypeLocation: string | undefined,
 ) => {
-    if (assetTransferType && !paysWithFeeDest) {
-        throw new BaseError(
-            'paysWithFeeDest input is required for bridge transactions when assetTransferType is provided',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
-    if (assetTransferType && assetTransferType === 'RemoteReserve' && !remoteReserveAssetTransferTypeLocation) {
-        throw new BaseError(
-            'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
-    if (feesTransferType && feesTransferType === 'RemoteReserve' && !remoteReserveFeesTransferTypeLocation) {
-        throw new BaseError(
-            'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (assetTransferType && !paysWithFeeDest) {
+		throw new BaseError(
+			'paysWithFeeDest input is required for bridge transactions when assetTransferType is provided',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
+	if (assetTransferType && assetTransferType === 'RemoteReserve' && !remoteReserveAssetTransferTypeLocation) {
+		throw new BaseError(
+			'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
+	if (feesTransferType && feesTransferType === 'RemoteReserve' && !remoteReserveFeesTransferTypeLocation) {
+		throw new BaseError(
+			'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 export const checkPaysWithFeeDestAssetIdIsInAssets = (assetIds: string[], paysWithFeeDest: string | undefined) => {
-    if (!paysWithFeeDest) {
-        return;
-    }
+	if (!paysWithFeeDest) {
+		return;
+	}
 
-    if (!assetIds.includes(paysWithFeeDest)) {
-        throw new BaseError(
-            `paysWithFeeDest asset must be present in assets to be transferred. Did not find ${paysWithFeeDest} in ${assetIds.toString()}`,
-        );
-    }
+	if (!assetIds.includes(paysWithFeeDest)) {
+		throw new BaseError(
+			`paysWithFeeDest asset must be present in assets to be transferred. Did not find ${paysWithFeeDest} in ${assetIds.toString()}`,
+		);
+	}
 };
 
 /**
@@ -985,19 +987,19 @@ export const checkPaysWithFeeDestAssetIdIsInAssets = (assetIds: string[], paysWi
  * @param paysWithFeeDest
  */
 export const checkXcmVersionIsValidForPaysWithFeeDest = (
-    xcmDirection: Direction,
-    xcmVersion?: number,
-    paysWithFeeDest?: string,
+	xcmDirection: Direction,
+	xcmVersion?: number,
+	paysWithFeeDest?: string,
 ) => {
-    if (
-        xcmDirection != Direction.ParaToSystem &&
-        xcmDirection != Direction.ParaToPara &&
-        paysWithFeeDest &&
-        xcmVersion &&
-        xcmVersion < 3
-    ) {
-        throw new BaseError('paysWithFeeDest requires XCM version 3 or greater', BaseErrorsEnum.InvalidXcmVersion);
-    }
+	if (
+		xcmDirection != Direction.ParaToSystem &&
+		xcmDirection != Direction.ParaToPara &&
+		paysWithFeeDest &&
+		xcmVersion &&
+		xcmVersion < 3
+	) {
+		throw new BaseError('paysWithFeeDest requires XCM version 3 or greater', BaseErrorsEnum.InvalidXcmVersion);
+	}
 };
 
 /**
@@ -1007,12 +1009,12 @@ export const checkXcmVersionIsValidForPaysWithFeeDest = (
  * @param isLiquidTokenTransfer
  */
 export const checkLiquidTokenTransferDirectionValidity = (xcmDirection: Direction, isLiquidTokenTransfer: boolean) => {
-    if (xcmDirection !== Direction.SystemToPara && isLiquidTokenTransfer) {
-        throw new BaseError(
-            `isLiquidTokenTransfer may not be true for the xcmDirection: ${xcmDirection}.`,
-            BaseErrorsEnum.InvalidInput,
-        );
-    }
+	if (xcmDirection !== Direction.SystemToPara && isLiquidTokenTransfer) {
+		throw new BaseError(
+			`isLiquidTokenTransfer may not be true for the xcmDirection: ${xcmDirection}.`,
+			BaseErrorsEnum.InvalidInput,
+		);
+	}
 };
 
 /**
@@ -1026,69 +1028,69 @@ export const checkLiquidTokenTransferDirectionValidity = (xcmDirection: Directio
  * @param registry
  */
 export const checkAssetIdInput = async (
-    api: ApiPromise,
-    assetIds: string[],
-    relayChainInfo: ChainInfo<ChainInfoKeys>,
-    specName: string,
-    xcmDirection: Direction,
-    registry: Registry,
-    xcmVersion: number,
-    isForeignAssetsTransfer: boolean,
-    isLiquidTokenTransfer: boolean,
+	api: ApiPromise,
+	assetIds: string[],
+	relayChainInfo: ChainInfo<ChainInfoKeys>,
+	specName: string,
+	xcmDirection: Direction,
+	registry: Registry,
+	xcmVersion: number,
+	isForeignAssetsTransfer: boolean,
+	isLiquidTokenTransfer: boolean,
 ) => {
-    for (let i = 0; i < assetIds.length; i++) {
-        const assetId = assetIds[i];
+	for (let i = 0; i < assetIds.length; i++) {
+		const assetId = assetIds[i];
 
-        checkIfAssetIdIsBlankSpace(assetId);
+		checkIfAssetIdIsBlankSpace(assetId);
 
-        if (xcmDirection === Direction.RelayToSystem) {
-            checkRelayToSystemAssetId(assetId, relayChainInfo, registry);
-        }
+		if (xcmDirection === Direction.RelayToSystem) {
+			checkRelayToSystemAssetId(assetId, relayChainInfo, registry);
+		}
 
-        if (xcmDirection === Direction.RelayToPara) {
-            checkRelayToParaAssetId(assetId, relayChainInfo);
-        }
+		if (xcmDirection === Direction.RelayToPara) {
+			checkRelayToParaAssetId(assetId, relayChainInfo);
+		}
 
-        if (xcmDirection === Direction.SystemToRelay) {
-            checkSystemToRelayAssetId(assetId, relayChainInfo, registry);
-        }
+		if (xcmDirection === Direction.SystemToRelay) {
+			checkSystemToRelayAssetId(assetId, relayChainInfo, registry);
+		}
 
-        if (xcmDirection === Direction.SystemToPara) {
-            await checkSystemToParaAssetId(
-                api,
-                assetId,
-                specName,
-                relayChainInfo,
-                registry,
-                xcmDirection,
-                xcmVersion,
-                isForeignAssetsTransfer,
-                isLiquidTokenTransfer,
-            );
-        }
+		if (xcmDirection === Direction.SystemToPara) {
+			await checkSystemToParaAssetId(
+				api,
+				assetId,
+				specName,
+				relayChainInfo,
+				registry,
+				xcmDirection,
+				xcmVersion,
+				isForeignAssetsTransfer,
+				isLiquidTokenTransfer,
+			);
+		}
 
-        if (xcmDirection === Direction.SystemToSystem) {
-            await checkSystemToSystemAssetId(
-                api,
-                assetId,
-                specName,
-                relayChainInfo,
-                registry,
-                xcmDirection,
-                xcmVersion,
-                isForeignAssetsTransfer,
-                isLiquidTokenTransfer,
-            );
-        }
+		if (xcmDirection === Direction.SystemToSystem) {
+			await checkSystemToSystemAssetId(
+				api,
+				assetId,
+				specName,
+				relayChainInfo,
+				registry,
+				xcmDirection,
+				xcmVersion,
+				isForeignAssetsTransfer,
+				isLiquidTokenTransfer,
+			);
+		}
 
-        if (xcmDirection === Direction.ParaToSystem || xcmDirection === Direction.ParaToPara) {
-            await checkParaOriginAssetId(api, assetId, specName, registry);
-        }
+		if (xcmDirection === Direction.ParaToSystem || xcmDirection === Direction.ParaToPara) {
+			await checkParaOriginAssetId(api, assetId, specName, registry);
+		}
 
-        if (xcmDirection === Direction.ParaToRelay) {
-            checkParaToRelayAssetId(assetId, registry, specName);
-        }
-    }
+		if (xcmDirection === Direction.ParaToRelay) {
+			checkParaToRelayAssetId(assetId, registry, specName);
+		}
+	}
 };
 
 /**
@@ -1102,131 +1104,146 @@ export const checkAssetIdInput = async (
  * @param registry
  */
 export const checkXcmTxInputs = async (baseArgs: XcmBaseArgsWithPallet, opts: CheckXcmTxInputsOpts) => {
-    const { api, direction, assetIds, amounts, destChainId, xcmVersion, specName, registry, xcmPallet } = baseArgs;
-    const {
-        paysWithFeeDest,
-        isForeignAssetsTransfer,
-        isLiquidTokenTransfer,
-        isPrimaryParachainNativeAsset,
-        assetTransferType,
-        remoteReserveAssetTransferTypeLocation,
-        feesTransferType,
-        remoteReserveFeesTransferTypeLocation,
-    } = opts;
-    const relayChainInfo = registry.currentRelayRegistry;
+	const { api, direction, assetIds, amounts, destChainId, xcmVersion, specName, registry, xcmPallet } = baseArgs;
+	const {
+		paysWithFeeDest,
+		isForeignAssetsTransfer,
+		isLiquidTokenTransfer,
+		isPrimaryParachainNativeAsset,
+		assetTransferType,
+		remoteReserveAssetTransferTypeLocation,
+		feesTransferType,
+		remoteReserveFeesTransferTypeLocation,
+	} = opts;
+	const relayChainInfo = registry.currentRelayRegistry;
 
-    if (isPrimaryParachainNativeAsset) {
-        /**
-         * Checks that the assetIds length is correct for primary native parachain asset tx
-         */
-        checkParaPrimaryAssetAssetIdsLength(assetIds);
-        /**
-         * Checks that the amounts length is correct for primary native parachain asset tx
-         */
-        checkParaPrimaryAssetAmountsLength(amounts);
-    }
+	if (isPrimaryParachainNativeAsset) {
+		/**
+		 * Checks that the assetIds length is correct for primary native parachain asset tx
+		 */
+		checkParaPrimaryAssetAssetIdsLength(assetIds);
+		/**
+		 * Checks that the amounts length is correct for primary native parachain asset tx
+		 */
+		checkParaPrimaryAssetAmountsLength(amounts);
+	}
 
-    /**
-     * Checks that the XcmVersion works with `PaysWithFeeDest` option
-     */
-    checkXcmVersionIsValidForPaysWithFeeDest(direction, xcmVersion, paysWithFeeDest);
+	/**
+	 * Checks that the XcmVersion works with `PaysWithFeeDest` option
+	 */
+	checkXcmVersionIsValidForPaysWithFeeDest(direction, xcmVersion, paysWithFeeDest);
 
-    /**
-     * Checks that the direction of the `transferLiquidToken` option is correct.
-     */
-    checkLiquidTokenTransferDirectionValidity(direction, isLiquidTokenTransfer);
+	/**
+	 * Checks that the direction of the `transferLiquidToken` option is correct.
+	 */
+	checkLiquidTokenTransferDirectionValidity(direction, isLiquidTokenTransfer);
 
-    /**
-     * Checks to ensure that assetId's have a length no greater than MAX_ASSETS_FOR_TRANSFER
-     */
-    checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+	/**
+	 * Checks to ensure that assetId's have a length no greater than MAX_ASSETS_FOR_TRANSFER
+	 */
+	checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
 
-    /**
-     * Checks to ensure that assetId's have no duplicate values
-     */
-    checkAssetIdsHaveNoDuplicates(assetIds);
+	/**
+	 * Checks to ensure that assetId's have no duplicate values
+	 */
+	checkAssetIdsHaveNoDuplicates(assetIds);
 
-    /**
-     * Checks to ensure that assetId's are either empty string, symbol and integer values or multilocations
-     */
-    checkAssetIdsAreOfSameAssetIdType(assetIds);
+	/**
+	 * Checks to ensure that assetId's are either empty string, symbol and integer values or multilocations
+	 */
+	checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-    /**
-     * Checks to ensure that assetId's are either valid integer numbers or native asset token symbols
-     */
-    await checkAssetIdInput(
-        api,
-        assetIds,
-        relayChainInfo,
-        specName,
-        direction,
-        registry,
-        xcmVersion,
-        isForeignAssetsTransfer,
-        isLiquidTokenTransfer,
-    );
+	/**
+	 * Checks to ensure that assetId's are either valid integer numbers or native asset token symbols
+	 */
+	await checkAssetIdInput(
+		api,
+		assetIds,
+		relayChainInfo,
+		specName,
+		direction,
+		registry,
+		xcmVersion,
+		isForeignAssetsTransfer,
+		isLiquidTokenTransfer,
+	);
 
-    if (direction === Direction.RelayToSystem) {
-        checkRelayAssetIdLength(assetIds);
-        checkRelayAmountsLength(amounts);
-    }
+	if (direction === Direction.RelayToSystem) {
+		checkRelayAssetIdLength(assetIds);
+		checkRelayAmountsLength(amounts);
+	}
 
-    if (direction === Direction.RelayToPara) {
-        checkRelayAssetIdLength(assetIds);
-        checkRelayAmountsLength(amounts);
-    }
+	if (direction === Direction.RelayToPara) {
+		checkRelayAssetIdLength(assetIds);
+		checkRelayAmountsLength(amounts);
+	}
 
-    if (direction === Direction.SystemToRelay) {
-        checkRelayAssetIdLength(assetIds);
-        checkRelayAmountsLength(amounts);
-    }
+	if (direction === Direction.RelayToBridge) {
+		checkRelayAssetIdLength(assetIds);
+		checkRelayAmountsLength(amounts);
+		getGlobalConsensusSystemName(destChainId);
+		checkBridgeTxInputs(
+			paysWithFeeDest,
+			assetTransferType,
+			remoteReserveAssetTransferTypeLocation,
+			feesTransferType,
+			remoteReserveFeesTransferTypeLocation,
+		);
+		checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
+		checkXcmVersionIsValidForBridgeTx(xcmVersion);
+	}
 
-    if (direction === Direction.SystemToPara) {
-        if (isForeignAssetsTransfer) {
-            checkMultiLocationIdLength(assetIds);
-            checkMultiLocationAmountsLength(amounts);
-            checkAssetsAmountMatch(assetIds, amounts);
-            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
-        }
-        checkAssetsAmountMatch(assetIds, amounts);
-    }
+	if (direction === Direction.SystemToRelay) {
+		checkRelayAssetIdLength(assetIds);
+		checkRelayAmountsLength(amounts);
+	}
 
-    if (direction === Direction.SystemToSystem) {
-        if (isForeignAssetsTransfer) {
-            checkAssetsAmountMatch(assetIds, amounts);
-            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
-        }
-        checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
-    }
+	if (direction === Direction.SystemToPara) {
+		if (isForeignAssetsTransfer) {
+			checkMultiLocationIdLength(assetIds);
+			checkMultiLocationAmountsLength(amounts);
+			checkAssetsAmountMatch(assetIds, amounts);
+			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
+		}
+		checkAssetsAmountMatch(assetIds, amounts);
+	}
 
-    if (direction === Direction.SystemToBridge) {
-        checkMultiLocationIdLength(assetIds);
-        checkMultiLocationAmountsLength(amounts);
-        checkAssetsAmountMatch(assetIds, amounts);
-        getGlobalConsensusSystemName(destChainId);
-        checkSystemToBridgeInputs(
-            paysWithFeeDest,
-            assetTransferType,
-            remoteReserveAssetTransferTypeLocation,
-            feesTransferType,
-            remoteReserveFeesTransferTypeLocation,
-        );
-        checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
-        checkXcmVersionIsValidForSystemToBridge(xcmVersion);
-    }
+	if (direction === Direction.SystemToSystem) {
+		if (isForeignAssetsTransfer) {
+			checkAssetsAmountMatch(assetIds, amounts);
+			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
+		}
+		checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
+	}
 
-    if (direction === Direction.ParaToSystem || direction === Direction.ParaToPara) {
-        CheckXTokensPalletOriginIsNonForeignAssetTx(direction, xcmPallet, isForeignAssetsTransfer);
-        checkAssetsAmountMatch(assetIds, amounts, isPrimaryParachainNativeAsset);
-    }
+	if (direction === Direction.SystemToBridge) {
+		checkMultiLocationIdLength(assetIds);
+		checkMultiLocationAmountsLength(amounts);
+		checkAssetsAmountMatch(assetIds, amounts);
+		getGlobalConsensusSystemName(destChainId);
+		checkBridgeTxInputs(
+			paysWithFeeDest,
+			assetTransferType,
+			remoteReserveAssetTransferTypeLocation,
+			feesTransferType,
+			remoteReserveFeesTransferTypeLocation,
+		);
+		checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
+		checkXcmVersionIsValidForBridgeTx(xcmVersion);
+	}
 
-    if (direction === Direction.ParaToRelay) {
-        checkRelayAssetIdLength(assetIds);
-        checkRelayAmountsLength(amounts);
-    }
+	if (direction === Direction.ParaToSystem || direction === Direction.ParaToPara) {
+		CheckXTokensPalletOriginIsNonForeignAssetTx(direction, xcmPallet, isForeignAssetsTransfer);
+		checkAssetsAmountMatch(assetIds, amounts, isPrimaryParachainNativeAsset);
+	}
+
+	if (direction === Direction.ParaToRelay) {
+		checkRelayAssetIdLength(assetIds);
+		checkRelayAmountsLength(amounts);
+	}
 };
 
 export const checkClaimAssetsInputs = (assets: string[], amounts: string[]) => {
-    checkAssetsAmountMatch(assets, amounts);
-    checkAssetIdsAreOfSameAssetIdType(assets);
+	checkAssetsAmountMatch(assets, amounts);
+	checkAssetIdsAreOfSameAssetIdType(assets);
 };

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -3,7 +3,6 @@
 import type { ApiPromise } from '@polkadot/api';
 import { isHex } from '@polkadot/util';
 import { isEthereumAddress } from '@polkadot/util-crypto';
-import { isRelayNativeAsset } from '../createXcmTypes/util/isRelayNativeAsset';
 
 import {
 	MAX_ASSETS_FOR_TRANSFER,
@@ -16,6 +15,7 @@ import { foreignAssetMultiLocationIsInCacheOrRegistry } from '../createXcmTypes/
 import { foreignAssetsMultiLocationExists } from '../createXcmTypes/util/foreignAssetsMultiLocationExists';
 import { getGlobalConsensusSystemName } from '../createXcmTypes/util/getGlobalConsensusSystemName';
 import { isParachainPrimaryNativeAsset } from '../createXcmTypes/util/isParachainPrimaryNativeAsset';
+import { isRelayNativeAsset } from '../createXcmTypes/util/isRelayNativeAsset';
 import { multiLocationAssetIsParachainsNativeAsset } from '../createXcmTypes/util/multiLocationAssetIsParachainsNativeAsset';
 import { Registry } from '../registry';
 import type { ChainInfo, ChainInfoKeys } from '../registry/types';
@@ -294,7 +294,7 @@ const checkRelayToParaAssetId = (assetId: string, relayChainInfo: ChainInfo<Chai
 
 	if (!assetIsRelayChainNativeAsset) {
 		throw new BaseError(
-			`(RelayToPara) asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`,
+			`(RelayToPara) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
 			BaseErrorsEnum.InvalidAsset,
 		);
 	}

--- a/src/errors/checkXcmTxInputs.ts
+++ b/src/errors/checkXcmTxInputs.ts
@@ -1,10 +1,10 @@
-// Copyright 2023 Parity Technologies (UK) Ltd.
+// Copyright 2024 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
 import { isHex } from '@polkadot/util';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
-import { MAX_ASSETS_FOR_TRANSFER, RELAY_CHAIN_IDS } from '../consts';
+import { SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION, MAX_ASSETS_FOR_TRANSFER, RELAY_CHAINS_NATIVE_ASSET_LOCATION, RELAY_CHAIN_IDS } from '../consts';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
 import { foreignAssetMultiLocationIsInCacheOrRegistry } from '../createXcmTypes/util/foreignAssetMultiLocationIsInCacheOrRegistry';
 import { foreignAssetsMultiLocationExists } from '../createXcmTypes/util/foreignAssetsMultiLocationExists';
@@ -18,6 +18,7 @@ import { AssetInfo, Direction } from '../types';
 import { validateNumber } from '../validate';
 import { BaseError, BaseErrorsEnum } from './BaseError';
 import type { CheckXcmTxInputsOpts } from './types';
+import { isRelayNativeAsset } from '../createXcmTypes/util/isRelayNativeAsset';
 
 /**
  * Ensure when sending tx's to or from the relay chain that the length of the assetIds array
@@ -26,12 +27,12 @@ import type { CheckXcmTxInputsOpts } from './types';
  * @param assetIds
  */
 export const checkRelayAssetIdLength = (assetIds: string[]) => {
-	if (assetIds.length > 1) {
-		throw new BaseError(
-			"`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.",
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (assetIds.length > 1) {
+        throw new BaseError(
+            "`assetIds` should be empty or length 1 when sending tx's to or from the relay chain.",
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -41,12 +42,12 @@ export const checkRelayAssetIdLength = (assetIds: string[]) => {
  * @param amounts
  */
 export const checkRelayAmountsLength = (amounts: string[]) => {
-	if (amounts.length !== 1) {
-		throw new BaseError(
-			'`amounts` should be of length 1 when sending to or from a relay chain',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (amounts.length !== 1) {
+        throw new BaseError(
+            '`amounts` should be of length 1 when sending to or from a relay chain',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -55,12 +56,12 @@ export const checkRelayAmountsLength = (amounts: string[]) => {
  * @param assetIds
  */
 export const checkParaPrimaryAssetAssetIdsLength = (assetIds: string[]) => {
-	if (assetIds.length > 1) {
-		throw new BaseError(
-			'`assetIds` should be of length 1 when sending a primary native parachain asset',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (assetIds.length > 1) {
+        throw new BaseError(
+            '`assetIds` should be of length 1 when sending a primary native parachain asset',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -70,12 +71,12 @@ export const checkParaPrimaryAssetAssetIdsLength = (assetIds: string[]) => {
  * @param amounts
  */
 export const checkParaPrimaryAssetAmountsLength = (amounts: string[]) => {
-	if (amounts.length !== 1) {
-		throw new BaseError(
-			'`amounts` should be of length 1 when sending a primary native parachain asset',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (amounts.length !== 1) {
+        throw new BaseError(
+            '`amounts` should be of length 1 when sending a primary native parachain asset',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -84,9 +85,9 @@ export const checkParaPrimaryAssetAmountsLength = (amounts: string[]) => {
  * @param assetIds
  */
 export const checkMultiLocationIdLength = (assetIds: string[]) => {
-	if (assetIds.length === 0) {
-		throw new BaseError('multilocation `assetIds` cannot be empty', BaseErrorsEnum.InvalidInput);
-	}
+    if (assetIds.length === 0) {
+        throw new BaseError('multilocation `assetIds` cannot be empty', BaseErrorsEnum.InvalidInput);
+    }
 };
 
 /**
@@ -95,9 +96,9 @@ export const checkMultiLocationIdLength = (assetIds: string[]) => {
  * @param amounts
  */
 export const checkMultiLocationAmountsLength = (amounts: string[]) => {
-	if (amounts.length === 0) {
-		throw new BaseError('multilocation `amounts` cannot be empty', BaseErrorsEnum.InvalidInput);
-	}
+    if (amounts.length === 0) {
+        throw new BaseError('multilocation `amounts` cannot be empty', BaseErrorsEnum.InvalidInput);
+    }
 };
 
 /**
@@ -107,16 +108,16 @@ export const checkMultiLocationAmountsLength = (amounts: string[]) => {
  * @param amounts
  */
 export const checkAssetsAmountMatch = (
-	assetIds: string[],
-	amounts: string[],
-	isParachainPrimaryNativeAsset?: boolean,
+    assetIds: string[],
+    amounts: string[],
+    isParachainPrimaryNativeAsset?: boolean,
 ) => {
-	if (!isParachainPrimaryNativeAsset && assetIds.length !== amounts.length) {
-		throw new BaseError(
-			'`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (!isParachainPrimaryNativeAsset && assetIds.length !== amounts.length) {
+        throw new BaseError(
+            '`amounts`, and `assetIds` fields should match in length when constructing a tx from a parachain to a parachain or locally on a system parachain.',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -126,16 +127,16 @@ export const checkAssetsAmountMatch = (
  * @param isForeignAssetsTransfer
  */
 export const CheckXTokensPalletOriginIsNonForeignAssetTx = (
-	xcmDirection: Direction,
-	xcmPallet: XcmPalletName,
-	isForeignAssetsTransfer: boolean,
+    xcmDirection: Direction,
+    xcmPallet: XcmPalletName,
+    isForeignAssetsTransfer: boolean,
 ) => {
-	if ((xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens) && isForeignAssetsTransfer) {
-		throw new BaseError(
-			`(${xcmDirection}) xTokens pallet does not support foreign asset transfers`,
-			BaseErrorsEnum.InvalidPallet,
-		);
-	}
+    if ((xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens) && isForeignAssetsTransfer) {
+        throw new BaseError(
+            `(${xcmDirection}) xTokens pallet does not support foreign asset transfers`,
+            BaseErrorsEnum.InvalidPallet,
+        );
+    }
 };
 
 /**
@@ -145,10 +146,10 @@ export const CheckXTokensPalletOriginIsNonForeignAssetTx = (
  * @param assetId
  */
 const checkIfAssetIdIsBlankSpace = (assetId: string) => {
-	// check if assetId is a blank space, if it is, throw an error
-	if (assetId.length > 0 && assetId.trim() === '') {
-		throw new BaseError(`assetId cannot be blank spaces.`, BaseErrorsEnum.InvalidInput);
-	}
+    // check if assetId is a blank space, if it is, throw an error
+    if (assetId.length > 0 && assetId.trim() === '') {
+        throw new BaseError(`assetId cannot be blank spaces.`, BaseErrorsEnum.InvalidInput);
+    }
 };
 
 /**
@@ -159,20 +160,20 @@ const checkIfAssetIdIsBlankSpace = (assetId: string) => {
  * @returns boolean
  */
 export const containsNativeRelayAsset = (assetIds: string[], relayChainAsset: string): boolean => {
-	// We assume when the assetId's input is empty that the native token is to be transferred.
-	if (assetIds.length === 0) {
-		return true;
-	}
+    // We assume when the assetId's input is empty that the native token is to be transferred.
+    if (assetIds.length === 0) {
+        return true;
+    }
 
-	for (let i = 0; i < assetIds.length; i++) {
-		const assetId = assetIds[i];
+    for (let i = 0; i < assetIds.length; i++) {
+        const assetId = assetIds[i];
 
-		if (assetId.toLowerCase() === relayChainAsset.toLowerCase()) {
-			return true;
-		}
-	}
+        if (assetId.toLowerCase() === relayChainAsset.toLowerCase()) {
+            return true;
+        }
+    }
 
-	return false;
+    return false;
 };
 
 /**
@@ -183,15 +184,15 @@ export const containsNativeRelayAsset = (assetIds: string[], relayChainAsset: st
  * @param registry Registry
  */
 export const checkIfNativeRelayChainAssetPresentInMultiAssetIdList = (assetIds: string[], registry: Registry) => {
-	const relayChainID = RELAY_CHAIN_IDS[0];
-	const nativeRelayChainAsset = registry.currentRelayRegistry[relayChainID].tokens[0];
+    const relayChainID = RELAY_CHAIN_IDS[0];
+    const nativeRelayChainAsset = registry.currentRelayRegistry[relayChainID].tokens[0];
 
-	if (assetIds.length > 1 && containsNativeRelayAsset(assetIds, nativeRelayChainAsset)) {
-		throw new BaseError(
-			`Found the relay chains native asset in list [${assetIds.toString()}]. \`assetIds\` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.`,
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (assetIds.length > 1 && containsNativeRelayAsset(assetIds, nativeRelayChainAsset)) {
+        throw new BaseError(
+            `Found the relay chains native asset in list [${assetIds.toString()}]. \`assetIds\` list must be empty or only contain the relay chain asset for direction SystemToSystem when sending the relay chains native asset.`,
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -205,32 +206,32 @@ export const checkIfNativeRelayChainAssetPresentInMultiAssetIdList = (assetIds: 
  * @returns boolean
  */
 export const checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain = (
-	xcmDirection: Direction,
-	destChainId: string,
-	multiLocationAssetIds: string[],
+    xcmDirection: Direction,
+    destChainId: string,
+    multiLocationAssetIds: string[],
 ) => {
-	if (multiLocationAssetIds.length > 1) {
-		let foreignMultiLocationAssetFound = false;
-		let nativeMultiLocationAssetFound = false;
+    if (multiLocationAssetIds.length > 1) {
+        let foreignMultiLocationAssetFound = false;
+        let nativeMultiLocationAssetFound = false;
 
-		// iterate through list and determine if each asset is native to the dest parachain
-		for (const multilocation of multiLocationAssetIds) {
-			const isNativeToDestChain = multiLocationAssetIsParachainsNativeAsset(destChainId, multilocation);
+        // iterate through list and determine if each asset is native to the dest parachain
+        for (const multilocation of multiLocationAssetIds) {
+            const isNativeToDestChain = multiLocationAssetIsParachainsNativeAsset(destChainId, multilocation);
 
-			if (isNativeToDestChain) {
-				nativeMultiLocationAssetFound = true;
-			} else {
-				foreignMultiLocationAssetFound = true;
-			}
+            if (isNativeToDestChain) {
+                nativeMultiLocationAssetFound = true;
+            } else {
+                foreignMultiLocationAssetFound = true;
+            }
 
-			if (nativeMultiLocationAssetFound && foreignMultiLocationAssetFound) {
-				throw new BaseError(
-					`(${xcmDirection}) found both foreign and native multilocations in ${multiLocationAssetIds.toString()}. multilocation XCMs must only include either native or foreign assets of the destination chain.`,
-					BaseErrorsEnum.InvalidInput,
-				);
-			}
-		}
-	}
+            if (nativeMultiLocationAssetFound && foreignMultiLocationAssetFound) {
+                throw new BaseError(
+                    `(${xcmDirection}) found both foreign and native multilocations in ${multiLocationAssetIds.toString()}. multilocation XCMs must only include either native or foreign assets of the destination chain.`,
+                    BaseErrorsEnum.InvalidInput,
+                );
+            }
+        }
+    }
 };
 
 /**
@@ -239,31 +240,24 @@ export const checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain = (
  * @param assetId
  * @param relayChainInfo
  */
-const checkRelayToSystemAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>) => {
-	const relayChainId = RELAY_CHAIN_IDS[0];
-	const relayChain = relayChainInfo[relayChainId];
-	const relayChainNativeAsset = relayChain.tokens[0];
+const checkRelayToSystemAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>, registry: Registry) => {
+    const relayChainId = RELAY_CHAIN_IDS[0];
+    const relayChain = relayChainInfo[relayChainId];
+    const relayChainNativeAsset = relayChain.tokens[0];
 
-	// relay chain can only send its native asset
-	// ensure the asset being sent is the native asset of the relay chain
-	// no need to check if id is a number, if it is, it fails the check by default
-	let assetIsRelayChainNativeAsset = false;
+    // relay chain can only send its native asset
+    // ensure the asset being sent is the native asset of the relay chain
+    // no need to check if id is a number, if it is, it fails the check by default
 
-	// if an empty string is passed, treat it as the native relay asset
-	if (assetId === '') {
-		assetIsRelayChainNativeAsset = true;
-	}
+    // ensure assetId is relay chain's native token
+    let assetIsRelayChainNativeAsset = isRelayNativeAsset(registry, assetId);
 
-	if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
-		assetIsRelayChainNativeAsset = true;
-	}
-
-	if (!assetIsRelayChainNativeAsset) {
-		throw new BaseError(
-			`(RelayToSystem) asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`,
-			BaseErrorsEnum.InvalidAsset,
-		);
-	}
+    if (!assetIsRelayChainNativeAsset) {
+        throw new BaseError(
+            `(RelayToSystem) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
+            BaseErrorsEnum.InvalidAsset,
+        );
+    }
 };
 
 /**
@@ -273,32 +267,32 @@ const checkRelayToSystemAssetId = (assetId: string, relayChainInfo: ChainInfo<Ch
  * @param relayChainInfo
  */
 const checkRelayToParaAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>) => {
-	const relayChainId = RELAY_CHAIN_IDS[0];
-	const relayChain = relayChainInfo[relayChainId];
-	const relayChainNativeAsset = relayChain.tokens[0];
+    const relayChainId = RELAY_CHAIN_IDS[0];
+    const relayChain = relayChainInfo[relayChainId];
+    const relayChainNativeAsset = relayChain.tokens[0];
 
-	// relay chain can only send its native asset
-	// ensure the asset being sent is the native asset of the relay chain
-	// no need to check if id is a number, if it is, it fails the check by default
-	let assetIsRelayChainNativeAsset = false;
+    // relay chain can only send its native asset
+    // ensure the asset being sent is the native asset of the relay chain
+    // no need to check if id is a number, if it is, it fails the check by default
+    let assetIsRelayChainNativeAsset = false;
 
-	// if an empty string is passed, treat it as the native relay asset
-	if (assetId === '') {
-		assetIsRelayChainNativeAsset = true;
-	}
+    // if an empty string is passed, treat it as the native relay asset
+    if (assetId === '') {
+        assetIsRelayChainNativeAsset = true;
+    }
 
-	if (typeof assetId === 'string') {
-		if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
-			assetIsRelayChainNativeAsset = true;
-		}
-	}
+    if (typeof assetId === 'string') {
+        if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
+            assetIsRelayChainNativeAsset = true;
+        }
+    }
 
-	if (!assetIsRelayChainNativeAsset) {
-		throw new BaseError(
-			`(RelayToPara) asset ${assetId} is not ${relayChain.specName}'s native asset. Expected ${relayChainNativeAsset}`,
-			BaseErrorsEnum.InvalidAsset,
-		);
-	}
+    if (!assetIsRelayChainNativeAsset) {
+        throw new BaseError(
+            `(RelayToPara) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${RELAY_CHAINS_NATIVE_ASSET_LOCATION}`,
+            BaseErrorsEnum.InvalidAsset,
+        );
+    }
 };
 /**
  * This will check the given assetId and ensure that it is the native token of the relay chain
@@ -306,345 +300,334 @@ const checkRelayToParaAssetId = (assetId: string, relayChainInfo: ChainInfo<Chai
  * @param assetId
  * @param relayChainInfo
  */
-const checkSystemToRelayAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>) => {
-	const relayChainId = RELAY_CHAIN_IDS[0];
-	const relayChain = relayChainInfo[relayChainId];
-	const relayChainNativeAsset = relayChain.tokens[0];
+const checkSystemToRelayAssetId = (assetId: string, relayChainInfo: ChainInfo<ChainInfoKeys>, registry: Registry) => {
+    const relayChainId = RELAY_CHAIN_IDS[0];
+    const relayChain = relayChainInfo[relayChainId];
+    const relayChainNativeAsset = relayChain.tokens[0];
 
-	// ensure assetId is relay chain's native token
-	let matchedRelayChainNativeToken = false;
+    // ensure assetId is relay chain's native token
+    let matchedRelayChainNativeToken = isRelayNativeAsset(registry, assetId);
 
-	// if an empty string is passed, treat it as the native relay asset
-	if (assetId === '') {
-		matchedRelayChainNativeToken = true;
-	}
-
-	if (typeof assetId === 'string') {
-		if (relayChainNativeAsset.toLowerCase() === assetId.toLowerCase()) {
-			matchedRelayChainNativeToken = true;
-		}
-	}
-
-	if (!matchedRelayChainNativeToken) {
-		throw new BaseError(
-			`(SystemToRelay) assetId ${assetId} not native to ${relayChain.specName}. Expected ${relayChainNativeAsset}`,
-			BaseErrorsEnum.InvalidAsset,
-		);
-	}
+    if (!matchedRelayChainNativeToken) {
+        throw new BaseError(
+            `(SystemToRelay) assetId ${assetId} is not the native asset of ${relayChain.specName} relay chain. Expected an assetId of ${relayChainNativeAsset} or asset location ${SYSTEM_AND_PARACHAINS_RELAY_ASSET_LOCATION}`,
+            BaseErrorsEnum.InvalidAsset,
+        );
+    }
 };
 
 export const checkLiquidTokenValidity = async (
-	api: ApiPromise,
-	registry: Registry,
-	systemParachainInfo: ChainInfoKeys,
-	assetId: string,
+    api: ApiPromise,
+    registry: Registry,
+    systemParachainInfo: ChainInfoKeys,
+    assetId: string,
 ) => {
-	const isValidInt = validateNumber(assetId);
-	if (!isValidInt) {
-		throw new BaseError(`Liquid Tokens must be valid Integers`, BaseErrorsEnum.InvalidAsset);
-	}
+    const isValidInt = validateNumber(assetId);
+    if (!isValidInt) {
+        throw new BaseError(`Liquid Tokens must be valid Integers`, BaseErrorsEnum.InvalidAsset);
+    }
 
-	// check cache for pool asset
-	if (registry.cacheLookupPoolAsset(assetId)) {
-		return;
-	}
+    // check cache for pool asset
+    if (registry.cacheLookupPoolAsset(assetId)) {
+        return;
+    }
 
-	// check registry
-	const poolPairIds = Object.keys(systemParachainInfo.poolPairsInfo);
-	if (poolPairIds.includes(assetId)) {
-		return;
-	}
+    // check registry
+    const poolPairIds = Object.keys(systemParachainInfo.poolPairsInfo);
+    if (poolPairIds.includes(assetId)) {
+        return;
+    }
 
-	// query chain state
-	const poolAsset = await api.query.poolAssets.asset(assetId);
-	if (poolAsset.isSome) {
-		for (const poolPairsData of await api.query.assetConversion.pools.entries()) {
-			const poolAssetData = JSON.stringify(poolPairsData[0]).replace(/(\d),/g, '$1');
-			const poolAssetInfo = poolPairsData[1].unwrap();
+    // query chain state
+    const poolAsset = await api.query.poolAssets.asset(assetId);
+    if (poolAsset.isSome) {
+        for (const poolPairsData of await api.query.assetConversion.pools.entries()) {
+            const poolAssetData = JSON.stringify(poolPairsData[0]).replace(/(\d),/g, '$1');
+            const poolAssetInfo = poolPairsData[1].unwrap();
 
-			if (poolAssetInfo.lpToken.toString() === assetId) {
-				const asset: {
-					lpToken: string;
-					pairInfo: string;
-				} = {
-					lpToken: assetId,
-					pairInfo: poolAssetData,
-				};
+            if (poolAssetInfo.lpToken.toString() === assetId) {
+                const asset: {
+                    lpToken: string;
+                    pairInfo: string;
+                } = {
+                    lpToken: assetId,
+                    pairInfo: poolAssetData,
+                };
 
-				// cache the queried liquidToken asset
-				registry.setLiquidPoolTokenInCache(assetId, asset);
-			}
-		}
-		return;
-	}
+                // cache the queried liquidToken asset
+                registry.setLiquidPoolTokenInCache(assetId, asset);
+            }
+        }
+        return;
+    }
 
-	// liquid token not found in cache, registry or chain state
-	throw new BaseError(
-		`No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.`,
-		BaseErrorsEnum.InvalidAsset,
-	);
+    // liquid token not found in cache, registry or chain state
+    throw new BaseError(
+        `No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.`,
+        BaseErrorsEnum.InvalidAsset,
+    );
 };
 
 const checkSystemAssets = async (
-	api: ApiPromise,
-	assetId: string,
-	specName: string,
-	systemParachainInfo: ChainInfoKeys,
-	registry: Registry,
-	xcmDirection: string,
-	xcmVersion: number,
-	isForeignAssetsTransfer: boolean,
-	isLiquidTokenTransfer?: boolean,
+    api: ApiPromise,
+    assetId: string,
+    specName: string,
+    systemParachainInfo: ChainInfoKeys,
+    registry: Registry,
+    xcmDirection: string,
+    xcmVersion: number,
+    isForeignAssetsTransfer: boolean,
+    isLiquidTokenTransfer?: boolean,
 ) => {
-	const currentChainId = registry.lookupChainIdBySpecName(specName);
+    const currentChainId = registry.lookupChainIdBySpecName(specName);
 
-	if (isForeignAssetsTransfer) {
-		// check that the asset id is a valid multilocation
-		const multiLocationIsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(assetId, registry, xcmVersion);
+    if (isForeignAssetsTransfer) {
+        // check that the asset id is a valid multilocation
+        const multiLocationIsInRegistry = foreignAssetMultiLocationIsInCacheOrRegistry(assetId, registry, xcmVersion);
 
-		if (!multiLocationIsInRegistry) {
-			const isValidForeignAsset = await foreignAssetsMultiLocationExists(api, registry, assetId);
+        if (!multiLocationIsInRegistry) {
+            const isValidForeignAsset = await foreignAssetsMultiLocationExists(api, registry, assetId);
 
-			if (!isValidForeignAsset) {
-				throw new BaseError(`MultiLocation ${assetId} not found`, BaseErrorsEnum.AssetNotFound);
-			}
-		}
-	} else if (isLiquidTokenTransfer) {
-		await checkLiquidTokenValidity(api, registry, systemParachainInfo, assetId);
-	} else {
-		const isValidInt = validateNumber(assetId);
+            if (!isValidForeignAsset) {
+                throw new BaseError(`MultiLocation ${assetId} not found`, BaseErrorsEnum.AssetNotFound);
+            }
+        }
+    } else if (isLiquidTokenTransfer) {
+        await checkLiquidTokenValidity(api, registry, systemParachainInfo, assetId);
+    } else {
+        const isValidInt = validateNumber(assetId);
 
-		if (isValidInt) {
-			let assetSymbol: string | undefined;
+        if (isValidInt) {
+            let assetSymbol: string | undefined;
 
-			// check the cache for the asset
-			// if not in cache, check the registry
-			if (registry.cacheLookupAsset(assetId)) {
-				assetSymbol = registry.cacheLookupAsset(assetId);
-			} else if (systemParachainInfo.assetsInfo[assetId]) {
-				assetSymbol = systemParachainInfo.assetsInfo[assetId];
-			}
+            // check the cache for the asset
+            // if not in cache, check the registry
+            if (registry.cacheLookupAsset(assetId)) {
+                assetSymbol = registry.cacheLookupAsset(assetId);
+            } else if (systemParachainInfo.assetsInfo[assetId]) {
+                assetSymbol = systemParachainInfo.assetsInfo[assetId];
+            }
 
-			if (!assetSymbol) {
-				// if asset is not in cache or registry, query the assets pallet to see if it has a value
-				const asset = await api.query.assets.asset(assetId);
+            if (!assetSymbol) {
+                // if asset is not in cache or registry, query the assets pallet to see if it has a value
+                const asset = await api.query.assets.asset(assetId);
 
-				// if asset is found in the assets pallet, return LocalTxType Assets
-				if (asset.isNone) {
-					throw new BaseError(
-						`(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
-						BaseErrorsEnum.AssetNotFound,
-					);
-				} else {
-					const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
+                // if asset is found in the assets pallet, return LocalTxType Assets
+                if (asset.isNone) {
+                    throw new BaseError(
+                        `(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
+                        BaseErrorsEnum.AssetNotFound,
+                    );
+                } else {
+                    const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
 
-					const assetStr = assetSymbol as string;
-					// add the asset to the cache
-					registry.setAssetInCache(assetId, assetStr);
-				}
-			}
-		} else {
-			// not a valid number
-			// check if id is a valid token symbol of the system parachain chain
-			if (assetId === '') {
-				return;
-			}
+                    const assetStr = assetSymbol as string;
+                    // add the asset to the cache
+                    registry.setAssetInCache(assetId, assetStr);
+                }
+            }
+        } else {
+            // not a valid number
+            // check if id is a valid token symbol of the system parachain chain
+            if (isRelayNativeAsset(registry, assetId)) {
+                return;
+            }
 
-			// ensure character string is valid symbol for the system chain
-			for (const token of systemParachainInfo.tokens) {
-				if (token.toLowerCase() === assetId.toLowerCase()) {
-					return;
-				}
-			}
-			const cacheTokensMatched: AssetInfo[] = [];
-			// not found in tokens, check the cache
-			if (registry.cache[registry.relayChain][currentChainId]) {
-				for (const [id, symbol] of Object.entries(registry.cache[registry.relayChain][currentChainId].assetsInfo)) {
-					if (symbol.toLowerCase() === assetId.toLowerCase()) {
-						// match found in cache
-						const assetInfo: AssetInfo = {
-							id,
-							symbol,
-						};
-						cacheTokensMatched.push(assetInfo);
-					}
-				}
-			}
+            // ensure character string is valid symbol for the system chain
+            for (const token of systemParachainInfo.tokens) {
+                if (token.toLowerCase() === assetId.toLowerCase()) {
+                    return;
+                }
+            }
+            const cacheTokensMatched: AssetInfo[] = [];
+            // not found in tokens, check the cache
+            if (registry.cache[registry.relayChain][currentChainId]) {
+                for (const [id, symbol] of Object.entries(registry.cache[registry.relayChain][currentChainId].assetsInfo)) {
+                    if (symbol.toLowerCase() === assetId.toLowerCase()) {
+                        // match found in cache
+                        const assetInfo: AssetInfo = {
+                            id,
+                            symbol,
+                        };
+                        cacheTokensMatched.push(assetInfo);
+                    }
+                }
+            }
 
-			// 1 valid match found in cache
-			if (cacheTokensMatched.length > 1) {
-				const assetMessageInfo = cacheTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
-				const message =
-					`Multiple assets found with symbol ${assetId}::\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol`
-						.trim()
-						.replace(',', '\n');
+            // 1 valid match found in cache
+            if (cacheTokensMatched.length > 1) {
+                const assetMessageInfo = cacheTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
+                const message =
+                    `Multiple assets found with symbol ${assetId}::\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol`
+                        .trim()
+                        .replace(',', '\n');
 
-				throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
-			} else if (cacheTokensMatched.length === 1) {
-				return;
-			}
+                throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
+            } else if (cacheTokensMatched.length === 1) {
+                return;
+            }
 
-			const assetsInfoTokensMatched: AssetInfo[] = [];
+            const assetsInfoTokensMatched: AssetInfo[] = [];
 
-			// if not found in system parachains tokens, or registry cache. Check assetsInfo
-			for (const [id, symbol] of Object.entries(systemParachainInfo.assetsInfo)) {
-				if (symbol.toLowerCase() === assetId.toLowerCase()) {
-					const assetInfo: AssetInfo = {
-						id,
-						symbol,
-					};
-					assetsInfoTokensMatched.push(assetInfo);
-				}
-			}
+            // if not found in system parachains tokens, or registry cache. Check assetsInfo
+            for (const [id, symbol] of Object.entries(systemParachainInfo.assetsInfo)) {
+                if (symbol.toLowerCase() === assetId.toLowerCase()) {
+                    const assetInfo: AssetInfo = {
+                        id,
+                        symbol,
+                    };
+                    assetsInfoTokensMatched.push(assetInfo);
+                }
+            }
 
-			// check if multiple matches found
-			// if more than 1 match is found throw an error and include details on the matched tokens
-			if (assetsInfoTokensMatched.length > 1) {
-				const assetMessageInfo = assetsInfoTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
-				const message =
-					`Multiple assets found with symbol ${assetId}:\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol
-				`
-						.trim()
-						.replace(',', '\n');
+            // check if multiple matches found
+            // if more than 1 match is found throw an error and include details on the matched tokens
+            if (assetsInfoTokensMatched.length > 1) {
+                const assetMessageInfo = assetsInfoTokensMatched.map((token) => `assetId: ${token.id} symbol: ${token.symbol}`);
+                const message =
+                    `Multiple assets found with symbol ${assetId}:\n${assetMessageInfo.toString()}\nPlease retry using an assetId rather than the token symbol
+                `
+                        .trim()
+                        .replace(',', '\n');
 
-				throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
-			} else if (assetsInfoTokensMatched.length === 1) {
-				return;
-			}
+                throw new BaseError(message, BaseErrorsEnum.MultipleNonUniqueAssetsFound);
+            } else if (assetsInfoTokensMatched.length === 1) {
+                return;
+            }
 
-			// if no native token for the system parachain was matched, throw an error
-			throw new BaseError(
-				`(${xcmDirection}) assetId ${assetId} not found for system parachain ${specName}`,
-				BaseErrorsEnum.AssetNotFound,
-			);
-		}
-	}
+            // if no native token for the system parachain was matched, throw an error
+            throw new BaseError(
+                `(${xcmDirection}) assetId ${assetId} not found for system parachain ${specName}`,
+                BaseErrorsEnum.AssetNotFound,
+            );
+        }
+    }
 };
 
 export const checkParaAssets = async (
-	api: ApiPromise,
-	assetId: string,
-	specName: string,
-	registry: Registry,
-	xcmDirection: Direction,
+    api: ApiPromise,
+    assetId: string,
+    specName: string,
+    registry: Registry,
+    xcmDirection: Direction,
 ) => {
-	if (isParachainPrimaryNativeAsset(registry, specName, xcmDirection, assetId)) {
-		return;
-	}
+    if (isParachainPrimaryNativeAsset(registry, specName, xcmDirection, assetId)) {
+        return;
+    }
 
-	const currentRelayChainSpecName = registry.relayChain;
-	const isValidInt = validateNumber(assetId);
-	const paraId = registry.lookupChainIdBySpecName(specName);
-	if (api.query.assets) {
-		if (isValidInt) {
-			if (!registry.cacheLookupAsset(assetId)) {
-				// query the parachains assets pallet to see if it has a value matching the assetId
-				const asset = await api.query.assets.asset(assetId);
+    const currentRelayChainSpecName = registry.relayChain;
+    const isValidInt = validateNumber(assetId);
+    const paraId = registry.lookupChainIdBySpecName(specName);
+    if (api.query.assets) {
+        if (isValidInt) {
+            if (!registry.cacheLookupAsset(assetId)) {
+                // query the parachains assets pallet to see if it has a value matching the assetId
+                const asset = await api.query.assets.asset(assetId);
 
-				if (asset.isNone) {
-					throw new BaseError(
-						`(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
-						BaseErrorsEnum.AssetNotFound,
-					);
-				} else {
-					const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
-					const assetSymbolStr = assetSymbol as string;
-					// store xcAsset in registry cache
-					registry.setAssetInCache(assetId, assetSymbolStr);
-				}
-			}
+                if (asset.isNone) {
+                    throw new BaseError(
+                        `(${xcmDirection}) integer assetId ${assetId} not found in ${specName}`,
+                        BaseErrorsEnum.AssetNotFound,
+                    );
+                } else {
+                    const assetSymbol = (await api.query.assets.metadata(assetId)).symbol.toHuman()?.toString();
+                    const assetSymbolStr = assetSymbol as string;
+                    // store xcAsset in registry cache
+                    registry.setAssetInCache(assetId, assetSymbolStr);
+                }
+            }
 
-			// Below checks when the asset exists on chain but not in our xcAssets registry.
-			const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
+            // Below checks when the asset exists on chain but not in our xcAssets registry.
+            const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
 
-			if (!paraXcAssets || paraXcAssets.length === 0) {
-				throw new BaseError(
-					`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
-					BaseErrorsEnum.InvalidPallet,
-				);
-			}
+            if (!paraXcAssets || paraXcAssets.length === 0) {
+                throw new BaseError(
+                    `unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
+                    BaseErrorsEnum.InvalidPallet,
+                );
+            }
 
-			for (const info of paraXcAssets) {
-				if (typeof info.asset === 'string' && info.asset === assetId) {
-					return;
-				}
-			}
+            for (const info of paraXcAssets) {
+                if (typeof info.asset === 'string' && info.asset === assetId) {
+                    return;
+                }
+            }
 
-			throw new BaseError(`unable to identify xcAsset with ID ${assetId}`, BaseErrorsEnum.AssetNotFound);
-		} else {
-			// not a valid number
-			// check if id is a valid token symbol of the parachain chain
-			const parachainAssets = await api.query.assets.asset.entries();
+            throw new BaseError(`unable to identify xcAsset with ID ${assetId}`, BaseErrorsEnum.AssetNotFound);
+        } else {
+            // not a valid number
+            // check if id is a valid token symbol of the parachain chain
+            const parachainAssets = await api.query.assets.asset.entries();
 
-			for (let i = 0; i < parachainAssets.length; i++) {
-				const parachainAsset = parachainAssets[i];
-				const id = parachainAsset[0].args[0];
+            for (let i = 0; i < parachainAssets.length; i++) {
+                const parachainAsset = parachainAssets[i];
+                const id = parachainAsset[0].args[0];
 
-				const metadata = await api.query.assets.metadata(id);
-				const symbol = metadata.symbol.toHuman()?.toString();
-				if (symbol && symbol.toLowerCase() === assetId.toLowerCase()) {
-					// store in registry cache
-					registry.setAssetInCache(symbol, id.toString());
-					return;
-				}
-			}
+                const metadata = await api.query.assets.metadata(id);
+                const symbol = metadata.symbol.toHuman()?.toString();
+                if (symbol && symbol.toLowerCase() === assetId.toLowerCase()) {
+                    // store in registry cache
+                    registry.setAssetInCache(symbol, id.toString());
+                    return;
+                }
+            }
 
-			// not an asset native to the Parachain
-			// check xcAsset registry for the symbol
-			const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
+            // not an asset native to the Parachain
+            // check xcAsset registry for the symbol
+            const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
 
-			if (!paraXcAssets || paraXcAssets.length === 0) {
-				throw new BaseError(
-					`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
-					BaseErrorsEnum.InvalidPallet,
-				);
-			}
+            if (!paraXcAssets || paraXcAssets.length === 0) {
+                throw new BaseError(
+                    `unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
+                    BaseErrorsEnum.InvalidPallet,
+                );
+            }
 
-			for (const info of paraXcAssets) {
-				if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
-					return;
-				}
-			}
+            for (const info of paraXcAssets) {
+                if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
+                    return;
+                }
+            }
 
-			// if no native token for the parachain was matched, throw an error
-			throw new BaseError(
-				`(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
-				BaseErrorsEnum.AssetNotFound,
-			);
-		}
-	} else {
-		// Parachain doesn't support pallet assets
-		// check for assetId in registry
-		const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
+            // if no native token for the parachain was matched, throw an error
+            throw new BaseError(
+                `(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
+                BaseErrorsEnum.AssetNotFound,
+            );
+        }
+    } else {
+        // Parachain doesn't support pallet assets
+        // check for assetId in registry
+        const paraXcAssets = registry.getRelaysRegistry[paraId].xcAssetsData;
 
-		if (!paraXcAssets || paraXcAssets.length === 0) {
-			throw new BaseError(
-				`unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
-				BaseErrorsEnum.InvalidPallet,
-			);
-		}
-		// if integer asset Id check if valid registry asset
-		if (isValidInt) {
-			for (const info of paraXcAssets) {
-				if (typeof info.asset === 'string' && info.asset.toLowerCase() === assetId.toLowerCase()) {
-					return;
-				}
-			}
-		} else {
-			// check for assetId symbol match
-			for (const info of paraXcAssets) {
-				if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
-					return;
-				}
-			}
-		}
+        if (!paraXcAssets || paraXcAssets.length === 0) {
+            throw new BaseError(
+                `unable to initialize xcAssets registry for ${currentRelayChainSpecName}`,
+                BaseErrorsEnum.InvalidPallet,
+            );
+        }
+        // if integer asset Id check if valid registry asset
+        if (isValidInt) {
+            for (const info of paraXcAssets) {
+                if (typeof info.asset === 'string' && info.asset.toLowerCase() === assetId.toLowerCase()) {
+                    return;
+                }
+            }
+        } else {
+            // check for assetId symbol match
+            for (const info of paraXcAssets) {
+                if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === assetId.toLowerCase()) {
+                    return;
+                }
+            }
+        }
 
-		// if no native token for the parachain was matched, throw an error
-		throw new BaseError(
-			`(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
-			BaseErrorsEnum.AssetNotFound,
-		);
-	}
+        // if no native token for the parachain was matched, throw an error
+        throw new BaseError(
+            `(${xcmDirection}) symbol assetId ${assetId} not found for parachain ${specName}`,
+            BaseErrorsEnum.AssetNotFound,
+        );
+    }
 };
 
 /**
@@ -655,56 +638,56 @@ export const checkParaAssets = async (
  * @param relayChainInfo
  */
 const checkSystemToParaAssetId = async (
-	api: ApiPromise,
-	assetId: string,
-	specName: string,
-	relayChainInfo: ChainInfo<ChainInfoKeys>,
-	registry: Registry,
-	xcmDirection: Direction,
-	xcmVersion: number,
-	isForeignAssetsTransfer: boolean,
-	isLiquidTokenTransfer: boolean,
+    api: ApiPromise,
+    assetId: string,
+    specName: string,
+    relayChainInfo: ChainInfo<ChainInfoKeys>,
+    registry: Registry,
+    xcmDirection: Direction,
+    xcmVersion: number,
+    isForeignAssetsTransfer: boolean,
+    isLiquidTokenTransfer: boolean,
 ) => {
-	await checkIsValidSystemChainAssetId(
-		api,
-		assetId,
-		specName,
-		relayChainInfo,
-		registry,
-		xcmDirection,
-		xcmVersion,
-		isForeignAssetsTransfer,
-		isLiquidTokenTransfer,
-	);
+    await checkIsValidSystemChainAssetId(
+        api,
+        assetId,
+        specName,
+        relayChainInfo,
+        registry,
+        xcmDirection,
+        xcmVersion,
+        isForeignAssetsTransfer,
+        isLiquidTokenTransfer,
+    );
 };
 
 export const checkIsValidSystemChainAssetId = async (
-	api: ApiPromise,
-	assetId: string,
-	specName: string,
-	relayChainInfo: ChainInfo<ChainInfoKeys>,
-	registry: Registry,
-	xcmDirection: Direction,
-	xcmVersion: number,
-	isForeignAssetsTransfer: boolean,
-	isLiquidTokenTransfer: boolean,
+    api: ApiPromise,
+    assetId: string,
+    specName: string,
+    relayChainInfo: ChainInfo<ChainInfoKeys>,
+    registry: Registry,
+    xcmDirection: Direction,
+    xcmVersion: number,
+    isForeignAssetsTransfer: boolean,
+    isLiquidTokenTransfer: boolean,
 ) => {
-	const systemChainId = registry.lookupChainIdBySpecName(specName);
-	const systemParachainInfo = relayChainInfo[systemChainId];
+    const systemChainId = registry.lookupChainIdBySpecName(specName);
+    const systemParachainInfo = relayChainInfo[systemChainId];
 
-	if (typeof assetId === 'string') {
-		await checkSystemAssets(
-			api,
-			assetId,
-			specName,
-			systemParachainInfo,
-			registry,
-			xcmDirection,
-			xcmVersion,
-			isForeignAssetsTransfer,
-			isLiquidTokenTransfer,
-		);
-	}
+    if (typeof assetId === 'string') {
+        await checkSystemAssets(
+            api,
+            assetId,
+            specName,
+            systemParachainInfo,
+            registry,
+            xcmDirection,
+            xcmVersion,
+            isForeignAssetsTransfer,
+            isLiquidTokenTransfer,
+        );
+    }
 };
 
 /**
@@ -714,23 +697,23 @@ export const checkIsValidSystemChainAssetId = async (
  * @param registry
  */
 const checkParaOriginAssetId = async (api: ApiPromise, assetId: string, specName: string, registry: Registry) => {
-	if (typeof assetId === 'string') {
-		// An assetId may be a hex value to represent a GeneralKey for erc20 tokens.
-		// These will be represented as Foreign Assets in regard to its MultiLocation
-		if (isHex(assetId)) {
-			const ethAddr = isEthereumAddress(assetId);
-			if (!ethAddr) {
-				throw new BaseError(
-					`(ParaToSystem) assetId ${assetId}, is not a valid erc20 token.`,
-					BaseErrorsEnum.InvalidAsset,
-				);
-			}
+    if (typeof assetId === 'string') {
+        // An assetId may be a hex value to represent a GeneralKey for erc20 tokens.
+        // These will be represented as Foreign Assets in regard to its MultiLocation
+        if (isHex(assetId)) {
+            const ethAddr = isEthereumAddress(assetId);
+            if (!ethAddr) {
+                throw new BaseError(
+                    `(ParaToSystem) assetId ${assetId}, is not a valid erc20 token.`,
+                    BaseErrorsEnum.InvalidAsset,
+                );
+            }
 
-			return;
-		}
+            return;
+        }
 
-		await checkParaAssets(api, assetId, specName, registry, Direction.ParaToSystem);
-	}
+        await checkParaAssets(api, assetId, specName, registry, Direction.ParaToSystem);
+    }
 };
 
 /**
@@ -740,27 +723,27 @@ const checkParaOriginAssetId = async (api: ApiPromise, assetId: string, specName
  * @param relayChainInfo
  */
 const checkSystemToSystemAssetId = async (
-	api: ApiPromise,
-	assetId: string,
-	specName: string,
-	relayChainInfo: ChainInfo<ChainInfoKeys>,
-	registry: Registry,
-	xcmDirection: Direction,
-	xcmVersion: number,
-	isForeignAssetsTransfer: boolean,
-	isLiquidTokenTransfer: boolean,
+    api: ApiPromise,
+    assetId: string,
+    specName: string,
+    relayChainInfo: ChainInfo<ChainInfoKeys>,
+    registry: Registry,
+    xcmDirection: Direction,
+    xcmVersion: number,
+    isForeignAssetsTransfer: boolean,
+    isLiquidTokenTransfer: boolean,
 ) => {
-	await checkIsValidSystemChainAssetId(
-		api,
-		assetId,
-		specName,
-		relayChainInfo,
-		registry,
-		xcmDirection,
-		xcmVersion,
-		isForeignAssetsTransfer,
-		isLiquidTokenTransfer,
-	);
+    await checkIsValidSystemChainAssetId(
+        api,
+        assetId,
+        specName,
+        relayChainInfo,
+        registry,
+        xcmDirection,
+        xcmVersion,
+        isForeignAssetsTransfer,
+        isLiquidTokenTransfer,
+    );
 };
 
 /**
@@ -771,45 +754,45 @@ const checkSystemToSystemAssetId = async (
  * @param specName
  */
 const checkParaToRelayAssetId = (assetId: string, registry: Registry, specName: string) => {
-	const relayRegistry = registry.currentRelayRegistry;
-	const relayNativeToken = relayRegistry[0].tokens[0];
-	const nativeEqAssetId = relayNativeToken === assetId;
-	const curParaId = registry.lookupChainIdBySpecName(specName);
-	const curParaRegistry = relayRegistry[curParaId];
-	const { xcAssetsData } = curParaRegistry;
+    const relayRegistry = registry.currentRelayRegistry;
+    const relayNativeToken = relayRegistry[0].tokens[0];
+    const nativeEqAssetId = relayNativeToken === assetId;
+    const curParaId = registry.lookupChainIdBySpecName(specName);
+    const curParaRegistry = relayRegistry[curParaId];
+    const { xcAssetsData } = curParaRegistry;
 
-	let assetIsRelayChainNativeAsset = false;
-	if (assetId === '') {
-		assetIsRelayChainNativeAsset = true;
-	}
+    let assetIsRelayChainNativeAsset = false;
+    if (assetId === '') {
+        assetIsRelayChainNativeAsset = true;
+    }
 
-	// If the asset equals the relays native asset exit.
-	if (nativeEqAssetId) {
-		assetIsRelayChainNativeAsset = true;
-	}
+    // If the asset equals the relays native asset exit.
+    if (nativeEqAssetId) {
+        assetIsRelayChainNativeAsset = true;
+    }
 
-	const isValidInt = validateNumber(assetId);
-	if (isValidInt && xcAssetsData && xcAssetsData.length > 0) {
-		// We assume the first xcAsset will represent the relay chain
-		// since they are all sorted in the registry.
-		if (xcAssetsData[0].asset === assetId) {
-			assetIsRelayChainNativeAsset = true;
-		}
-	}
+    const isValidInt = validateNumber(assetId);
+    if (isValidInt && xcAssetsData && xcAssetsData.length > 0) {
+        // We assume the first xcAsset will represent the relay chain
+        // since they are all sorted in the registry.
+        if (xcAssetsData[0].asset === assetId) {
+            assetIsRelayChainNativeAsset = true;
+        }
+    }
 
-	const paraIncludesRelayNativeInTokens = curParaRegistry.tokens.includes(relayNativeToken);
-	const paraIncludesRelayNativeInXcAssets = xcAssetsData && xcAssetsData[0].symbol === relayNativeToken;
+    const paraIncludesRelayNativeInTokens = curParaRegistry.tokens.includes(relayNativeToken);
+    const paraIncludesRelayNativeInXcAssets = xcAssetsData && xcAssetsData[0].symbol === relayNativeToken;
 
-	if (paraIncludesRelayNativeInTokens || paraIncludesRelayNativeInXcAssets) {
-		assetIsRelayChainNativeAsset = true;
-	}
+    if (paraIncludesRelayNativeInTokens || paraIncludesRelayNativeInXcAssets) {
+        assetIsRelayChainNativeAsset = true;
+    }
 
-	if (!assetIsRelayChainNativeAsset) {
-		throw new BaseError(
-			"The current input for assetId's does not meet our specifications for ParaToRelay transfers.",
-			BaseErrorsEnum.InvalidAsset,
-		);
-	}
+    if (!assetIsRelayChainNativeAsset) {
+        throw new BaseError(
+            "The current input for assetId's does not meet our specifications for ParaToRelay transfers.",
+            BaseErrorsEnum.InvalidAsset,
+        );
+    }
 };
 
 /**
@@ -818,27 +801,27 @@ const checkParaToRelayAssetId = (assetId: string, registry: Registry, specName: 
  * @param assetIds
  */
 export const checkAssetIdsLengthIsValid = (
-	assetIds: string[],
-	xcmPalletName: XcmPalletName,
-	assetTransferType: string | undefined,
+    assetIds: string[],
+    xcmPalletName: XcmPalletName,
+    assetTransferType: string | undefined,
 ) => {
-	if (assetIds.length > MAX_ASSETS_FOR_TRANSFER) {
-		throw new BaseError(
-			`Maximum number of assets allowed for transfer is 2. Found ${assetIds.length} assetIds`,
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (assetIds.length > MAX_ASSETS_FOR_TRANSFER) {
+        throw new BaseError(
+            `Maximum number of assets allowed for transfer is 2. Found ${assetIds.length} assetIds`,
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 
-	if (
-		assetIds.length > 1 &&
-		!assetTransferType &&
-		(xcmPalletName === XcmPalletName.polkadotXcm || xcmPalletName === XcmPalletName.xcmPallet)
-	) {
-		throw new BaseError(
-			`transferAssets transactions cannot contain more than 1 asset location id. Found ${assetIds.length} assetIds`,
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (
+        assetIds.length > 1 &&
+        !assetTransferType &&
+        (xcmPalletName === XcmPalletName.polkadotXcm || xcmPalletName === XcmPalletName.xcmPallet)
+    ) {
+        throw new BaseError(
+            `transferAssets transactions cannot contain more than 1 asset location id. Found ${assetIds.length} assetIds`,
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -847,38 +830,38 @@ export const checkAssetIdsLengthIsValid = (
  * @param assetIds
  */
 export const checkAssetIdsHaveNoDuplicates = (assetIds: string[]) => {
-	const duplicateAssetIds: string[] = [];
+    const duplicateAssetIds: string[] = [];
 
-	if (assetIds.length > 1) {
-		for (let i = 0; i < assetIds.length; i++) {
-			const asset1 = assetIds[i];
+    if (assetIds.length > 1) {
+        for (let i = 0; i < assetIds.length; i++) {
+            const asset1 = assetIds[i];
 
-			for (let j = 0; j < assetIds.length; j++) {
-				if (i === j) {
-					continue;
-				}
+            for (let j = 0; j < assetIds.length; j++) {
+                if (i === j) {
+                    continue;
+                }
 
-				const asset2 = assetIds[j];
-				if (asset1.trim().toLowerCase().replace(/ /g, '') === asset2.trim().toLowerCase().replace(/ /g, '')) {
-					duplicateAssetIds.push(asset2);
-				}
-			}
-		}
+                const asset2 = assetIds[j];
+                if (asset1.trim().toLowerCase().replace(/ /g, '') === asset2.trim().toLowerCase().replace(/ /g, '')) {
+                    duplicateAssetIds.push(asset2);
+                }
+            }
+        }
 
-		if (duplicateAssetIds.length > 0) {
-			if (assetIds[0] === '') {
-				throw new BaseError(
-					`AssetIds must be unique. Found duplicate native relay assets as empty strings`,
-					BaseErrorsEnum.InvalidInput,
-				);
-			}
+        if (duplicateAssetIds.length > 0) {
+            if (assetIds[0] === '') {
+                throw new BaseError(
+                    `AssetIds must be unique. Found duplicate native relay assets as empty strings`,
+                    BaseErrorsEnum.InvalidInput,
+                );
+            }
 
-			throw new BaseError(
-				`AssetIds must be unique. Found duplicate assetId ${duplicateAssetIds[0]}`,
-				BaseErrorsEnum.InvalidInput,
-			);
-		}
-	}
+            throw new BaseError(
+                `AssetIds must be unique. Found duplicate assetId ${duplicateAssetIds[0]}`,
+                BaseErrorsEnum.InvalidInput,
+            );
+        }
+    }
 };
 
 /**
@@ -887,65 +870,68 @@ export const checkAssetIdsHaveNoDuplicates = (assetIds: string[]) => {
  * @param assetIds
  */
 export const checkAssetIdsAreOfSameAssetIdType = (assetIds: string[]) => {
-	if (assetIds.length > 1) {
-		let relayDefaultValueFound = false;
-		let symbolAssetIdFound = '';
-		let integerAssetIdFound = '';
-		let multiLocationAssetIdFound = '';
+    if (assetIds.length > 1) {
+        let relayDefaultValueFound = false;
+        let symbolAssetIdFound = '';
+        let integerAssetIdFound = '';
+        let multiLocationAssetIdFound = '';
 
-		for (const assetId of assetIds) {
-			if (assetId === '') {
-				relayDefaultValueFound = true;
-				continue;
-			}
+        for (const assetId of assetIds) {
+            if (assetId === '') {
+                relayDefaultValueFound = true;
+                continue;
+            }
 
-			const isValidInt = validateNumber(assetId);
-			if (isValidInt) {
-				integerAssetIdFound = assetId;
-			} else if (assetId.toLowerCase().includes('parents')) {
-				multiLocationAssetIdFound = assetId;
-			} else {
-				symbolAssetIdFound = assetId;
-			}
-		}
+            const isValidInt = validateNumber(assetId);
+            if (isValidInt) {
+                integerAssetIdFound = assetId;
+            } else if (assetId.toLowerCase().includes('parents')) {
+                multiLocationAssetIdFound = assetId;
+            } else {
+                symbolAssetIdFound = assetId;
+            }
+        }
 
-		if (relayDefaultValueFound && multiLocationAssetIdFound) {
-			throw new BaseError(
-				`Found both default relay native asset and foreign asset with assetId: ${multiLocationAssetIdFound}. Relay native asset and foreign assets can't be transferred within the same call.`,
-				BaseErrorsEnum.InvalidInput,
-			);
-		}
+        if (relayDefaultValueFound && multiLocationAssetIdFound) {
+            throw new BaseError(
+                `Found both default relay native asset and foreign asset with assetId: ${multiLocationAssetIdFound}. Relay native asset and foreign assets can't be transferred within the same call.`,
+                BaseErrorsEnum.InvalidInput,
+            );
+        }
 
-		if (integerAssetIdFound && multiLocationAssetIdFound) {
-			throw new BaseError(
-				`Found both native asset with assetID ${integerAssetIdFound} and foreign asset with assetId ${multiLocationAssetIdFound}. Native assets and foreign assets can't be transferred within the same call.`,
-				BaseErrorsEnum.InvalidInput,
-			);
-		}
+        if (integerAssetIdFound && multiLocationAssetIdFound) {
+            throw new BaseError(
+                `Found both native asset with assetID ${integerAssetIdFound} and foreign asset with assetId ${multiLocationAssetIdFound}. Native assets and foreign assets can't be transferred within the same call.`,
+                BaseErrorsEnum.InvalidInput,
+            );
+        }
 
-		if (symbolAssetIdFound && multiLocationAssetIdFound) {
-			throw new BaseError(
-				`Found both symbol ${symbolAssetIdFound} and multilocation assetId ${multiLocationAssetIdFound}. Asset Ids must be symbol and integer or multilocation exclusively.`,
-				BaseErrorsEnum.InvalidInput,
-			);
-		}
-	}
+        if (symbolAssetIdFound && multiLocationAssetIdFound) {
+            throw new BaseError(
+                `Found both symbol ${symbolAssetIdFound} and multilocation assetId ${multiLocationAssetIdFound}. Asset Ids must be symbol and integer or multilocation exclusively.`,
+                BaseErrorsEnum.InvalidInput,
+            );
+        }
+    }
 };
 
 /**
- * Checks to ensure that the xcmVersion is at least 3 for Bridge transactions
+ * Checks to ensure that the xcmVersion is at least 3 for a SystemToBridge transaction
  *
  * @param xcmDirection
  * @param xcmVersion
  */
-export const checkXcmVersionIsValidForBridgeTx = (xcmVersion: number) => {
-	if (xcmVersion && xcmVersion < 3) {
-		throw new BaseError('Bridge transactions require XCM version 3 or greater', BaseErrorsEnum.InvalidXcmVersion);
-	}
+export const checkXcmVersionIsValidForSystemToBridge = (xcmVersion: number) => {
+    if (xcmVersion && xcmVersion < 3) {
+        throw new BaseError(
+            'SystemToBridge transactions require XCM version 3 or greater',
+            BaseErrorsEnum.InvalidXcmVersion,
+        );
+    }
 };
 
 /**
- * Checks to ensure that required inputs are provided for Bridge transactions
+ * Checks to ensure that required inputs are provided for SystemToBridge transactions
  *
  * @param paysWithFeeDest
  * @param assetTransferType
@@ -953,43 +939,43 @@ export const checkXcmVersionIsValidForBridgeTx = (xcmVersion: number) => {
  * @param feesTransferType
  * @param remoteReserveFeesTransferTypeLocation
  */
-export const checkBridgeTxInputs = (
-	paysWithFeeDest: string | undefined,
-	assetTransferType: string | undefined,
-	remoteReserveAssetTransferTypeLocation: string | undefined,
-	feesTransferType: string | undefined,
-	remoteReserveFeesTransferTypeLocation: string | undefined,
+export const checkSystemToBridgeInputs = (
+    paysWithFeeDest: string | undefined,
+    assetTransferType: string | undefined,
+    remoteReserveAssetTransferTypeLocation: string | undefined,
+    feesTransferType: string | undefined,
+    remoteReserveFeesTransferTypeLocation: string | undefined,
 ) => {
-	if (assetTransferType && !paysWithFeeDest) {
-		throw new BaseError(
-			'paysWithFeeDest input is required for bridge transactions when assetTransferType is provided',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
-	if (assetTransferType && assetTransferType === 'RemoteReserve' && !remoteReserveAssetTransferTypeLocation) {
-		throw new BaseError(
-			'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
-	if (feesTransferType && feesTransferType === 'RemoteReserve' && !remoteReserveFeesTransferTypeLocation) {
-		throw new BaseError(
-			'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (assetTransferType && !paysWithFeeDest) {
+        throw new BaseError(
+            'paysWithFeeDest input is required for bridge transactions when assetTransferType is provided',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
+    if (assetTransferType && assetTransferType === 'RemoteReserve' && !remoteReserveAssetTransferTypeLocation) {
+        throw new BaseError(
+            'remoteReserveAssetTransferTypeLocation input is required for bridge transactions when asset transfer type is RemoteReserve',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
+    if (feesTransferType && feesTransferType === 'RemoteReserve' && !remoteReserveFeesTransferTypeLocation) {
+        throw new BaseError(
+            'remoteReserveFeeAssetTransferTypeLocation input is required for bridge transactions when fee asset transfer type is RemoteReserve',
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 export const checkPaysWithFeeDestAssetIdIsInAssets = (assetIds: string[], paysWithFeeDest: string | undefined) => {
-	if (!paysWithFeeDest) {
-		return;
-	}
+    if (!paysWithFeeDest) {
+        return;
+    }
 
-	if (!assetIds.includes(paysWithFeeDest)) {
-		throw new BaseError(
-			`paysWithFeeDest asset must be present in assets to be transferred. Did not find ${paysWithFeeDest} in ${assetIds.toString()}`,
-		);
-	}
+    if (!assetIds.includes(paysWithFeeDest)) {
+        throw new BaseError(
+            `paysWithFeeDest asset must be present in assets to be transferred. Did not find ${paysWithFeeDest} in ${assetIds.toString()}`,
+        );
+    }
 };
 
 /**
@@ -999,19 +985,19 @@ export const checkPaysWithFeeDestAssetIdIsInAssets = (assetIds: string[], paysWi
  * @param paysWithFeeDest
  */
 export const checkXcmVersionIsValidForPaysWithFeeDest = (
-	xcmDirection: Direction,
-	xcmVersion?: number,
-	paysWithFeeDest?: string,
+    xcmDirection: Direction,
+    xcmVersion?: number,
+    paysWithFeeDest?: string,
 ) => {
-	if (
-		xcmDirection != Direction.ParaToSystem &&
-		xcmDirection != Direction.ParaToPara &&
-		paysWithFeeDest &&
-		xcmVersion &&
-		xcmVersion < 3
-	) {
-		throw new BaseError('paysWithFeeDest requires XCM version 3 or greater', BaseErrorsEnum.InvalidXcmVersion);
-	}
+    if (
+        xcmDirection != Direction.ParaToSystem &&
+        xcmDirection != Direction.ParaToPara &&
+        paysWithFeeDest &&
+        xcmVersion &&
+        xcmVersion < 3
+    ) {
+        throw new BaseError('paysWithFeeDest requires XCM version 3 or greater', BaseErrorsEnum.InvalidXcmVersion);
+    }
 };
 
 /**
@@ -1021,12 +1007,12 @@ export const checkXcmVersionIsValidForPaysWithFeeDest = (
  * @param isLiquidTokenTransfer
  */
 export const checkLiquidTokenTransferDirectionValidity = (xcmDirection: Direction, isLiquidTokenTransfer: boolean) => {
-	if (xcmDirection !== Direction.SystemToPara && isLiquidTokenTransfer) {
-		throw new BaseError(
-			`isLiquidTokenTransfer may not be true for the xcmDirection: ${xcmDirection}.`,
-			BaseErrorsEnum.InvalidInput,
-		);
-	}
+    if (xcmDirection !== Direction.SystemToPara && isLiquidTokenTransfer) {
+        throw new BaseError(
+            `isLiquidTokenTransfer may not be true for the xcmDirection: ${xcmDirection}.`,
+            BaseErrorsEnum.InvalidInput,
+        );
+    }
 };
 
 /**
@@ -1040,69 +1026,69 @@ export const checkLiquidTokenTransferDirectionValidity = (xcmDirection: Directio
  * @param registry
  */
 export const checkAssetIdInput = async (
-	api: ApiPromise,
-	assetIds: string[],
-	relayChainInfo: ChainInfo<ChainInfoKeys>,
-	specName: string,
-	xcmDirection: Direction,
-	registry: Registry,
-	xcmVersion: number,
-	isForeignAssetsTransfer: boolean,
-	isLiquidTokenTransfer: boolean,
+    api: ApiPromise,
+    assetIds: string[],
+    relayChainInfo: ChainInfo<ChainInfoKeys>,
+    specName: string,
+    xcmDirection: Direction,
+    registry: Registry,
+    xcmVersion: number,
+    isForeignAssetsTransfer: boolean,
+    isLiquidTokenTransfer: boolean,
 ) => {
-	for (let i = 0; i < assetIds.length; i++) {
-		const assetId = assetIds[i];
+    for (let i = 0; i < assetIds.length; i++) {
+        const assetId = assetIds[i];
 
-		checkIfAssetIdIsBlankSpace(assetId);
+        checkIfAssetIdIsBlankSpace(assetId);
 
-		if (xcmDirection === Direction.RelayToSystem) {
-			checkRelayToSystemAssetId(assetId, relayChainInfo);
-		}
+        if (xcmDirection === Direction.RelayToSystem) {
+            checkRelayToSystemAssetId(assetId, relayChainInfo, registry);
+        }
 
-		if (xcmDirection === Direction.RelayToPara) {
-			checkRelayToParaAssetId(assetId, relayChainInfo);
-		}
+        if (xcmDirection === Direction.RelayToPara) {
+            checkRelayToParaAssetId(assetId, relayChainInfo);
+        }
 
-		if (xcmDirection === Direction.SystemToRelay) {
-			checkSystemToRelayAssetId(assetId, relayChainInfo);
-		}
+        if (xcmDirection === Direction.SystemToRelay) {
+            checkSystemToRelayAssetId(assetId, relayChainInfo, registry);
+        }
 
-		if (xcmDirection === Direction.SystemToPara) {
-			await checkSystemToParaAssetId(
-				api,
-				assetId,
-				specName,
-				relayChainInfo,
-				registry,
-				xcmDirection,
-				xcmVersion,
-				isForeignAssetsTransfer,
-				isLiquidTokenTransfer,
-			);
-		}
+        if (xcmDirection === Direction.SystemToPara) {
+            await checkSystemToParaAssetId(
+                api,
+                assetId,
+                specName,
+                relayChainInfo,
+                registry,
+                xcmDirection,
+                xcmVersion,
+                isForeignAssetsTransfer,
+                isLiquidTokenTransfer,
+            );
+        }
 
-		if (xcmDirection === Direction.SystemToSystem) {
-			await checkSystemToSystemAssetId(
-				api,
-				assetId,
-				specName,
-				relayChainInfo,
-				registry,
-				xcmDirection,
-				xcmVersion,
-				isForeignAssetsTransfer,
-				isLiquidTokenTransfer,
-			);
-		}
+        if (xcmDirection === Direction.SystemToSystem) {
+            await checkSystemToSystemAssetId(
+                api,
+                assetId,
+                specName,
+                relayChainInfo,
+                registry,
+                xcmDirection,
+                xcmVersion,
+                isForeignAssetsTransfer,
+                isLiquidTokenTransfer,
+            );
+        }
 
-		if (xcmDirection === Direction.ParaToSystem || xcmDirection === Direction.ParaToPara) {
-			await checkParaOriginAssetId(api, assetId, specName, registry);
-		}
+        if (xcmDirection === Direction.ParaToSystem || xcmDirection === Direction.ParaToPara) {
+            await checkParaOriginAssetId(api, assetId, specName, registry);
+        }
 
-		if (xcmDirection === Direction.ParaToRelay) {
-			checkParaToRelayAssetId(assetId, registry, specName);
-		}
-	}
+        if (xcmDirection === Direction.ParaToRelay) {
+            checkParaToRelayAssetId(assetId, registry, specName);
+        }
+    }
 };
 
 /**
@@ -1116,146 +1102,131 @@ export const checkAssetIdInput = async (
  * @param registry
  */
 export const checkXcmTxInputs = async (baseArgs: XcmBaseArgsWithPallet, opts: CheckXcmTxInputsOpts) => {
-	const { api, direction, assetIds, amounts, destChainId, xcmVersion, specName, registry, xcmPallet } = baseArgs;
-	const {
-		paysWithFeeDest,
-		isForeignAssetsTransfer,
-		isLiquidTokenTransfer,
-		isPrimaryParachainNativeAsset,
-		assetTransferType,
-		remoteReserveAssetTransferTypeLocation,
-		feesTransferType,
-		remoteReserveFeesTransferTypeLocation,
-	} = opts;
-	const relayChainInfo = registry.currentRelayRegistry;
+    const { api, direction, assetIds, amounts, destChainId, xcmVersion, specName, registry, xcmPallet } = baseArgs;
+    const {
+        paysWithFeeDest,
+        isForeignAssetsTransfer,
+        isLiquidTokenTransfer,
+        isPrimaryParachainNativeAsset,
+        assetTransferType,
+        remoteReserveAssetTransferTypeLocation,
+        feesTransferType,
+        remoteReserveFeesTransferTypeLocation,
+    } = opts;
+    const relayChainInfo = registry.currentRelayRegistry;
 
-	if (isPrimaryParachainNativeAsset) {
-		/**
-		 * Checks that the assetIds length is correct for primary native parachain asset tx
-		 */
-		checkParaPrimaryAssetAssetIdsLength(assetIds);
-		/**
-		 * Checks that the amounts length is correct for primary native parachain asset tx
-		 */
-		checkParaPrimaryAssetAmountsLength(amounts);
-	}
+    if (isPrimaryParachainNativeAsset) {
+        /**
+         * Checks that the assetIds length is correct for primary native parachain asset tx
+         */
+        checkParaPrimaryAssetAssetIdsLength(assetIds);
+        /**
+         * Checks that the amounts length is correct for primary native parachain asset tx
+         */
+        checkParaPrimaryAssetAmountsLength(amounts);
+    }
 
-	/**
-	 * Checks that the XcmVersion works with `PaysWithFeeDest` option
-	 */
-	checkXcmVersionIsValidForPaysWithFeeDest(direction, xcmVersion, paysWithFeeDest);
+    /**
+     * Checks that the XcmVersion works with `PaysWithFeeDest` option
+     */
+    checkXcmVersionIsValidForPaysWithFeeDest(direction, xcmVersion, paysWithFeeDest);
 
-	/**
-	 * Checks that the direction of the `transferLiquidToken` option is correct.
-	 */
-	checkLiquidTokenTransferDirectionValidity(direction, isLiquidTokenTransfer);
+    /**
+     * Checks that the direction of the `transferLiquidToken` option is correct.
+     */
+    checkLiquidTokenTransferDirectionValidity(direction, isLiquidTokenTransfer);
 
-	/**
-	 * Checks to ensure that assetId's have a length no greater than MAX_ASSETS_FOR_TRANSFER
-	 */
-	checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
+    /**
+     * Checks to ensure that assetId's have a length no greater than MAX_ASSETS_FOR_TRANSFER
+     */
+    checkAssetIdsLengthIsValid(assetIds, xcmPallet, assetTransferType);
 
-	/**
-	 * Checks to ensure that assetId's have no duplicate values
-	 */
-	checkAssetIdsHaveNoDuplicates(assetIds);
+    /**
+     * Checks to ensure that assetId's have no duplicate values
+     */
+    checkAssetIdsHaveNoDuplicates(assetIds);
 
-	/**
-	 * Checks to ensure that assetId's are either empty string, symbol and integer values or multilocations
-	 */
-	checkAssetIdsAreOfSameAssetIdType(assetIds);
+    /**
+     * Checks to ensure that assetId's are either empty string, symbol and integer values or multilocations
+     */
+    checkAssetIdsAreOfSameAssetIdType(assetIds);
 
-	/**
-	 * Checks to ensure that assetId's are either valid integer numbers or native asset token symbols
-	 */
-	await checkAssetIdInput(
-		api,
-		assetIds,
-		relayChainInfo,
-		specName,
-		direction,
-		registry,
-		xcmVersion,
-		isForeignAssetsTransfer,
-		isLiquidTokenTransfer,
-	);
+    /**
+     * Checks to ensure that assetId's are either valid integer numbers or native asset token symbols
+     */
+    await checkAssetIdInput(
+        api,
+        assetIds,
+        relayChainInfo,
+        specName,
+        direction,
+        registry,
+        xcmVersion,
+        isForeignAssetsTransfer,
+        isLiquidTokenTransfer,
+    );
 
-	if (direction === Direction.RelayToSystem) {
-		checkRelayAssetIdLength(assetIds);
-		checkRelayAmountsLength(amounts);
-	}
+    if (direction === Direction.RelayToSystem) {
+        checkRelayAssetIdLength(assetIds);
+        checkRelayAmountsLength(amounts);
+    }
 
-	if (direction === Direction.RelayToPara) {
-		checkRelayAssetIdLength(assetIds);
-		checkRelayAmountsLength(amounts);
-	}
+    if (direction === Direction.RelayToPara) {
+        checkRelayAssetIdLength(assetIds);
+        checkRelayAmountsLength(amounts);
+    }
 
-	if (direction === Direction.RelayToBridge) {
-		checkRelayAssetIdLength(assetIds);
-		checkRelayAmountsLength(amounts);
-		getGlobalConsensusSystemName(destChainId);
-		checkBridgeTxInputs(
-			paysWithFeeDest,
-			assetTransferType,
-			remoteReserveAssetTransferTypeLocation,
-			feesTransferType,
-			remoteReserveFeesTransferTypeLocation,
-		);
-		checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
-		checkXcmVersionIsValidForBridgeTx(xcmVersion);
-	}
+    if (direction === Direction.SystemToRelay) {
+        checkRelayAssetIdLength(assetIds);
+        checkRelayAmountsLength(amounts);
+    }
 
-	if (direction === Direction.SystemToRelay) {
-		checkRelayAssetIdLength(assetIds);
-		checkRelayAmountsLength(amounts);
-	}
+    if (direction === Direction.SystemToPara) {
+        if (isForeignAssetsTransfer) {
+            checkMultiLocationIdLength(assetIds);
+            checkMultiLocationAmountsLength(amounts);
+            checkAssetsAmountMatch(assetIds, amounts);
+            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
+        }
+        checkAssetsAmountMatch(assetIds, amounts);
+    }
 
-	if (direction === Direction.SystemToPara) {
-		if (isForeignAssetsTransfer) {
-			checkMultiLocationIdLength(assetIds);
-			checkMultiLocationAmountsLength(amounts);
-			checkAssetsAmountMatch(assetIds, amounts);
-			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
-		}
-		checkAssetsAmountMatch(assetIds, amounts);
-	}
+    if (direction === Direction.SystemToSystem) {
+        if (isForeignAssetsTransfer) {
+            checkAssetsAmountMatch(assetIds, amounts);
+            checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
+        }
+        checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
+    }
 
-	if (direction === Direction.SystemToSystem) {
-		if (isForeignAssetsTransfer) {
-			checkAssetsAmountMatch(assetIds, amounts);
-			checkMultiLocationsContainOnlyNativeOrForeignAssetsOfDestChain(direction, destChainId, assetIds);
-		}
-		checkIfNativeRelayChainAssetPresentInMultiAssetIdList(assetIds, registry);
-	}
+    if (direction === Direction.SystemToBridge) {
+        checkMultiLocationIdLength(assetIds);
+        checkMultiLocationAmountsLength(amounts);
+        checkAssetsAmountMatch(assetIds, amounts);
+        getGlobalConsensusSystemName(destChainId);
+        checkSystemToBridgeInputs(
+            paysWithFeeDest,
+            assetTransferType,
+            remoteReserveAssetTransferTypeLocation,
+            feesTransferType,
+            remoteReserveFeesTransferTypeLocation,
+        );
+        checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
+        checkXcmVersionIsValidForSystemToBridge(xcmVersion);
+    }
 
-	if (direction === Direction.SystemToBridge) {
-		checkMultiLocationIdLength(assetIds);
-		checkMultiLocationAmountsLength(amounts);
-		checkAssetsAmountMatch(assetIds, amounts);
-		getGlobalConsensusSystemName(destChainId);
-		checkBridgeTxInputs(
-			paysWithFeeDest,
-			assetTransferType,
-			remoteReserveAssetTransferTypeLocation,
-			feesTransferType,
-			remoteReserveFeesTransferTypeLocation,
-		);
-		checkPaysWithFeeDestAssetIdIsInAssets(assetIds, paysWithFeeDest);
-		checkXcmVersionIsValidForBridgeTx(xcmVersion);
-	}
+    if (direction === Direction.ParaToSystem || direction === Direction.ParaToPara) {
+        CheckXTokensPalletOriginIsNonForeignAssetTx(direction, xcmPallet, isForeignAssetsTransfer);
+        checkAssetsAmountMatch(assetIds, amounts, isPrimaryParachainNativeAsset);
+    }
 
-	if (direction === Direction.ParaToSystem || direction === Direction.ParaToPara) {
-		CheckXTokensPalletOriginIsNonForeignAssetTx(direction, xcmPallet, isForeignAssetsTransfer);
-		checkAssetsAmountMatch(assetIds, amounts, isPrimaryParachainNativeAsset);
-	}
-
-	if (direction === Direction.ParaToRelay) {
-		checkRelayAssetIdLength(assetIds);
-		checkRelayAmountsLength(amounts);
-	}
+    if (direction === Direction.ParaToRelay) {
+        checkRelayAssetIdLength(assetIds);
+        checkRelayAmountsLength(amounts);
+    }
 };
 
 export const checkClaimAssetsInputs = (assets: string[], amounts: string[]) => {
-	checkAssetsAmountMatch(assets, amounts);
-	checkAssetIdsAreOfSameAssetIdType(assets);
+    checkAssetsAmountMatch(assets, amounts);
+    checkAssetIdsAreOfSameAssetIdType(assets);
 };


### PR DESCRIPTION
This PR improves error messaging which previously only mentioned integer assetIDs and symbols as inputs by adding asset locations

closes: [#405](https://github.com/paritytech/asset-transfer-api/issues/405)