### PR TITLE
fix: dryRun requires xcmVersion, so use safeXcmVersion if none given

### DIFF
--- a/e2e-tests/polkadotAssetHub.hydration.spec.ts
+++ b/e2e-tests/polkadotAssetHub.hydration.spec.ts
@@ -229,7 +229,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 			);
 
 			expect(parseInt(destinationFees[0][1].xcmFee)).to.toBeGreaterThan(0);
-			expect(destinationFees[0][1].xcmDest).to.eq('{"v4":{"parents":1,"interior":{"x1":[{"parachain":2034}]}}}');
+			expect(destinationFees[0][1].xcmDest).to.eq('{"v3":{"parents":1,"interior":{"x1":{"parachain":2034}}}}');
 			expect(destinationFees[0][1].xcmFeeAsset).to.eq(
 				'{"V3":{"Concrete":{"parents":1,"interior":{"x3":[{"parachain":1000},{"palletInstance":50},{"generalIndex":1984}]}}}}',
 			);

--- a/e2e-tests/polkadotAssetHub.hydration.spec.ts
+++ b/e2e-tests/polkadotAssetHub.hydration.spec.ts
@@ -218,7 +218,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 				paysWithFeeOrigin: `1984`,
 			});
 
-			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload');
+			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload', xcmVersion);
 			expect(dryRunResult?.asOk.executionResult.isOk).toBe(true);
 			const destinationFees = await AssetTransferApi.getDestinationXcmWeightToFeeAsset(
 				'hydradx',
@@ -263,7 +263,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 				},
 			);
 
-			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload');
+			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload', xcmVersion);
 			expect(dryRunResult?.asOk.executionResult.isErr).toBe(true);
 			const destinationFees = await AssetTransferApi.getDestinationXcmWeightToFeeAsset(
 				'hydradx',
@@ -539,7 +539,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 				paysWithFeeOrigin: `1984`,
 			});
 
-			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload');
+			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload', xcmVersion);
 
 			expect(dryRunResult?.asOk.executionResult.isOk).toBe(true);
 
@@ -587,7 +587,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 				},
 			);
 
-			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload');
+			const dryRunResult = await assetTransferApi.dryRunCall(alice.address, tx.tx, 'payload', xcmVersion);
 			expect(dryRunResult?.asOk.executionResult.isErr).toBe(true);
 			const destinationFees = await AssetTransferApi.getDestinationXcmWeightToFeeAsset(
 				'hydradx',

--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -20,7 +20,8 @@ const relayAssetsApiV1016000 = new AssetTransferApi(adjustedMockRelayApiV1016000
 	registryType: 'NPM',
 });
 const systemAssetsApi = new AssetTransferApi(adjustedMockSystemApi, 'statemine', 2, { registryType: 'NPM' });
