### PR TITLE
fix: Update sanitizeKeys to match polkadot-sdk XCM types

### DIFF
--- a/e2e-tests/polkadotAssetHub.hydration.spec.ts
+++ b/e2e-tests/polkadotAssetHub.hydration.spec.ts
@@ -212,7 +212,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 			expect(parseInt(destinationFees[0][1].xcmFee)).to.toBeGreaterThan(0);
 			expect(destinationFees[0][1].xcmDest).to.eq('{"v3":{"parents":1,"interior":{"x1":{"parachain":2034}}}}');
 			expect(destinationFees[0][1].xcmFeeAsset).to.eq(
-				'{"V3":{"Concrete":{"Parents":"1","Interior":{"X3":[{"Parachain":"1000"},{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}}}',
+				'{"V3":{"Concrete":{"parents":"1","interior":{"X3":[{"Parachain":"1000"},{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}}}',
 			);
 		}, 200000);
 
@@ -534,7 +534,7 @@ describe('Polkadot AssetHub <> Hydration', () => {
 			expect(parseInt(destinationFees[0][1].xcmFee)).to.toBeGreaterThan(0);
 			expect(destinationFees[0][1].xcmDest).to.eq('{"v4":{"parents":1,"interior":{"x1":[{"parachain":2034}]}}}');
 			expect(destinationFees[0][1].xcmFeeAsset).to.eq(
-				'{"V4":{"Parents":"1","Interior":{"X3":[{"Parachain":"1000"},{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}}',
+				'{"V4":{"parents":"1","interior":{"X3":[{"Parachain":"1000"},{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}}',
 			);
 		}, 200000);
 

--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -577,7 +577,7 @@ describe('AssetTransferAPI', () => {
 			expect(callTxResult.localXcmFees![1]).toEqual({
 				xcmDest: '"local"',
 				xcmFee: '3500000000000000',
-				xcmFeeAsset: '{"V4":{"Parents":"1","Interior":{"Here":""}}}',
+				xcmFeeAsset: '{"V4":{"parents":"1","interior":{"Here":""}}}',
 				xcmWeight: '{"refTime":3500000000,"proofSize":350000000}',
 			});
 
@@ -1821,8 +1821,8 @@ describe('AssetTransferAPI', () => {
 			expect(await systemAssetsApi['checkAssetLpTokenPairExists'](paysWithFeeOrigin)).toEqual([
 				true,
 				{
-					Parents: '0',
-					Interior: {
+					parents: '0',
+					interior: {
 						X2: [{ PalletInstance: '50' }, { GeneralIndex: '1984' }],
 					},
 				},
@@ -1834,8 +1834,8 @@ describe('AssetTransferAPI', () => {
 			expect(await systemAssetsApi['checkAssetLpTokenPairExists'](paysWithFeeOrigin)).toEqual([
 				false,
 				{
-					Parents: '0',
-					Interior: {
+					parents: '0',
+					interior: {
 						X2: [{ PalletInstance: '50' }, { GeneralIndex: '2000' }],
 					},
 				},

--- a/src/createXcmTypes/handlers/ParaToEthereum.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToEthereum.spec.ts
@@ -188,8 +188,8 @@ describe('ParaToEthereum', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									Here: null,
 								},
 							},
@@ -201,8 +201,8 @@ describe('ParaToEthereum', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
@@ -234,8 +234,8 @@ describe('ParaToEthereum', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
@@ -247,8 +247,8 @@ describe('ParaToEthereum', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 								},
 							},
@@ -279,8 +279,8 @@ describe('ParaToEthereum', () => {
 				V4: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 							},
 						},
@@ -290,8 +290,8 @@ describe('ParaToEthereum', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 							},
 						},
@@ -321,8 +321,8 @@ describe('ParaToEthereum', () => {
 				V5: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 							},
 						},
@@ -332,8 +332,8 @@ describe('ParaToEthereum', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 							},
 						},

--- a/src/createXcmTypes/handlers/ParaToPara.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToPara.spec.ts
@@ -265,8 +265,8 @@ describe('ParaToPara test', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									Here: null,
 								},
 							},
@@ -278,8 +278,8 @@ describe('ParaToPara test', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
@@ -311,8 +311,8 @@ describe('ParaToPara test', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
@@ -324,8 +324,8 @@ describe('ParaToPara test', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 								},
 							},
@@ -356,8 +356,8 @@ describe('ParaToPara test', () => {
 				V4: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 							},
 						},
@@ -367,8 +367,8 @@ describe('ParaToPara test', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 							},
 						},
@@ -398,8 +398,8 @@ describe('ParaToPara test', () => {
 				V5: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 							},
 						},
@@ -409,8 +409,8 @@ describe('ParaToPara test', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 							},
 						},

--- a/src/createXcmTypes/handlers/ParaToRelay.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToRelay.spec.ts
@@ -351,8 +351,8 @@ describe('ParaToRelay', () => {
 				V2: {
 					id: {
 						Concrete: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								Here: null,
 							},
 						},
@@ -370,8 +370,8 @@ describe('ParaToRelay', () => {
 				V3: {
 					id: {
 						Concrete: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								Here: null,
 							},
 						},
@@ -388,8 +388,8 @@ describe('ParaToRelay', () => {
 			const expected = {
 				V4: {
 					id: {
-						Parents: '1',
-						Interior: {
+						parents: '1',
+						interior: {
 							Here: null,
 						},
 					},
@@ -405,8 +405,8 @@ describe('ParaToRelay', () => {
 			const expected = {
 				V5: {
 					id: {
-						Parents: '1',
-						Interior: {
+						parents: '1',
+						interior: {
 							Here: null,
 						},
 					},

--- a/src/createXcmTypes/handlers/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToSystem.spec.ts
@@ -188,8 +188,8 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									Here: null,
 								},
 							},
@@ -201,8 +201,8 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
@@ -234,8 +234,8 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 								},
 							},
@@ -247,8 +247,8 @@ describe('ParaToSystem', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 								},
 							},
@@ -279,8 +279,8 @@ describe('ParaToSystem', () => {
 				V4: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 							},
 						},
@@ -290,8 +290,8 @@ describe('ParaToSystem', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 							},
 						},
@@ -321,8 +321,8 @@ describe('ParaToSystem', () => {
 				V5: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '8' }],
 							},
 						},
@@ -332,8 +332,8 @@ describe('ParaToSystem', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								X3: [{ Parachain: '1000' }, { PalletInstance: '50' }, { GeneralIndex: '1984' }],
 							},
 						},

--- a/src/createXcmTypes/handlers/SystemToPara.spec.ts
+++ b/src/createXcmTypes/handlers/SystemToPara.spec.ts
@@ -265,8 +265,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '1' }],
 								},
 							},
@@ -278,8 +278,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '2' }],
 								},
 							},
@@ -306,8 +306,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '1' }],
 								},
 							},
@@ -319,8 +319,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '2' }],
 								},
 							},
