### PR TITLE
fix: dependabot PR title

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore"
       # include a list of updated dependencies
-      prefix: "chore:"
+      prefix: "chore"
       include: "scope"
     labels:
       - "dependencies"


### PR DESCRIPTION
### Description
Solves the issues of having to manually change the PR title prefix opened by the Dependabot.