### PR TITLE
fix: replace `assert` with `with` to support newer node versions

### DIFF
--- a/src/registry/registry-json.ts
+++ b/src/registry/registry-json.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 // https://github.com/isaacs/tshy?tab=readme-ov-file#commonjs-dialect-polyfills
 // @ts-ignore suppress "Import assertions are not allowed on statements that compile to CommonJS 'require' calls."
-import registry from '@substrate/asset-transfer-api-registry' assert { type: 'json' };
+import registry from '@substrate/asset-transfer-api-registry' with { type: 'json' };
 
 export { registry };


### PR DESCRIPTION
fixes https://github.com/paritytech/asset-transfer-api/issues/570