### PR TITLE
feat: Improve fetchSafeXcmVersion to throw error on unsupported versions

### DIFF
--- a/src/createXcmCalls/util/fetchSafeXcmVersion.ts
+++ b/src/createXcmCalls/util/fetchSafeXcmVersion.ts
@@ -3,7 +3,7 @@
 import type { ApiPromise } from '@polkadot/api';
 import type { Option, u32 } from '@polkadot/types';
 
-import { DEFAULT_XCM_VERSION } from '../../consts.js';
+import { DEFAULT_XCM_VERSION, SUPPORTED_XCM_VERSIONS } from '../../consts.js';
 import { establishXcmPallet } from './establishXcmPallet.js';
 
 /**
@@ -15,7 +15,17 @@ import { establishXcmPallet } from './establishXcmPallet.js';
 export const fetchSafeXcmVersion = async (api: ApiPromise): Promise<number> => {
 	const pallet = establishXcmPallet(api);
 	const safeVersion = await api.query[pallet].safeXcmVersion<Option<u32>>();
-	const version = safeVersion.isSome ? safeVersion.unwrap().toNumber() : DEFAULT_XCM_VERSION;
-
-	return version;
+	const maxSupportedVersion = Math.max(...SUPPORTED_XCM_VERSIONS);
+	const minSupportedVersion = Math.min(...SUPPORTED_XCM_VERSIONS);
+	if (safeVersion.isSome) {
+		const version = safeVersion.unwrap().toNumber();
+		if (version < minSupportedVersion || version > maxSupportedVersion) {
+			throw new Error(
+				`XCM v${version} not supported by asset-transfer-api. Supported versions: [${SUPPORTED_XCM_VERSIONS.toString()}]`,
+			);
+		}
+		return version;
+	} else {
+		return DEFAULT_XCM_VERSION;
+	}
 };


### PR DESCRIPTION
Throw an error if the safe xcm version is outside of the range of XCM versions supported by asset-transfer-api