### PR TITLE
chore: Update default xcm version from v2 to v4.

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -41,7 +41,7 @@ export const PASEO_ASSET_HUB_SPEC_NAME = ['asset-hub-paseo'];
 /**
  * The default xcm version to construct a xcm message.
  */
-export const DEFAULT_XCM_VERSION = 2;
+export const DEFAULT_XCM_VERSION = 4;
 /**
  * There should only ever be three supported versions.
  * Therefore supported xcm versions will always have a fixed length of 3.


### PR DESCRIPTION
v2 is no longer officially supported. v3-5 are the current supported versions. v5 support still needs to be added to asset-transfer-api

BREAKING CHANGE