@@ -346,8 +346,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				V4: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '50' }, { GeneralIndex: '1' }],
 							},
 						},
@@ -357,8 +357,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '50' }, { GeneralIndex: '2' }],
 							},
 						},
@@ -383,8 +383,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				V5: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '50' }, { GeneralIndex: '1' }],
 							},
 						},
@@ -394,8 +394,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '50' }, { GeneralIndex: '2' }],
 							},
 						},
@@ -421,8 +421,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '55' }, { GeneralIndex: '1' }],
 								},
 							},
@@ -434,8 +434,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '55' }, { GeneralIndex: '2' }],
 								},
 							},
@@ -461,8 +461,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				V4: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '55' }, { GeneralIndex: '1' }],
 							},
 						},
@@ -472,8 +472,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '55' }, { GeneralIndex: '2' }],
 							},
 						},
@@ -498,8 +498,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 				V5: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '55' }, { GeneralIndex: '1' }],
 							},
 						},
@@ -509,8 +509,8 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [{ PalletInstance: '55' }, { GeneralIndex: '2' }],
 							},
 						},
@@ -562,10 +562,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					id: {
 						Concrete: {
-							Interior: {
+							interior: {
 								X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 							},
-							Parents: '0',
+							parents: '0',
 						},
 					},
 				},
@@ -575,10 +575,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					id: {
 						Concrete: {
-							Interior: {
+							interior: {
 								Here: '',
 							},
-							Parents: '1',
+							parents: '1',
 						},
 					},
 				},
@@ -609,10 +609,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					id: {
 						Concrete: {
-							Interior: {
+							interior: {
 								X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 							},
-							Parents: '0',
+							parents: '0',
 						},
 					},
 				},
@@ -622,10 +622,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					},
 					id: {
 						Concrete: {
-							Interior: {
+							interior: {
 								Here: '',
 							},
-							Parents: '1',
+							parents: '1',
 						},
 					},
 				},
@@ -655,10 +655,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 						Fungible: '300000000000000',
 					},
 					id: {
-						Interior: {
+						interior: {
 							X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 						},
-						Parents: '0',
+						parents: '0',
 					},
 				},
 				{
@@ -666,10 +666,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 						Fungible: '100000000000000',
 					},
 					id: {
-						Interior: {
+						interior: {
 							Here: '',
 						},
-						Parents: '1',
+						parents: '1',
 					},
 				},
 			];
