### PR TITLE
fix(bug): fix fetchFeeInfo partial fee

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ const call = assetsApi.createTransferTransaction(
 ### AssetTransferApi & AssetTransferApiOpts & TransferArgsOpts
 
 ```Typescript
-// The AssetTransferApi exposes one method as of now called: `createTransferTransaction`
+// The AssetTransferApi method: `createTransferTransaction`
 
 /**
  * Create an XCM transaction to transfer Assets, or native tokens from one
@@ -114,6 +114,20 @@ AssetTransferApi.createTransferTransaction(
 )
 ```
 
+```typescript
+// The AssetTransferApi method: `fetchFeeInfo`
+
+/**
+ * Fetch estimated fee information for an extrinsic
+ *
+ * @param tx a payload, call or submittable
+ * @param format The format the tx is in
+ */
+AssetTransferApi.fetchFeeInfo(
+  	tx: ConstructedFormat<T>,
+	format: T,
+)
+```
 
 ```typescript
 // AssetTransferApiOpts are the options for the `AssetTransferApi`

--- a/examples/fetchFeeInfo.ts
+++ b/examples/fetchFeeInfo.ts
@@ -8,9 +8,10 @@ import { TxResult } from '../src/types';
 import { GREEN, PURPLE, RESET } from './colors';
 
 /**
- * In this example we are creating a call to send PHA from a Moonriver (Parachain) account
- * to a Kusama Khala (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and a `weightLimit` option is provided declaring that
- * it will be a weight limited tx with a custom `refTime` and `proofSize`.
+ * In this example we are creating a call to send WETH from a Bifrost Polkadot (Parachain) account
+ * to a Polkadot AssetHub (System Parachain) account, where the `xcmVersion` is set to 3.
+ *
+ * `fetchFeeInfo` returns the associated weight of the transaction, the transaction's class and the estimated fee denoted in the native asset of the origin chain.
  *
  */
 const main = async () => {

--- a/examples/fetchFeeInfo.ts
+++ b/examples/fetchFeeInfo.ts
@@ -1,0 +1,49 @@
+/**
+ * When importing from @substrate/asset-transfer-api it would look like the following
+ *
+ * import { AssetTransferApi, constructApiPromise } from '@substrate/asset-transfer-api'
+ */
+import { AssetTransferApi, constructApiPromise } from '../src';
+import { TxResult } from '../src/types';
+import { GREEN, PURPLE, RESET } from './colors';
+
+/**
+ * In this example we are creating a call to send PHA from a Moonriver (Parachain) account
+ * to a Kusama Khala (Parachain) account, where the `xcmVersion` is set to safeXcmVersion and a `weightLimit` option is provided declaring that
+ * it will be a weight limited tx with a custom `refTime` and `proofSize`.
+ *
+ */
+const main = async () => {
+	const safeXcmVersion = 3;
+	const { api, specName } = await constructApiPromise('wss://bifrost-polkadot-rpc.dwellir.com');
+	const assetApi = new AssetTransferApi(api, specName, safeXcmVersion);
+	let callInfo: TxResult<'call'>;
+	try {
+		callInfo = await assetApi.createTransferTransaction(
+			'1000',
+			'0xc4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a063',
+			['WETH'],
+			['1000000000000000000'],
+			{
+				format: 'call',
+				xcmVersion: safeXcmVersion,
+			},
+		);
+
+		const feeInfo = await assetApi.fetchFeeInfo(callInfo.tx, 'call');
+
+		console.log(
+			`${PURPLE}The following feeInfo data that is returned:\n${GREEN}${JSON.stringify(feeInfo?.toHuman(), null, 4)}`,
+		);
+	} catch (e) {
+		console.error(e);
+		throw Error(e as string);
+	}
+
+	const decoded = assetApi.decodeExtrinsic(callInfo.tx, 'call');
+	console.log(`\n${PURPLE}The following decoded tx:\n${GREEN} ${JSON.stringify(JSON.parse(decoded), null, 4)}${RESET}`);
+};
+
+main()
+	.catch((err) => console.error(err))
+	.finally(() => process.exit());

--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -1834,4 +1834,39 @@ describe('AssetTransferAPI', () => {
 			expect(result).toBe(false);
 		});
 	});
+	describe('extToU8a', () => {
+		it('Should correctly return a Uint8Array from an extrinsic for AssetHub', async () => {
+			const assetHubCall =
+				'0x1f0b04010100a90f0400010100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a063040401000013000064a7b3b6e00d0000000000';
+			const ext = westmintAssetsApi.api.registry.createType('Extrinsic', { method: assetHubCall }, { version: 4 });
+			const fakeSignerAddress = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+			const u8a = await westmintAssetsApi['extToU8a'](westmintAssetsApi.api, ext, fakeSignerAddress);
+
+			expect(u8a.toString()).toEqual(
+				'165,2,132,0,212,53,147,199,21,253,211,28,97,20,26,189,4,169,159,214,130,44,133,88,133,76,205,227,154,86,132,231,165,109,162,125,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,69,2,40,0,0,0,31,11,4,1,1,0,169,15,4,0,1,1,0,196,219,123,203,115,62,17,124,11,52,172,150,53,75,16,212,126,132,160,6,185,231,230,106,34,157,23,78,143,242,160,99,4,4,1,0,0,19,0,0,100,167,179,182,224,13,0,0,0,0,0',
+			);
+		});
+		it('Should correctly return a Uint8Array from an extrinsic for Bifrost', async () => {
+			const bifrostCall =
+				'0x46010100010200451f0608010a0013000064a7b3b6e00d01010200a10f0100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06300';
+			const ext = bifrostAssetsApi.api.registry.createType('Extrinsic', { method: bifrostCall }, { version: 4 });
+			const fakeSignerAddress = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+			const u8a = await bifrostAssetsApi['extToU8a'](bifrostAssetsApi.api, ext, fakeSignerAddress);
+
+			expect(u8a.toString()).toEqual(
+				'229,2,132,0,212,53,147,199,21,253,211,28,97,20,26,189,4,169,159,214,130,44,133,88,133,76,205,227,154,86,132,231,165,109,162,125,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,69,2,40,0,0,70,1,4,1,2,9,7,4,3,0,192,42,170,57,178,35,254,141,10,14,92,79,39,234,217,8,60,117,108,194,0,19,0,0,100,167,179,182,224,13,4,1,2,0,161,15,1,0,196,219,123,203,115,62,17,124,11,52,172,150,53,75,16,212,126,132,160,6,185,231,230,106,34,157,23,78,143,242,160,99,0',
+			);
+		});
+		it('Should correctly return a Uint8Array from an extrinsic for Moonriver', async () => {
+			const moonriverCall =
+				'0x6a010100010200451f0608010a0013000064a7b3b6e00d01010200451f0100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06300';
+			const ext = moonriverAssetsApi.api.registry.createType('Extrinsic', { method: moonriverCall }, { version: 4 });
+			const fakeSignerAddress = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+			const u8a = await moonriverAssetsApi['extToU8a'](moonriverAssetsApi.api, ext, fakeSignerAddress);
+
+			expect(u8a.toString()).toEqual(
+				'105,2,132,53,71,114,119,118,97,69,70,53,122,88,98,50,54,70,122,57,114,99,81,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,69,2,40,0,106,1,1,0,1,2,0,69,31,6,8,1,10,0,19,0,0,100,167,179,182,224,13,1,1,2,0,69,31,1,0,196,219,123,203,115,62,17,124,11,52,172,150,53,75,16,212,126,132,160,6,185,231,230,106,34,157,23,78,143,242,160,99,0',
+			);
+		});
+	});
 });

--- a/src/integrationTests/parachains/bifrost.spec.ts
+++ b/src/integrationTests/parachains/bifrost.spec.ts
@@ -812,6 +812,18 @@ describe('Bifrost', () => {
 					});
 					expect(res.tx.toRawType()).toEqual('Extrinsic');
 				});
+				it('Should correctly estimate the feeInfo for a transferMultiasset extrinsic', async () => {
+					const res = await bifrostTransferMultiasset(bifrostATA, 'submittable', 3, '0', 'ksm', {
+						weightLimit: {
+							refTime: '1000',
+							proofSize: '2000',
+						},
+						isForeignAssetsTransfer: false,
+						isLiquidTokenTransfer: false,
+					});
+					const fees = await bifrostATA.fetchFeeInfo(res.tx, 'submittable');
+					expect(fees?.partialFee.toString()).toEqual('171607466');
+				});
 			});
 		});
 	});

--- a/src/testHelpers/adjustedMockBifrostParachainApi.ts
+++ b/src/testHelpers/adjustedMockBifrostParachainApi.ts
@@ -1,7 +1,20 @@
 import { ApiPromise } from '@polkadot/api';
-import type { Header } from '@polkadot/types/interfaces';
+import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
+import type { Call, Extrinsic, Header } from '@polkadot/types/interfaces';
+import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { mockBifrostParachainApi } from './mockBifrostParachainApi';
+import { mockWeightInfo } from './mockWeightInfo';
+
+const queryInfoCallAt = () =>
+	Promise.resolve().then(() => mockBifrostParachainApi.createType('RuntimeDispatchInfoV2', mockWeightInfo));
+const mockApiAt = {
+	call: {
+		transactionPaymentApi: {
+			queryInfo: queryInfoCallAt,
+		},
+	},
+};
 
 const getSystemSafeXcmVersion = () =>
 	Promise.resolve().then(() => {
@@ -28,6 +41,10 @@ const getHeader = (): Promise<Header> =>
 	);
 
 const accountNextIndex = () => mockBifrostParachainApi.registry.createType('u32', 10);
+const mockSubmittableExt = mockBifrostParachainApi.registry.createType(
+	'Extrinsic',
+	'0x49010446010401020907040300c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20013000064a7b3b6e00d04010200a10f0100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06300',
+) as SubmittableExtrinsic<'promise', ISubmittableResult>;
 
 export const adjustedMockBifrostParachainApi = {
 	registry: mockBifrostParachainApi.registry,
@@ -47,17 +64,27 @@ export const adjustedMockBifrostParachainApi = {
 			safeXcmVersion: getSystemSafeXcmVersion,
 		},
 	},
-	tx: {
-		polkadotXcm: {
-			limitedReserveTransferAssets: mockBifrostParachainApi.tx['polkadotXcm'].limitedReserveTransferAssets,
-			reserveTransferAssets: mockBifrostParachainApi.tx['polkadotXcm'].reserveTransferAssets,
-			teleportAssets: mockBifrostParachainApi.tx['polkadotXcm'].teleportAssets,
-			limitedTeleportAssets: mockBifrostParachainApi.tx['polkadotXcm'].limitedTeleportAssets,
+	tx: Object.assign(
+		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {
+			return mockSubmittableExt;
 		},
-		xTokens: {
-			transferMultiasset: mockBifrostParachainApi.tx['xTokens'].transferMultiasset,
-			transferMultiassetWithFee: mockBifrostParachainApi.tx['xTokens'].transferMultiassetWithFee,
-			transferMultiassets: mockBifrostParachainApi.tx['xTokens'].transferMultiassets,
+		{
+			polkadotXcm: {
+				limitedReserveTransferAssets: mockBifrostParachainApi.tx['polkadotXcm'].limitedReserveTransferAssets,
+				reserveTransferAssets: mockBifrostParachainApi.tx['polkadotXcm'].reserveTransferAssets,
+				teleportAssets: mockBifrostParachainApi.tx['polkadotXcm'].teleportAssets,
+				limitedTeleportAssets: mockBifrostParachainApi.tx['polkadotXcm'].limitedTeleportAssets,
+			},
+			xTokens: {
+				transferMultiasset: mockBifrostParachainApi.tx['xTokens'].transferMultiasset,
+				transferMultiassetWithFee: mockBifrostParachainApi.tx['xTokens'].transferMultiassetWithFee,
+				transferMultiassets: mockBifrostParachainApi.tx['xTokens'].transferMultiassets,
+			},
+		},
+	),
+	call: {
+		transactionPaymentApi: {
+			queryInfo: mockApiAt.call.transactionPaymentApi.queryInfo,
 		},
 	},
 	runtimeVersion: {

--- a/src/testHelpers/adjustedMockMoonriverParachainApi.ts
+++ b/src/testHelpers/adjustedMockMoonriverParachainApi.ts
@@ -1,9 +1,11 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import { ApiPromise } from '@polkadot/api';
+import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import { Metadata, Option, StorageKey, TypeRegistry, u128 } from '@polkadot/types';
-import type { Header } from '@polkadot/types/interfaces';
+import type { Call, Extrinsic, Header } from '@polkadot/types/interfaces';
 import { PalletAssetsAssetDetails, PalletAssetsAssetMetadata } from '@polkadot/types/lookup';
+import type { ISubmittableResult } from '@polkadot/types/types';
 import { getSpecTypes } from '@polkadot/types-known';
 
 import { moonriverV2302 } from './metadata/moonriverV2302';
@@ -416,6 +418,10 @@ const metadata = (assetId: number): Promise<PalletAssetsAssetMetadata> =>
 
 		return mockMoonriverParachainApi.registry.createType('PalletAssetsAssetMetadata', {});
 	});
+const mockSubmittableExt = mockMoonriverParachainApi.registry.createType(
+	'Extrinsic',
+	'0x0501046a010100010200451f0608010a0013000064a7b3b6e00d01010200451f0100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06300',
+) as SubmittableExtrinsic<'promise', ISubmittableResult>;
 
 export const adjustedMockMoonriverParachainApi = {
 	registry: mockMoonriverParachainApi.registry,
@@ -564,19 +570,24 @@ export const adjustedMockMoonriverParachainApi = {
 			metadata: metadata,
 		},
 	},
-	tx: {
-		polkadotXcm: {
-			limitedReserveTransferAssets: mockMoonriverParachainApi.tx['polkadotXcm'].limitedReserveTransferAssets,
-			reserveTransferAssets: mockMoonriverParachainApi.tx['polkadotXcm'].reserveTransferAssets,
-			teleportAssets: mockMoonriverParachainApi.tx['polkadotXcm'].teleportAssets,
-			limitedTeleportAssets: mockMoonriverParachainApi.tx['polkadotXcm'].limitedTeleportAssets,
+	tx: Object.assign(
+		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {
+			return mockSubmittableExt;
 		},
-		xTokens: {
-			transferMultiasset: mockMoonriverParachainApi.tx['xTokens'].transferMultiasset,
-			transferMultiassetWithFee: mockMoonriverParachainApi.tx['xTokens'].transferMultiassetWithFee,
-			transferMultiassets: mockMoonriverParachainApi.tx['xTokens'].transferMultiassets,
+		{
+			polkadotXcm: {
+				limitedReserveTransferAssets: mockMoonriverParachainApi.tx['polkadotXcm'].limitedReserveTransferAssets,
+				reserveTransferAssets: mockMoonriverParachainApi.tx['polkadotXcm'].reserveTransferAssets,
+				teleportAssets: mockMoonriverParachainApi.tx['polkadotXcm'].teleportAssets,
+				limitedTeleportAssets: mockMoonriverParachainApi.tx['polkadotXcm'].limitedTeleportAssets,
+			},
+			xTokens: {
+				transferMultiasset: mockMoonriverParachainApi.tx['xTokens'].transferMultiasset,
+				transferMultiassetWithFee: mockMoonriverParachainApi.tx['xTokens'].transferMultiassetWithFee,
+				transferMultiassets: mockMoonriverParachainApi.tx['xTokens'].transferMultiassets,
+			},
 		},
-	},
+	),
 	runtimeVersion: {
 		transactionVersion: mockMoonriverParachainApi.registry.createType('u32', 4),
 		specVersion: mockMoonriverParachainApi.registry.createType('u32', 2302),

--- a/src/testHelpers/adjustedMockSystemApiV1004000.ts
+++ b/src/testHelpers/adjustedMockSystemApiV1004000.ts
@@ -1,14 +1,16 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
+import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import { Metadata, Option, TypeRegistry } from '@polkadot/types';
-import type { Header } from '@polkadot/types/interfaces';
+import type { Call, Extrinsic, Header } from '@polkadot/types/interfaces';
 import type {
 	PalletAssetConversionEvent,
 	PalletAssetConversionPoolInfo,
 	PalletAssetsAssetDetails,
 	PalletAssetsAssetMetadata,
 } from '@polkadot/types/lookup';
+import type { ISubmittableResult } from '@polkadot/types/types';
 import { ITuple } from '@polkadot/types-codec/types';
 import { getSpecTypes } from '@polkadot/types-known';
 import BN from 'bn.js';
@@ -291,6 +293,11 @@ const mockApiAt = {
 	},
 };
 
+const mockSubmittableExt = mockSystemApi.registry.createType(
+	'Extrinsic',
+	'0x1901041f0b04010100451f0400010100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a06304040002043205011f0013000064a7b3b6e00d0000000000',
+) as SubmittableExtrinsic<'promise', ISubmittableResult>;
+
 export const adjustedMockSystemApi = {
 	createType: createType,
 	registry: createStatemineRegistry(1004000),
@@ -553,31 +560,36 @@ export const adjustedMockSystemApi = {
 			}),
 		},
 	},
-	tx: {
-		polkadotXcm: {
-			limitedReserveTransferAssets: mockSystemApi.tx['polkadotXcm'].limitedReserveTransferAssets,
-			reserveTransferAssets: mockSystemApi.tx['polkadotXcm'].reserveTransferAssets,
-			teleportAssets: mockSystemApi.tx['polkadotXcm'].teleportAssets,
-			limitedTeleportAssets: mockSystemApi.tx['polkadotXcm'].limitedTeleportAssets,
+	tx: Object.assign(
+		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {
+			return mockSubmittableExt;
 		},
-		assets: {
-			transfer: mockSystemApi.tx.assets.transfer,
-			transferKeepAlive: mockSystemApi.tx.assets.transferKeepAlive,
+		{
+			polkadotXcm: {
+				limitedReserveTransferAssets: mockSystemApi.tx['polkadotXcm'].limitedReserveTransferAssets,
+				reserveTransferAssets: mockSystemApi.tx['polkadotXcm'].reserveTransferAssets,
+				teleportAssets: mockSystemApi.tx['polkadotXcm'].teleportAssets,
+				limitedTeleportAssets: mockSystemApi.tx['polkadotXcm'].limitedTeleportAssets,
+			},
+			assets: {
+				transfer: mockSystemApi.tx.assets.transfer,
+				transferKeepAlive: mockSystemApi.tx.assets.transferKeepAlive,
+			},
+			foreignAssets: {
+				transfer: mockSystemApi.tx.foreignAssets.transfer,
+				transferKeepAlive: mockSystemApi.tx.foreignAssets.transferKeepAlive,
+			},
+			balances: {
+				transfer: mockSystemApi.tx.balances.transfer,
+				transferAllowDeath: mockSystemApi.tx.balances.transferAllowDeath,
+				transferKeepAlive: mockSystemApi.tx.balances.transferKeepAlive,
+			},
+			poolAssets: {
+				transfer: mockSystemApi.tx.poolAssets.transfer,
+				transferKeepAlive: mockSystemApi.tx.poolAssets.transferKeepAlive,
+			},
 		},
-		foreignAssets: {
-			transfer: mockSystemApi.tx.foreignAssets.transfer,
-			transferKeepAlive: mockSystemApi.tx.foreignAssets.transferKeepAlive,
-		},
-		balances: {
-			transfer: mockSystemApi.tx.balances.transfer,
-			transferAllowDeath: mockSystemApi.tx.balances.transferAllowDeath,
-			transferKeepAlive: mockSystemApi.tx.balances.transferKeepAlive,
-		},
-		poolAssets: {
-			transfer: mockSystemApi.tx.poolAssets.transfer,
-			transferKeepAlive: mockSystemApi.tx.poolAssets.transferKeepAlive,
-		},
-	},
+	),
 	call: {
 		transactionPaymentApi: {
 			queryInfo: mockApiAt.call.transactionPaymentApi.queryInfo,

--- a/src/testHelpers/adjustedMockSystemApiV1016000.ts
+++ b/src/testHelpers/adjustedMockSystemApiV1016000.ts
@@ -1,14 +1,16 @@
 // Copyright 2023 Parity Technologies (UK) Ltd.
 
 import type { ApiPromise } from '@polkadot/api';
+import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import { Metadata, Option, TypeRegistry } from '@polkadot/types';
-import type { Header } from '@polkadot/types/interfaces';
+import type { Call, Extrinsic, Header } from '@polkadot/types/interfaces';
 import type {
 	PalletAssetConversionEvent,
 	PalletAssetConversionPoolInfo,
 	PalletAssetsAssetDetails,
 	PalletAssetsAssetMetadata,
 } from '@polkadot/types/lookup';
+import type { ISubmittableResult } from '@polkadot/types/types';
 import { ITuple } from '@polkadot/types-codec/types';
 import { getSpecTypes } from '@polkadot/types-known';
 import BN from 'bn.js';
@@ -340,6 +342,11 @@ const mockApiAt = {
 	},
 };
 
+const mockSubmittableExt = mockSystemApi.registry.createType(
+	'Extrinsic',
+	'0x0501041f0b04010100a90f0400010100c4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a063040401000013000064a7b3b6e00d0000000000',
+) as SubmittableExtrinsic<'promise', ISubmittableResult>;
+
 export const adjustedMockSystemApiV1016000 = {
 	createType: createType,
 	registry: createWestmintRegistry(1016000),
@@ -600,38 +607,43 @@ export const adjustedMockSystemApiV1016000 = {
 			}),
 		},
 	},
-	tx: {
-		polkadotXcm: {
-			limitedReserveTransferAssets: mockSystemApi.tx['polkadotXcm'].limitedReserveTransferAssets,
-			reserveTransferAssets: mockSystemApi.tx['polkadotXcm'].reserveTransferAssets,
-			teleportAssets: mockSystemApi.tx['polkadotXcm'].teleportAssets,
-			limitedTeleportAssets: mockSystemApi.tx['polkadotXcm'].limitedTeleportAssets,
-			transferAssets: mockSystemApi.tx['polkadotXcm'].transferAssets,
-			claimAssets: mockSystemApi.tx['polkadotXcm'].claimAssets,
-			transferAssetsUsingTypeAndThen: mockSystemApi.tx['polkadotXcm'].transferAssetsUsingTypeAndThen,
+	tx: Object.assign(
+		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {
+			return mockSubmittableExt;
 		},
-		assets: {
-			transfer: mockSystemApi.tx.assets.transfer,
-			transferKeepAlive: mockSystemApi.tx.assets.transferKeepAlive,
-			transferAll: mockSystemApi.tx.assets.transferAll,
+		{
+			polkadotXcm: {
+				limitedReserveTransferAssets: mockSystemApi.tx['polkadotXcm'].limitedReserveTransferAssets,
+				reserveTransferAssets: mockSystemApi.tx['polkadotXcm'].reserveTransferAssets,
+				teleportAssets: mockSystemApi.tx['polkadotXcm'].teleportAssets,
+				limitedTeleportAssets: mockSystemApi.tx['polkadotXcm'].limitedTeleportAssets,
+				transferAssets: mockSystemApi.tx['polkadotXcm'].transferAssets,
+				claimAssets: mockSystemApi.tx['polkadotXcm'].claimAssets,
+				transferAssetsUsingTypeAndThen: mockSystemApi.tx['polkadotXcm'].transferAssetsUsingTypeAndThen,
+			},
+			assets: {
+				transfer: mockSystemApi.tx.assets.transfer,
+				transferKeepAlive: mockSystemApi.tx.assets.transferKeepAlive,
+				transferAll: mockSystemApi.tx.assets.transferAll,
+			},
+			foreignAssets: {
+				transfer: mockSystemApi.tx.foreignAssets.transfer,
+				transferKeepAlive: mockSystemApi.tx.foreignAssets.transferKeepAlive,
+				transferAll: mockSystemApi.tx.foreignAssets.transferAll,
+			},
+			balances: {
+				transfer: mockSystemApi.tx.balances.transfer,
+				transferAllowDeath: mockSystemApi.tx.balances.transferAllowDeath,
+				transferKeepAlive: mockSystemApi.tx.balances.transferKeepAlive,
+				transferAll: mockSystemApi.tx.balances.transferAll,
+			},
+			poolAssets: {
+				transfer: mockSystemApi.tx.poolAssets.transfer,
+				transferKeepAlive: mockSystemApi.tx.poolAssets.transferKeepAlive,
+				transferAll: mockSystemApi.tx.poolAssets.transferAll,
+			},
 		},
-		foreignAssets: {
-			transfer: mockSystemApi.tx.foreignAssets.transfer,
-			transferKeepAlive: mockSystemApi.tx.foreignAssets.transferKeepAlive,
-			transferAll: mockSystemApi.tx.foreignAssets.transferAll,
-		},
-		balances: {
-			transfer: mockSystemApi.tx.balances.transfer,
-			transferAllowDeath: mockSystemApi.tx.balances.transferAllowDeath,
-			transferKeepAlive: mockSystemApi.tx.balances.transferKeepAlive,
-			transferAll: mockSystemApi.tx.balances.transferAll,
-		},
-		poolAssets: {
-			transfer: mockSystemApi.tx.poolAssets.transfer,
-			transferKeepAlive: mockSystemApi.tx.poolAssets.transferKeepAlive,
-			transferAll: mockSystemApi.tx.poolAssets.transferAll,
-		},
-	},
+	),
 	call: {
 		transactionPaymentApi: {
 			queryInfo: mockApiAt.call.transactionPaymentApi.queryInfo,


### PR DESCRIPTION
Fixes a bug where an incorrect extrinsic argument to `queryInfo` caused the `partialFee` of the returned `RuntimeDispatchInfo` to always be 0.

example Bifrost Polkadot -> Polkadot AssetHub input:

```typescript
		callInfo = await assetApi.createTransferTransaction(
			'1000',
			'0xc4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a063',
			['WETH'],
			['1000000000000000000'],
			{
				format: 'call',
				xcmVersion: safeXcmVersion,
			},
		);

		const feeInfo = await assetApi.fetchFeeInfo(callInfo.tx, 'call');

		console.log(
			`${PURPLE}The following feeInfo data that is returned:\n${GREEN}${JSON.stringify(feeInfo?.toHuman(), null, 4)}`,
		);
```

expected output:
```
The following feeInfo data that is returned:
{
    "weight": {
        "refTime": "1,600,000,000",
        "proofSize": "0"
    },
    "class": "Normal",
    "partialFee": "83.0091 mBNC"
}
```