### PR TITLE
fix: check if X1 exists in multilocation

### DIFF
--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -2319,7 +2319,7 @@ describe('AssetTransferApi Integration Tests', () => {
 			await expect(async () => {
 				await AssetTransferApi.getDestinationXcmWeightToFeeAsset(
 					'interlay-parachain',
-					'wss://interlay-rpc.dwellir.com',
+					'wss://rpc-interlay.luckyfriday.io',
 					4,
 					dryRunResult,
 					'usdt',

--- a/src/util/resolveMultiLocation.ts
+++ b/src/util/resolveMultiLocation.ts
@@ -41,7 +41,7 @@ export const resolveMultiLocation = (multiLocation: AnyJson, xcmVersion: number)
 
 	const isX1V4Location = multiLocationStr.includes('"X1":[');
 
-	if (xcmVersion > 3 && typeof result === 'object' && result.interior.X1 && !isX1V4Location) {
+	if (xcmVersion > 3 && typeof result === 'object' && result.interior?.X1 && !isX1V4Location) {
 		result = {
 			parents: result.parents,
 			interior: {


### PR DESCRIPTION
### Description
Added this very small check because otherwise with : 
- this `asset-transfer-api-registry` update - PR [#180](https://github.com/paritytech/asset-transfer-api-registry/pull/180)
- and for this case in `asset-transfer-api` - Issue [#544](https://github.com/paritytech/asset-transfer-api/issues/544)

This line of code throws an error because it always expects for `xcmVersion > 3` to have `X1` in `result.interior` which I do not think it is the case. This can be double checked by using for example : 
- https://polkadot.js.org/apps/#/runtime connected to Polimec chain
- `xcmPaymentApi` - `queryAcceptablePaymentAssets`
- xcmVersion : 4
- the result will give also assets that have `interior.X3` and some other that have `interior.X1`