@@ -698,10 +698,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 						Fungible: '300000000000000',
 					},
 					id: {
-						Interior: {
+						interior: {
 							X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 						},
-						Parents: '0',
+						parents: '0',
 					},
 				},
 				{
@@ -709,10 +709,10 @@ describe('SystemToPara XcmVersioned Generation', () => {
 						Fungible: '100000000000000',
 					},
 					id: {
-						Interior: {
+						interior: {
 							Here: '',
 						},
-						Parents: '1',
+						parents: '1',
 					},
 				},
 			];

--- a/src/createXcmTypes/handlers/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/handlers/SystemToSystem.spec.ts
@@ -186,8 +186,8 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 								},
 							},
@@ -214,8 +214,8 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									Here: '',
 								},
 							},
@@ -241,8 +241,8 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 				V4: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								Here: '',
 							},
 						},
@@ -267,8 +267,8 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 				V5: [
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								Here: '',
 							},
 						},
@@ -307,8 +307,8 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '55' }, { GeneralIndex: '11' }],
 								},
 							},

--- a/src/createXcmTypes/util/createAssetLocations.spec.ts
+++ b/src/createXcmTypes/util/createAssetLocations.spec.ts
@@ -15,8 +15,8 @@ describe('createAssetLocations', () => {
 				V5: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [
 									{
 										PalletInstance: '50',
@@ -33,8 +33,8 @@ describe('createAssetLocations', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								Here: '',
 							},
 						},
@@ -71,8 +71,8 @@ describe('createAssetLocations', () => {
 				V4: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								X2: [
 									{
 										PalletInstance: '50',
@@ -89,8 +89,8 @@ describe('createAssetLocations', () => {
 					},
 					{
 						id: {
-							Parents: '1',
-							Interior: {
+							parents: '1',
+							interior: {
 								Here: '',
 							},
 						},
@@ -128,8 +128,8 @@ describe('createAssetLocations', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 								},
 							},
@@ -141,8 +141,8 @@ describe('createAssetLocations', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									Here: '',
 								},
 							},
@@ -178,8 +178,8 @@ describe('createAssetLocations', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									X2: [{ PalletInstance: '50' }, { GeneralIndex: '11' }],
 								},
 							},
@@ -191,8 +191,8 @@ describe('createAssetLocations', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '1',
-								Interior: {
+								parents: '1',
+								interior: {
 									Here: '',
 								},
 							},
@@ -231,8 +231,8 @@ describe('createAssetLocations', () => {
 				V5: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								Here: '',
 							},
 						},
@@ -266,8 +266,8 @@ describe('createAssetLocations', () => {
 				V4: [
 					{
 						id: {
-							Parents: '0',
-							Interior: {
+							parents: '0',
+							interior: {
 								Here: '',
 							},
 						},
@@ -302,8 +302,8 @@ describe('createAssetLocations', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									Here: '',
 								},
 							},
@@ -339,8 +339,8 @@ describe('createAssetLocations', () => {
 					{
 						id: {
 							Concrete: {
-								Parents: '0',
-								Interior: {
+								parents: '0',
+								interior: {
 									Here: '',
 								},
 							},

--- a/src/createXcmTypes/util/resolveAssetTransferType.spec.ts
+++ b/src/createXcmTypes/util/resolveAssetTransferType.spec.ts
@@ -14,8 +14,8 @@ describe('resolveAssetTransferType', () => {
 			const expected = {
 				RemoteReserve: {
 					V3: {
-						Parents: '1',
-						Interior: {
+						parents: '1',
+						interior: {
 							X1: {
 								Parachain: '1000',
 							},
@@ -35,8 +35,8 @@ describe('resolveAssetTransferType', () => {
 			const expected = {
 				RemoteReserve: {
 					V4: {
-						Parents: '1',
-						Interior: {
+						parents: '1',
+						interior: {
 							X1: [{ Parachain: '1000' }],
 						},
 					},
@@ -54,8 +54,8 @@ describe('resolveAssetTransferType', () => {
 			const expected = {
 				RemoteReserve: {
 					V5: {
-						Parents: '1',
-						Interior: {
+						parents: '1',
+						interior: {
 							X1: [{ Parachain: '1000' }],
 						},
 					},

--- a/src/createXcmTypes/xcm/v3.ts
+++ b/src/createXcmTypes/xcm/v3.ts
@@ -87,9 +87,6 @@ export const V3: XcmCreator = {
 	resolveMultiLocation(multiLocation: AnyJson): UnionXcmMultiLocation {
 		const multiLocationStr = typeof multiLocation === 'string' ? multiLocation : JSON.stringify(multiLocation);
 
-		const hasGlobalConsensus =
-			multiLocationStr.includes('globalConsensus') || multiLocationStr.includes('GlobalConsensus');
-
 		let result = parseLocationStrToLocation(multiLocationStr, this.xcmVersion);
 
 		// handle case where result is an xcmV1Multilocation from the registry
@@ -97,12 +94,7 @@ export const V3: XcmCreator = {
 			result = result.v1 as UnionXcmMultiLocation;
 		}
 
-		// TODO: Clean up - not sure why we don't always sanitize
-		if (!hasGlobalConsensus) {
-			return sanitizeKeys(result);
-		} else {
-			return result;
-		}
+		return sanitizeKeys(result);
 	},
 
 	// Same as V2

--- a/src/createXcmTypes/xcm/v4.ts
+++ b/src/createXcmTypes/xcm/v4.ts
@@ -86,9 +86,6 @@ export const V4: XcmCreator = {
 	resolveMultiLocation(multiLocation: AnyJson): UnionXcmMultiLocation {
 		const multiLocationStr = typeof multiLocation === 'string' ? multiLocation : JSON.stringify(multiLocation);
 
-		const hasGlobalConsensus =
-			multiLocationStr.includes('globalConsensus') || multiLocationStr.includes('GlobalConsensus');
-
 		let result = parseLocationStrToLocation(multiLocationStr, this.xcmVersion);
 
 		// handle case where result is an xcmV1Multilocation from the registry
@@ -108,12 +105,7 @@ export const V4: XcmCreator = {
 			};
 		}
 
-		// TODO: Clean up - not sure why we don't always sanitize
-		if (!hasGlobalConsensus) {
-			return sanitizeKeys(result);
-		} else {
-			return result;
-		}
+		return sanitizeKeys(result);
 	},
 
 	multiAsset(asset: FungibleAssetType): UnionXcAssetsMultiAsset {

--- a/src/util/resolveMultiLocation.spec.ts
+++ b/src/util/resolveMultiLocation.spec.ts
@@ -13,7 +13,7 @@ describe('resolveMultiLocation', () => {
 	});
 	it('Should correctly return a resolved multilocation object given a correct value', () => {
 		const str = `{"parents":1,"interior":{"x2":[{"parachain":2001},{"generalKey":"0x0001"}]}}`;
-		const exp = { Parents: '1', Interior: { X2: [{ Parachain: '2001' }, { GeneralKey: '0x0001' }] } };
+		const exp = { parents: '1', interior: { X2: [{ Parachain: '2001' }, { GeneralKey: '0x0001' }] } };
 		const xcmCreator = getXcmCreator(2);
 
 		expect(resolveMultiLocation(str, xcmCreator)).toStrictEqual(exp);
@@ -37,11 +37,11 @@ describe('resolveMultiLocation', () => {
 	it('Should correctly resolve an xcmV1Multilocation values location', () => {
 		const str = `{"v1":{"parents":1,"interior":{"x2":[{"globalConsensus":{"ethereum":{"chainId":1}}},{"accountKey20":{"network":null,"key":"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"}}]}}}`;
 		const exp = {
-			parents: 1,
+			parents: '1',
 			interior: {
-				x2: [
-					{ globalConsensus: { ethereum: { chainId: 1 } } },
-					{ accountKey20: { network: null, key: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' } },
+				X2: [
+					{ GlobalConsensus: { Ethereum: { chainId: '1' } } },
+					{ AccountKey20: { network: null, key: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2' } },
 				],
 			},
 		};

--- a/src/util/sanitizeKeys.ts
+++ b/src/util/sanitizeKeys.ts
@@ -11,6 +11,12 @@ enum MultiLocationJunctionTypeKeys {
 	'onlychild' = 'OnlyChild',
 	'plurality' = 'Plurality',
 	'globalconsensus' = 'GlobalConsensus',
+	// Hack around some exceptions
+	'parents' = 'parents',
+	'key' = 'key',
+	'network' = 'network',
+	'chainid' = 'chainId',
+	'interior' = 'interior',
 }
 
 const isPlainObject = (input: unknown) => {


### PR DESCRIPTION
The following keys are consistently lowercase:
- parents
- key
- network
- chainId
- interior

and messing up the casing can cause messages to fail. By fixing sanitizeKeys, we can ideally sanitize everything without bespoke hacks like for GlobalConsensus

## Motivation

I wanted to clean up the GlobalConsensus hack in `XcmCreator.resolveMultiLocation` but this turned out to break e2e tests and have XCMs fail purely based on the changes to capitalization. Thus, I went and made sure everything matches up with `polkadot-sdk` definitions for XCM.

## Longer term idea

(in rough order)

1. Enforce consistency via the type system removing the need for `sanitizeKeys()`
2. Remove `sanitizeKeys()`
3. Change input from stringified json to actual objects
4. Change output from stringified json to actual objects with well defined types

The main idea being that we can lean on the type system more and remove all/most code related to massaging data