-const systemAssetsApiV1016000 = new AssetTransferApi(adjustedMockSystemApiV1016000, 'westmint', 2, {
+const xcmVersion = 2;
+const systemAssetsApiV1016000 = new AssetTransferApi(adjustedMockSystemApiV1016000, 'westmint', xcmVersion, {
 	registryType: 'NPM',
 });
 
@@ -44,7 +45,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'assets::transfer',
 					tx: '0x3208040078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `assets::transferKeepAlive` call on a system parachain', async () => {
@@ -65,7 +66,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'assets::transferKeepAlive',
 					tx: '0x3209040078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct an `assets::transferAll` call on a system parachain', async () => {
@@ -86,7 +87,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'assets::transferAll',
 					tx: '0x3220040078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba266500',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `balances::transfer` call on a system parachain', async () => {
@@ -106,7 +107,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'balances::transfer',
 					tx: '0x0a000078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `balances::transferKeepAlive` call on a system parachain', async () => {
@@ -127,7 +128,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'balances::transferKeepAlive',
 					tx: '0x0a030078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `balances::transferAll` call on a system parachain', async () => {
@@ -149,7 +150,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'balances::transferAll',
 					tx: '0x0a040078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba266501',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `balances::transferAll` call on a relay chain', async () => {
@@ -170,7 +171,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'balances::transferAll',
 					tx: '0x04040078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba266500',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `balances::transferKeepAlive` call on a relay chain', async () => {
@@ -191,7 +192,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'balances::transferKeepAlive',
 					tx: '0x04030078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `foreignAssets::transfer` call on a system parachain', async () => {
@@ -211,7 +212,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'foreignAssets::transfer',
 					tx: '0x3508010200352105000078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `foreignAssets::transferKeepAlive` call on a system parachain', async () => {
@@ -232,17 +233,18 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'foreignAssets::transferKeepAlive',
 					tx: '0x3509010200352105000078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `foreignAssets::transferAll` call on a system parachain', async () => {
+				const xcmVersion = 3;
 				const res = await systemAssetsApiV1016000.createTransferTransaction(
 					'1000',
 					'5EnxxUmEbw8DkENKiYuZ1DwQuMoB2UWEQJZZXrTsxoz7SpgG',
 					['{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}'],
 					['100'],
 					{
-						xcmVersion: 3,
+						xcmVersion,
 						transferAll: true,
 						format: 'call',
 					},
@@ -254,7 +256,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					format: 'call',
 					method: 'foreignAssets::transferAll',
 					tx: '0x3520020109020078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba266500',
-					xcmVersion: null,
+					xcmVersion,
 				});
 			});
 			it('Should construct a `poolAssets::transfer` call on a system parachain', async () => {
@@ -274,7 +276,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					direction: 'local',
 					format: 'call',
 					method: 'poolAssets::transfer',
-					xcmVersion: null,
+					xcmVersion,
 					tx: '0x3708000000000078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
 				});
 			});
@@ -296,7 +298,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					direction: 'local',
 					format: 'call',
 					method: 'poolAssets::transferKeepAlive',
-					xcmVersion: null,
+					xcmVersion,
 					tx: '0x3709000000000078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba26659101',
 				});
 			});
@@ -319,7 +321,7 @@ describe('AssetTransferApi Integration Tests', () => {
 					direction: 'local',
 					format: 'call',
 					method: 'poolAssets::transferAll',
-					xcmVersion: null,
+					xcmVersion,
 					tx: '0x3720000000000078b39b0b6dd87cb68009eb570511d21c229bdb5e94129ae570e9b79442ba266501',
 				});
 			});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8525,8 +8525,8 @@ __metadata:
   linkType: hard
 
 "typedoc@npm:^0.28.4":
-  version: 0.28.4
-  resolution: "typedoc@npm:0.28.4"
+  version: 0.28.5
+  resolution: "typedoc@npm:0.28.5"
   dependencies:
     "@gerrit0/mini-shiki": "npm:^3.2.2"
     lunr: "npm:^2.3.9"
@@ -8537,7 +8537,7 @@ __metadata:
     typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x
   bin:
     typedoc: bin/typedoc
-  checksum: 10/0ccab46519e4be1aa9bd4defd55e920cbefe8825e0ba7ca93b8d6fd3867300e8b60260d2182033b46121f9040251366f6a496a3500da458c3031b224d7bdadd7
+  checksum: 10/620426f4fd593dea5ffd37bce8741bfa996cb25e0f67c6aac11434788652c3cd10af2a9c47d1445f10b9fbb44304ffcf6ec59f5cedd353175e3b3d9a24cb5d29
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`dryRun` calls require an `xcmVersion`. Default to `safeXcm` version if none is given.

Relates to [this comment in polkadot-sdk](https://github.com/paritytech/polkadot-sdk/pull/7438/files#r2113620849).

Also fixes the test issue mentioned in these PRs:
- https://github.com/paritytech/asset-transfer-api/pull/568
- https://github.com/paritytech/asset-transfer-api/pull/567
- https://github.com/paritytech/asset-transfer-api/pull/566