### PR TITLE
feat: Add CI job to unit test code across node versions.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,6 +72,38 @@ jobs:
       - name: Build
         run: yarn build
 
+  node-support:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22, 24]
+    steps:
+      - name: Checkout files
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install JS dependencies
+        run: yarn install
+
+      - name: Unit tests.
+        run: yarn test:unit
+
   tests:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -100,8 +132,9 @@ jobs:
       - name: Install JS dependencies
         run: yarn install
 
-      - name: Unit tests.
-        run: yarn test:unit
+      # Unit tests take place in the above node support tests
+      # - name: Unit tests.
+      #   run: yarn test:unit
 
       - name: Integration tests.
         run: yarn test:integration


### PR DESCRIPTION
Testing with node 18, 20, 22, and 24.

In order to verify that we don't break, we can test all stable versions at and above the minimally supported version (currently v18) via CI/GitHub Actions.

Inspired by https://github.com/paritytech/asset-transfer-api/issues/570