### PR TITLE
refactor: Remove benficiary types as they are just MultiLocations

### DIFF
--- a/src/createXcmCalls/xTokens/transferMultiassets.ts
+++ b/src/createXcmCalls/xTokens/transferMultiassets.ts
@@ -2,7 +2,7 @@ import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { getTypeCreator } from '../../createXcmTypes/index.js';
-import type { XcmDestBeneficiaryXcAssets } from '../../createXcmTypes/types.js';
+import type { XcmBeneficiary } from '../../createXcmTypes/types.js';
 import { XcmMultiAssets } from '../../createXcmTypes/types.js';
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
 import type { CreateXcmCallOpts } from '../types.js';
@@ -29,7 +29,7 @@ export const transferMultiassets = async (
 	});
 
 	let assets: XcmMultiAssets;
-	let beneficiary: XcmDestBeneficiaryXcAssets;
+	let beneficiary: XcmBeneficiary;
 
 	if (
 		typeCreator.createXTokensAssets &&

--- a/src/createXcmTypes/handlers/ParaToEthereum.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToEthereum.spec.ts
@@ -18,7 +18,7 @@ describe('ParaToEthereum', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -34,7 +34,7 @@ describe('ParaToEthereum', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe('ParaToEthereum', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},
@@ -69,7 +69,7 @@ describe('ParaToEthereum', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/ParaToEthereum.ts
+++ b/src/createXcmTypes/handlers/ParaToEthereum.ts
@@ -10,8 +10,8 @@ import type {
 	FungibleAssetType,
 	FungibleMultiAsset,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
 import { createFeeAssetItem } from '../util/createFeeAssetItem.js';
@@ -28,7 +28,7 @@ export class ParaToEthereum extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 1,

--- a/src/createXcmTypes/handlers/ParaToPara.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToPara.spec.ts
@@ -18,7 +18,7 @@ describe('ParaToPara test', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -34,7 +34,7 @@ describe('ParaToPara test', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe('ParaToPara test', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},
@@ -69,7 +69,7 @@ describe('ParaToPara test', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/ParaToPara.ts
+++ b/src/createXcmTypes/handlers/ParaToPara.ts
@@ -12,8 +12,8 @@ import type {
 	XcAssetsMultiAsset,
 	XcmBeneficiary,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
 import { createXTokensParachainDestBeneficiary } from '../util/createBeneficiary.js';
@@ -32,7 +32,7 @@ export class ParaToPara extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 1,

--- a/src/createXcmTypes/handlers/ParaToPara.ts
+++ b/src/createXcmTypes/handlers/ParaToPara.ts
@@ -10,9 +10,9 @@ import type {
 	FungibleAssetType,
 	FungibleMultiAsset,
 	XcAssetsMultiAsset,
+	XcmBeneficiary,
 	XcmCreator,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
@@ -84,7 +84,7 @@ export class ParaToPara extends DefaultHandler {
 	 * @param destChainId The parachain Id of the destination.
 	 * @param accountId The accountId of the beneficiary.
 	 */
-	createXTokensBeneficiary(destChainId: string, accountId: string): XcmDestBeneficiaryXcAssets {
+	createXTokensBeneficiary(destChainId: string, accountId: string): XcmBeneficiary {
 		return createXTokensParachainDestBeneficiary(destChainId, accountId, this.xcmCreator);
 	}
 

--- a/src/createXcmTypes/handlers/ParaToRelay.ts
+++ b/src/createXcmTypes/handlers/ParaToRelay.ts
@@ -5,8 +5,8 @@ import {
 	CreateFeeAssetItemOpts,
 	XcAssetsMultiAsset,
 	XcmBeneficiary,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { createXTokensDestBeneficiary } from '../util/createBeneficiary.js';
 import { createXTokensAssetToRelay } from '../util/createXTokensAssets.js';
@@ -18,7 +18,7 @@ export class ParaToRelay extends DefaultHandler {
 	 *
 	 * @param destId The destId in this case, which is the relay chain.
 	 */
-	createDest(_: string): XcmDestBeneficiary {
+	createDest(_: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.hereDest({ parents: 1 });
 	}
 

--- a/src/createXcmTypes/handlers/ParaToRelay.ts
+++ b/src/createXcmTypes/handlers/ParaToRelay.ts
@@ -4,8 +4,8 @@ import {
 	CreateAssetsOpts,
 	CreateFeeAssetItemOpts,
 	XcAssetsMultiAsset,
+	XcmBeneficiary,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 } from '../types.js';
 import { createXTokensDestBeneficiary } from '../util/createBeneficiary.js';
@@ -49,7 +49,7 @@ export class ParaToRelay extends DefaultHandler {
 		return Promise.resolve(0);
 	}
 
-	createXTokensBeneficiary(_: string, accountId: string): XcmDestBeneficiaryXcAssets {
+	createXTokensBeneficiary(_: string, accountId: string): XcmBeneficiary {
 		return createXTokensDestBeneficiary(accountId, this.xcmCreator);
 	}
 

--- a/src/createXcmTypes/handlers/ParaToSystem.spec.ts
+++ b/src/createXcmTypes/handlers/ParaToSystem.spec.ts
@@ -18,7 +18,7 @@ describe('ParaToSystem', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -34,7 +34,7 @@ describe('ParaToSystem', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe('ParaToSystem', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},
@@ -69,7 +69,7 @@ describe('ParaToSystem', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/ParaToSystem.ts
+++ b/src/createXcmTypes/handlers/ParaToSystem.ts
@@ -9,9 +9,9 @@ import type {
 	CreateFeeAssetItemOpts,
 	FungibleAssetType,
 	XcAssetsMultiAsset,
+	XcmBeneficiary,
 	XcmCreator,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
@@ -83,7 +83,7 @@ export class ParaToSystem extends DefaultHandler {
 	 * @param destChainId The parachain Id of the destination.
 	 * @param accountId The accountId of the beneficiary.
 	 */
-	createXTokensBeneficiary(destChainId: string, accountId: string): XcmDestBeneficiaryXcAssets {
+	createXTokensBeneficiary(destChainId: string, accountId: string): XcmBeneficiary {
 		return createXTokensParachainDestBeneficiary(destChainId, accountId, this.xcmCreator);
 	}
 

--- a/src/createXcmTypes/handlers/ParaToSystem.ts
+++ b/src/createXcmTypes/handlers/ParaToSystem.ts
@@ -11,8 +11,8 @@ import type {
 	XcAssetsMultiAsset,
 	XcmBeneficiary,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
 import { createXTokensParachainDestBeneficiary } from '../util/createBeneficiary.js';
@@ -31,7 +31,7 @@ export class ParaToSystem extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 1,

--- a/src/createXcmTypes/handlers/RelayToBridge.ts
+++ b/src/createXcmTypes/handlers/RelayToBridge.ts
@@ -1,6 +1,6 @@
 import type { ApiPromise } from '@polkadot/api';
 
-import { CreateAssetsOpts, XcmDestBeneficiary, XcmMultiAssets } from '../types.js';
+import { CreateAssetsOpts, XcmMultiAssets, XcmVersionedMultiLocation } from '../types.js';
 import { DefaultHandler } from './default.js';
 
 export class RelayToBridge extends DefaultHandler {
@@ -9,7 +9,7 @@ export class RelayToBridge extends DefaultHandler {
 	 *
 	 * @param destId The chainId of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.interiorDest({
 			destId,
 			parents: 1,

--- a/src/createXcmTypes/handlers/RelayToPara.spec.ts
+++ b/src/createXcmTypes/handlers/RelayToPara.spec.ts
@@ -18,7 +18,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 					parents: 0,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -34,7 +34,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 					parents: 0,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},
@@ -69,7 +69,7 @@ describe('RelayToPara XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/RelayToPara.ts
+++ b/src/createXcmTypes/handlers/RelayToPara.ts
@@ -1,6 +1,6 @@
 import type { ApiPromise } from '@polkadot/api';
 
-import { CreateAssetsOpts, XcmDestBeneficiary, XcmMultiAssets } from '../types.js';
+import { CreateAssetsOpts, XcmMultiAssets, XcmVersionedMultiLocation } from '../types.js';
 import { DefaultHandler } from './default.js';
 
 /**
@@ -12,7 +12,7 @@ export class RelayToPara extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 0,

--- a/src/createXcmTypes/handlers/RelayToSystem.spec.ts
+++ b/src/createXcmTypes/handlers/RelayToSystem.spec.ts
@@ -18,7 +18,7 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 					parents: 0,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -34,7 +34,7 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 					parents: 0,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},
@@ -69,7 +69,7 @@ describe('RelayToSystem XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/RelayToSystem.ts
+++ b/src/createXcmTypes/handlers/RelayToSystem.ts
@@ -1,6 +1,6 @@
 import type { ApiPromise } from '@polkadot/api';
 
-import { CreateAssetsOpts, XcmDestBeneficiary, XcmMultiAssets } from '../types.js';
+import { CreateAssetsOpts, XcmMultiAssets, XcmVersionedMultiLocation } from '../types.js';
 import { DefaultHandler } from './default.js';
 /**
  * XCM type generation for transactions from the relay chain to a system parachain.
@@ -11,7 +11,7 @@ export class RelayToSystem extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 0,

--- a/src/createXcmTypes/handlers/SystemToBridge.ts
+++ b/src/createXcmTypes/handlers/SystemToBridge.ts
@@ -8,9 +8,9 @@ import {
 	FungibleAssetType,
 	OneOfXcmJunctions,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
 import { createFeeAssetItem } from '../util/createFeeAssetItem.js';
@@ -27,7 +27,7 @@ export class SystemToBridge extends DefaultHandler {
 	 *
 	 * @param destId The chainId of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.interiorDest({
 			destId,
 			parents: 2,

--- a/src/createXcmTypes/handlers/SystemToPara.spec.ts
+++ b/src/createXcmTypes/handlers/SystemToPara.spec.ts
@@ -20,7 +20,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -36,7 +36,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '100',
+							Parachain: 100,
 						},
 					},
 				},
@@ -53,7 +53,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},
@@ -71,7 +71,7 @@ describe('SystemToPara XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '100',
+								Parachain: 100,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/SystemToPara.ts
+++ b/src/createXcmTypes/handlers/SystemToPara.ts
@@ -9,9 +9,9 @@ import type {
 	FungibleAssetType,
 	OneOfXcmJunctions,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { assetIdIsLocation } from '../util/assetIdIsLocation.js';
 import { createAssets } from '../util/createAssets.js';
@@ -30,7 +30,7 @@ export class SystemToPara extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 1,

--- a/src/createXcmTypes/handlers/SystemToRelay.ts
+++ b/src/createXcmTypes/handlers/SystemToRelay.ts
@@ -1,6 +1,6 @@
 import type { ApiPromise } from '@polkadot/api';
 
-import { CreateAssetsOpts, XcmDestBeneficiary, XcmMultiAssets } from '../types.js';
+import { CreateAssetsOpts, XcmMultiAssets, XcmVersionedMultiLocation } from '../types.js';
 import { DefaultHandler } from './default.js';
 
 export class SystemToRelay extends DefaultHandler {
@@ -9,7 +9,7 @@ export class SystemToRelay extends DefaultHandler {
 	 *
 	 * @param destId The destId in this case, which is the relay chain.
 	 */
-	createDest(_: string): XcmDestBeneficiary {
+	createDest(_: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.hereDest({ parents: 1 });
 	}
 

--- a/src/createXcmTypes/handlers/SystemToSystem.spec.ts
+++ b/src/createXcmTypes/handlers/SystemToSystem.spec.ts
@@ -18,7 +18,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '1000',
+							Parachain: 1000,
 						},
 					},
 				},
@@ -34,7 +34,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					parents: 1,
 					interior: {
 						X1: {
-							Parachain: '1002',
+							Parachain: 1002,
 						},
 					},
 				},
@@ -51,7 +51,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '1002',
+								Parachain: 1002,
 							},
 						],
 					},
@@ -69,7 +69,7 @@ describe('SystemToSystem XcmVersioned Generation', () => {
 					interior: {
 						X1: [
 							{
-								Parachain: '1002',
+								Parachain: 1002,
 							},
 						],
 					},

--- a/src/createXcmTypes/handlers/SystemToSystem.ts
+++ b/src/createXcmTypes/handlers/SystemToSystem.ts
@@ -8,9 +8,9 @@ import {
 	CreateFeeAssetItemOpts,
 	FungibleAssetType,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { createAssets } from '../util/createAssets.js';
 import { createFeeAssetItem } from '../util/createFeeAssetItem.js';
@@ -28,7 +28,7 @@ export class SystemToSystem extends DefaultHandler {
 	 *
 	 * @param destId The parachain Id of the destination.
 	 */
-	createDest(destId: string): XcmDestBeneficiary {
+	createDest(destId: string): XcmVersionedMultiLocation {
 		return this.xcmCreator.parachainDest({
 			destId,
 			parents: 1,

--- a/src/createXcmTypes/handlers/default.ts
+++ b/src/createXcmTypes/handlers/default.ts
@@ -8,8 +8,8 @@ import {
 	ICreateXcmType,
 	XcAssetsMultiLocation,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
+	XcmVersionedMultiLocation,
 	XcmWeight,
 } from '../types.js';
 import { createBeneficiary } from '../util/createBeneficiary.js';
@@ -32,7 +32,7 @@ export class DefaultHandler implements ICreateXcmType {
 	 *
 	 * @param accountId The accountId of the beneficiary.
 	 */
-	createBeneficiary(accountId: string): XcmDestBeneficiary {
+	createBeneficiary(accountId: string): XcmVersionedMultiLocation {
 		return createBeneficiary(accountId, this.xcmCreator);
 	}
 
@@ -47,7 +47,7 @@ export class DefaultHandler implements ICreateXcmType {
 
 	// Unique per handler
 
-	createDest(_destId: string): XcmDestBeneficiary {
+	createDest(_destId: string): XcmVersionedMultiLocation {
 		throw new Error('Not Implemented');
 	}
 

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -95,19 +95,6 @@ export type XcAssetsMultiLocation = {
 
 // DestBeneficiaries
 
-export type InteriorValue = RequireOnlyOne<XcmJunctionDestBeneficiary> | XcmV4JunctionDestBeneficiary[] | null;
-
-export type InteriorKey = {
-	[x: string]: InteriorValue;
-};
-
-export type XcmDestBeneficiary = {
-	[x: string]: {
-		parents: number;
-		interior: InteriorKey;
-	};
-};
-
 type XcmJunctionDestBeneficiary = {
 	AccountId32: {
 		network?: string;
@@ -121,6 +108,7 @@ type XcmJunctionDestBeneficiary = {
 	GlobalConsensus: string | AnyJson;
 };
 
+// Only used in v4.ts and v5.ts for interiorDest() -> XcmDestBeneficiary
 export type XcmV4JunctionDestBeneficiary =
 	| {
 			AccountId32: {
@@ -141,6 +129,27 @@ export type XcmV4JunctionDestBeneficiary =
 			GlobalConsensus: string | AnyJson;
 	  };
 
+// Only used in v3.ts - interiorDest() -> XcmDestBeneficiary
+export type InteriorValue = RequireOnlyOne<XcmJunctionDestBeneficiary> | XcmV4JunctionDestBeneficiary[] | null;
+
+// Only used in v3.ts, v4.ts, v5.ts
+// to define interior when returning
+// {
+// 	parents,
+// 	interior: parseLocationStrToLocation()
+// }
+export type InteriorKey = {
+	[x: string]: InteriorValue;
+};
+
+// Used just about everywhere
+export type XcmDestBeneficiary = {
+	[x: string]: {
+		parents: number;
+		interior: InteriorKey;
+	};
+};
+
 type XcmDestBeneficiaryMap = {
 	V2: {
 		parents: string | number;
@@ -159,15 +168,18 @@ type XcmDestBeneficiaryMap = {
 		interior: { X1: [{ AccountId32: { id: string } }] };
 	};
 };
+// Used in v{}.ts
 export type XcmV2DestBeneficiary = VersionedXcmType<XcmVersionKey.V2, XcmDestBeneficiaryMap[XcmVersionKey.V2]>;
 export type XcmV3DestBeneficiary = VersionedXcmType<XcmVersionKey.V3, XcmDestBeneficiaryMap[XcmVersionKey.V3]>;
 export type XcmV4DestBeneficiary = VersionedXcmType<XcmVersionKey.V4, XcmDestBeneficiaryMap[XcmVersionKey.V4]>;
 export type XcmV5DestBeneficiary = VersionedXcmType<XcmVersionKey.V5, XcmDestBeneficiaryMap[XcmVersionKey.V5]>;
 
+// only used in common.ts
 export type ParachainX2Interior =
 	| [{ Parachain: string }, { AccountId32: { id: string } }]
 	| [{ Parachain: string }, { AccountKey20: { key: string } }];
 
+// only used in common.ts and v{}.ts for xTokensParachainDestBeneficiary() -> XcmDestBeneficiaryXcAssets
 export type ParachainDestBeneficiaryInner = {
 	parents: string | number;
 	interior: {
@@ -184,6 +196,7 @@ type XcmV3ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersio
 type XcmV4ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersionKey.V4>;
 type XcmV5ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersionKey.V5>;
 
+// used in v{}.ts, createBeneficiary, ParaTo{}.ts, transferMultiassets.ts
 export type XcmDestBeneficiaryXcAssets =
 	| XcmV2DestBeneficiary
 	| XcmV3DestBeneficiary

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -95,21 +95,8 @@ export type XcAssetsMultiLocation = {
 
 // DestBeneficiaries
 
-type XcmJunctionDestBeneficiary = {
-	AccountId32: {
-		network?: string;
-		id: string;
-	};
-	AccountKey20: {
-		network?: string;
-		key: string;
-	};
-	Parachain: string;
-	GlobalConsensus: string | AnyJson;
-};
-
 // Only used in v4.ts and v5.ts for interiorDest() -> XcmDestBeneficiary
-export type XcmV4JunctionDestBeneficiary =
+export type XcmJunctionDestBeneficiary =
 	| {
 			AccountId32: {
 				network?: string;
@@ -130,7 +117,7 @@ export type XcmV4JunctionDestBeneficiary =
 	  };
 
 // Only used in v3.ts - interiorDest() -> XcmDestBeneficiary
-export type InteriorValue = RequireOnlyOne<XcmJunctionDestBeneficiary> | XcmV4JunctionDestBeneficiary[] | null;
+export type InteriorValue = XcmJunctionDestBeneficiary | XcmJunctionDestBeneficiary[] | null;
 
 // Only used in v3.ts, v4.ts, v5.ts
 // to define interior when returning

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -152,34 +152,24 @@ type X1Beneficiary = {
 }[XcmVersionKey];
 
 // only used in common.ts
-export type ParachainX2Interior =
+export type X2BeneficiaryInner =
 	| [{ Parachain: string }, { AccountId32: { id: string } }]
 	| [{ Parachain: string }, { AccountKey20: { key: string } }];
 
 // only used in common.ts and v{}.ts for xTokensParachainDestBeneficiary() -> XcmDestBeneficiaryXcAssets
-export type ParachainDestBeneficiaryInner = {
+export type X2BeneficiaryVariant = {
 	parents: string | number;
 	interior: {
-		X2: ParachainX2Interior;
+		X2: X2BeneficiaryInner;
 	};
 };
-
-type VersionedParachainDestBeneficiary<K extends string> = {
-	[P in K]: ParachainDestBeneficiaryInner;
-};
-
-type XcmV2ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersionKey.V2>;
-type XcmV3ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersionKey.V3>;
-type XcmV4ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersionKey.V4>;
-type XcmV5ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersionKey.V5>;
+type X2BeneficiaryForVersion<V extends XcmVersionKey> = VersionedXcmType<V, X2BeneficiaryVariant>;
+export type X2Beneficiary = {
+	[V in XcmVersionKey]: X2BeneficiaryForVersion<V>;
+}[XcmVersionKey];
 
 // used in v{}.ts, createBeneficiary, ParaTo{}.ts, transferMultiassets.ts
-export type XcmDestBeneficiaryXcAssets =
-	| X1Beneficiary
-	| XcmV2ParachainDestBeneficiary
-	| XcmV3ParachainDestBeneficiary
-	| XcmV4ParachainDestBeneficiary
-	| XcmV5ParachainDestBeneficiary;
+export type XcmDestBeneficiaryXcAssets = X1Beneficiary | X2Beneficiary;
 
 // Wild Asset
 interface WildAssetV3 {

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -39,7 +39,7 @@ type XcmJunctionBase<V extends XcmVersionKey> = XcmJunctionFields & XcmJunctionE
 
 // Junctions - XcmJunction
 type JunctionVariant<T> = RequireOnlyOne<T>;
-type XcmJunctionForVersion<V extends XcmVersionKey> = JunctionVariant<XcmJunctionBase<V>>;
+export type XcmJunctionForVersion<V extends XcmVersionKey> = JunctionVariant<XcmJunctionBase<V>>;
 export type XcmJunction = {
 	[V in XcmVersionKey]: XcmJunctionForVersion<V>;
 }[XcmVersionKey];
@@ -75,7 +75,7 @@ type MultiLocationVariant<J> = {
 	parents: number;
 	interior: RequireOnlyOne<J>;
 };
-type XcmMultiLocationForVersion<V extends XcmVersionKey> = MultiLocationVariant<XcmJunctionsForVersion<V>>;
+export type XcmMultiLocationForVersion<V extends XcmVersionKey> = MultiLocationVariant<XcmJunctionsForVersion<V>>;
 export type XcmMultiLocation = {
 	[V in XcmVersionKey]: XcmMultiLocationForVersion<V>;
 }[XcmVersionKey];
@@ -83,6 +83,9 @@ export type XcmV2MultiLocation = MultiLocationVariant<XcmJunctionsForVersion<Xcm
 export type XcmV3MultiLocation = MultiLocationVariant<XcmJunctionsForVersion<XcmVersionKey.V3>>;
 export type XcmV4MultiLocation = MultiLocationVariant<XcmJunctionsForVersion<XcmVersionKey.V4>>;
 export type XcmV5MultiLocation = MultiLocationVariant<XcmJunctionsForVersion<XcmVersionKey.V5>>;
+export type XcmVersionedMultiLocation = {
+	[V in XcmVersionKey]: VersionedXcmType<V, XcmMultiLocationForVersion<V>>;
+}[XcmVersionKey];
 
 // XcAssetsMultiLocation
 type XcAssetsMultiLocationVariant<V extends XcmVersionKey> = V extends XcmVersionKey.V2 | XcmVersionKey.V3
@@ -94,48 +97,6 @@ export type XcAssetsMultiLocation = {
 }[XcmVersionKey];
 
 // DestBeneficiaries
-
-// Only used in v4.ts and v5.ts for interiorDest() -> XcmDestBeneficiary
-export type XcmJunctionDestBeneficiary =
-	| {
-			AccountId32: {
-				network?: string;
-				id: string;
-			};
-	  }
-	| {
-			Parachain: number;
-	  }
-	| {
-			AccountKey20: {
-				network?: string;
-				key: string;
-			};
-	  }
-	| {
-			GlobalConsensus: string | AnyJson;
-	  };
-
-// Only used in v3.ts - interiorDest() -> XcmDestBeneficiary
-export type InteriorValue = XcmJunctionDestBeneficiary | XcmJunctionDestBeneficiary[] | null;
-
-// Only used in v3.ts, v4.ts, v5.ts
-// to define interior when returning
-// {
-// 	parents,
-// 	interior: parseLocationStrToLocation()
-// }
-export type InteriorKey = {
-	[x: string]: InteriorValue;
-};
-
-// Used just about everywhere
-export type XcmDestBeneficiary = {
-	[x: string]: {
-		parents: number;
-		interior: InteriorKey;
-	};
-};
 
 type X1BeneficiaryInner<V extends XcmVersionKey> = V extends XcmVersionKey.V2 | XcmVersionKey.V3
 	? { AccountId32: { id: string } }
@@ -258,8 +219,8 @@ export interface ICreateXcmTypeConstructor {
 export interface ICreateXcmType {
 	xcmCreator: XcmCreator;
 
-	createBeneficiary: (accountId: string) => XcmDestBeneficiary;
-	createDest: (destId: string) => XcmDestBeneficiary;
+	createBeneficiary: (accountId: string) => XcmVersionedMultiLocation;
+	createDest: (destId: string) => XcmVersionedMultiLocation;
 	createAssets: (
 		amounts: string[],
 		specName: string,
@@ -288,7 +249,7 @@ export interface ICreateXcmType {
 // XcmCreator - per version
 export interface XcmCreator {
 	xcmVersion: number;
-	beneficiary: (opts: { accountId: string; parents: number }) => XcmDestBeneficiary;
+	beneficiary: (opts: { accountId: string; parents: number }) => XcmVersionedMultiLocation;
 	xTokensParachainDestBeneficiary: (opts: {
 		accountId: string;
 		destChainId: string;
@@ -302,9 +263,9 @@ export interface XcmCreator {
 	multiLocation: (multiLocation: XcmMultiLocation) => XcAssetsMultiLocation;
 	remoteReserve: (multiLocation: XcmMultiLocation) => RemoteReserve;
 	versionedAssetId: (multiLocation: XcmMultiLocation) => XcmVersionedAssetId;
-	parachainDest: (opts: { destId: string; parents: number }) => XcmDestBeneficiary;
-	hereDest: (opts: { parents: number }) => XcmDestBeneficiary;
-	interiorDest: (opts: { destId: string; parents: number }) => XcmDestBeneficiary;
+	parachainDest: (opts: { destId: string; parents: number }) => XcmVersionedMultiLocation;
+	hereDest: (opts: { parents: number }) => XcmVersionedMultiLocation;
+	interiorDest: (opts: { destId: string; parents: number }) => XcmVersionedMultiLocation;
 	hereAsset: (opts: { amount: string; parents: number }) => XcmMultiAssets;
 	xcmMessage: (msg: AnyJson) => AnyJson;
 }

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -156,7 +156,7 @@ export type X2BeneficiaryInner =
 	| [{ Parachain: string }, { AccountId32: { id: string } }]
 	| [{ Parachain: string }, { AccountKey20: { key: string } }];
 
-// only used in common.ts and v{}.ts for xTokensParachainDestBeneficiary() -> XcmDestBeneficiaryXcAssets
+// only used in common.ts
 export type X2BeneficiaryVariant = {
 	parents: string | number;
 	interior: {
@@ -169,7 +169,7 @@ export type X2Beneficiary = {
 }[XcmVersionKey];
 
 // used in v{}.ts, createBeneficiary, ParaTo{}.ts, transferMultiassets.ts
-export type XcmDestBeneficiaryXcAssets = X1Beneficiary | X2Beneficiary;
+export type XcmBeneficiary = X1Beneficiary | X2Beneficiary;
 
 // Wild Asset
 interface WildAssetV3 {
@@ -268,7 +268,7 @@ export interface ICreateXcmType {
 	) => Promise<XcmMultiAssets>;
 	createWeightLimit: (opts: CreateWeightLimitOpts) => XcmWeight;
 	createFeeAssetItem: (api: ApiPromise, opts: CreateFeeAssetItemOpts) => Promise<number>;
-	createXTokensBeneficiary?: (destChainId: string, accountId: string) => XcmDestBeneficiaryXcAssets;
+	createXTokensBeneficiary?: (destChainId: string, accountId: string) => XcmBeneficiary;
 	createXTokensAssets?: (
 		amounts: string[],
 		specName: string,
@@ -293,8 +293,8 @@ export interface XcmCreator {
 		accountId: string;
 		destChainId: string;
 		parents: number;
-	}) => XcmDestBeneficiaryXcAssets;
-	xTokensDestBeneficiary: (opts: { accountId: string; parents: number }) => XcmDestBeneficiaryXcAssets;
+	}) => XcmBeneficiary;
+	xTokensDestBeneficiary: (opts: { accountId: string; parents: number }) => XcmBeneficiary;
 	fungibleAsset: (opts: { amount: string; multiLocation: AnyJson }) => FungibleAssetType;
 	resolveMultiLocation: (multiLocation: AnyJson) => XcmMultiLocation;
 	multiAsset: (asset: FungibleAssetType) => XcAssetsMultiAsset;

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -104,7 +104,7 @@ export type XcmJunctionDestBeneficiary =
 			};
 	  }
 	| {
-			Parachain: string;
+			Parachain: number;
 	  }
 	| {
 			AccountKey20: {
@@ -153,8 +153,8 @@ type X1Beneficiary = {
 
 // only used in common.ts
 export type X2BeneficiaryInner =
-	| [{ Parachain: string }, { AccountId32: { id: string } }]
-	| [{ Parachain: string }, { AccountKey20: { key: string } }];
+	| [{ Parachain: number }, { AccountId32: { id: string } }]
+	| [{ Parachain: number }, { AccountKey20: { key: string } }];
 
 // only used in common.ts
 export type X2BeneficiaryVariant = {

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -137,29 +137,19 @@ export type XcmDestBeneficiary = {
 	};
 };
 
-type XcmDestBeneficiaryMap = {
-	V2: {
-		parents: string | number;
-		interior: { X1: { AccountId32: { id: string } } };
-	};
-	V3: {
-		parents: string | number;
-		interior: { X1: { AccountId32: { id: string } } };
-	};
-	V4: {
-		parents: string | number;
-		interior: { X1: [{ AccountId32: { id: string } }] };
-	};
-	V5: {
-		parents: string | number;
-		interior: { X1: [{ AccountId32: { id: string } }] };
+type X1BeneficiaryInner<V extends XcmVersionKey> = V extends XcmVersionKey.V2 | XcmVersionKey.V3
+	? { AccountId32: { id: string } }
+	: [{ AccountId32: { id: string } }];
+type X1BeneficiaryVariant<V extends XcmVersionKey> = {
+	parents: string | number;
+	interior: {
+		X1: X1BeneficiaryInner<V>;
 	};
 };
-// Used in v{}.ts
-export type XcmV2DestBeneficiary = VersionedXcmType<XcmVersionKey.V2, XcmDestBeneficiaryMap[XcmVersionKey.V2]>;
-export type XcmV3DestBeneficiary = VersionedXcmType<XcmVersionKey.V3, XcmDestBeneficiaryMap[XcmVersionKey.V3]>;
-export type XcmV4DestBeneficiary = VersionedXcmType<XcmVersionKey.V4, XcmDestBeneficiaryMap[XcmVersionKey.V4]>;
-export type XcmV5DestBeneficiary = VersionedXcmType<XcmVersionKey.V5, XcmDestBeneficiaryMap[XcmVersionKey.V5]>;
+type X1BeneficiaryForVersion<V extends XcmVersionKey> = VersionedXcmType<V, X1BeneficiaryVariant<V>>;
+type X1Beneficiary = {
+	[V in XcmVersionKey]: X1BeneficiaryForVersion<V>;
+}[XcmVersionKey];
 
 // only used in common.ts
 export type ParachainX2Interior =
@@ -185,10 +175,7 @@ type XcmV5ParachainDestBeneficiary = VersionedParachainDestBeneficiary<XcmVersio
 
 // used in v{}.ts, createBeneficiary, ParaTo{}.ts, transferMultiassets.ts
 export type XcmDestBeneficiaryXcAssets =
-	| XcmV2DestBeneficiary
-	| XcmV3DestBeneficiary
-	| XcmV4DestBeneficiary
-	| XcmV5DestBeneficiary
+	| X1Beneficiary
 	| XcmV2ParachainDestBeneficiary
 	| XcmV3ParachainDestBeneficiary
 	| XcmV4ParachainDestBeneficiary

--- a/src/createXcmTypes/util/createBeneficiary.ts
+++ b/src/createXcmTypes/util/createBeneficiary.ts
@@ -1,4 +1,4 @@
-import { XcmCreator, XcmDestBeneficiary, XcmDestBeneficiaryXcAssets } from '../types.js';
+import { XcmBeneficiary, XcmCreator, XcmDestBeneficiary } from '../types.js';
 
 export const createBeneficiary = (accountId: string, xcmCreator: XcmCreator): XcmDestBeneficiary => {
 	const parents = 0; // always 0
@@ -9,7 +9,7 @@ export const createXTokensParachainDestBeneficiary = (
 	destChainId: string,
 	accountId: string,
 	xcmCreator: XcmCreator,
-): XcmDestBeneficiaryXcAssets => {
+): XcmBeneficiary => {
 	const parents = 1; // always 1
 	return xcmCreator.xTokensParachainDestBeneficiary({
 		accountId,
@@ -18,7 +18,7 @@ export const createXTokensParachainDestBeneficiary = (
 	});
 };
 
-export const createXTokensDestBeneficiary = (accountId: string, xcmCreator: XcmCreator): XcmDestBeneficiaryXcAssets => {
+export const createXTokensDestBeneficiary = (accountId: string, xcmCreator: XcmCreator): XcmBeneficiary => {
 	const parents = 1; // always 1
 	return xcmCreator.xTokensDestBeneficiary({ accountId, parents });
 };

--- a/src/createXcmTypes/util/createBeneficiary.ts
+++ b/src/createXcmTypes/util/createBeneficiary.ts
@@ -1,6 +1,6 @@
-import { XcmBeneficiary, XcmCreator, XcmDestBeneficiary } from '../types.js';
+import { XcmBeneficiary, XcmCreator, XcmVersionedMultiLocation } from '../types.js';
 
-export const createBeneficiary = (accountId: string, xcmCreator: XcmCreator): XcmDestBeneficiary => {
+export const createBeneficiary = (accountId: string, xcmCreator: XcmCreator): XcmVersionedMultiLocation => {
 	const parents = 0; // always 0
 	return xcmCreator.beneficiary({ accountId, parents });
 };

--- a/src/createXcmTypes/xcm/common.ts
+++ b/src/createXcmTypes/xcm/common.ts
@@ -1,6 +1,6 @@
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
-import { ParachainDestBeneficiaryInner, ParachainX2Interior } from '../types.js';
+import { X2BeneficiaryInner, X2BeneficiaryVariant } from '../types.js';
 
 export const createParachainDestBeneficiaryInner = ({
 	accountId,
@@ -10,8 +10,8 @@ export const createParachainDestBeneficiaryInner = ({
 	accountId: string;
 	destChainId: string;
 	parents: number;
-}): ParachainDestBeneficiaryInner => {
-	const X2: ParachainX2Interior = isEthereumAddress(accountId)
+}): X2BeneficiaryVariant => {
+	const X2: X2BeneficiaryInner = isEthereumAddress(accountId)
 		? [{ Parachain: destChainId }, { AccountKey20: { key: accountId } }]
 		: [{ Parachain: destChainId }, { AccountId32: { id: accountId } }];
 	return {

--- a/src/createXcmTypes/xcm/common.ts
+++ b/src/createXcmTypes/xcm/common.ts
@@ -1,5 +1,6 @@
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
+import { BaseError, BaseErrorsEnum } from '../../errors/BaseError.js';
 import { X2BeneficiaryInner, X2BeneficiaryVariant } from '../types.js';
 
 export const createParachainDestBeneficiaryInner = ({
@@ -11,9 +12,13 @@ export const createParachainDestBeneficiaryInner = ({
 	destChainId: string;
 	parents: number;
 }): X2BeneficiaryVariant => {
+	const chainId = Number(destChainId);
+	if (isNaN(chainId)) {
+		throw new BaseError('destChainId expected to be string representation of an integer', BaseErrorsEnum.InvalidInput);
+	}
 	const X2: X2BeneficiaryInner = isEthereumAddress(accountId)
-		? [{ Parachain: destChainId }, { AccountKey20: { key: accountId } }]
-		: [{ Parachain: destChainId }, { AccountId32: { id: accountId } }];
+		? [{ Parachain: chainId }, { AccountKey20: { key: accountId } }]
+		: [{ Parachain: chainId }, { AccountId32: { id: accountId } }];
 	return {
 		parents,
 		interior: { X2 },

--- a/src/createXcmTypes/xcm/v2.ts
+++ b/src/createXcmTypes/xcm/v2.ts
@@ -9,9 +9,9 @@ import {
 	FungibleMultiAsset,
 	XcAssetsMultiAsset,
 	XcAssetsMultiLocation,
+	XcmBeneficiary,
 	XcmCreator,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 	XcmMultiLocation,
 	XcmV2MultiLocation,
@@ -44,7 +44,7 @@ export const V2: XcmCreator = {
 		accountId: string;
 		destChainId: string;
 		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	}): XcmBeneficiary {
 		const beneficiary = createParachainDestBeneficiaryInner({
 			accountId,
 			destChainId,
@@ -53,13 +53,7 @@ export const V2: XcmCreator = {
 		return { V2: beneficiary };
 	},
 
-	xTokensDestBeneficiary({
-		accountId,
-		parents = 1,
-	}: {
-		accountId: string;
-		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	xTokensDestBeneficiary({ accountId, parents = 1 }: { accountId: string; parents: number }): XcmBeneficiary {
 		const X1 = { AccountId32: { id: accountId } };
 		const beneficiary = {
 			parents,

--- a/src/createXcmTypes/xcm/v2.ts
+++ b/src/createXcmTypes/xcm/v2.ts
@@ -119,7 +119,14 @@ export const V2: XcmCreator = {
 	},
 
 	parachainDest({ destId, parents }: { destId: string; parents: number }): XcmDestBeneficiary {
-		const X1 = { Parachain: destId };
+		const chainId = Number(destId);
+		if (isNaN(chainId)) {
+			throw new BaseError(
+				'destChainId expected to be string representation of an integer',
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
+		const X1 = { Parachain: chainId };
 		return {
 			V2: {
 				parents,

--- a/src/createXcmTypes/xcm/v2.ts
+++ b/src/createXcmTypes/xcm/v2.ts
@@ -11,11 +11,11 @@ import {
 	XcAssetsMultiLocation,
 	XcmBeneficiary,
 	XcmCreator,
-	XcmDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
 	XcmV2MultiLocation,
 	XcmVersionedAssetId,
+	XcmVersionedMultiLocation,
 } from '../types.js';
 import { parseLocationStrToLocation } from '../util/parseLocationStrToLocation.js';
 import { createParachainDestBeneficiaryInner } from './common.js';
@@ -23,7 +23,7 @@ import { createParachainDestBeneficiaryInner } from './common.js';
 export const V2: XcmCreator = {
 	xcmVersion: 2,
 
-	beneficiary({ accountId, parents = 0 }: { accountId: string; parents: number }): XcmDestBeneficiary {
+	beneficiary({ accountId, parents = 0 }: { accountId: string; parents: number }): XcmVersionedMultiLocation {
 		const X1 = isEthereumAddress(accountId)
 			? { AccountKey20: { network: 'Any', key: accountId } }
 			: { AccountId32: { network: 'Any', id: accountId } };
@@ -118,7 +118,7 @@ export const V2: XcmCreator = {
 		return { V2: { Concrete: this.resolveMultiLocation(multiLocation) } };
 	},
 
-	parachainDest({ destId, parents }: { destId: string; parents: number }): XcmDestBeneficiary {
+	parachainDest({ destId, parents }: { destId: string; parents: number }): XcmVersionedMultiLocation {
 		const chainId = Number(destId);
 		if (isNaN(chainId)) {
 			throw new BaseError(
@@ -136,7 +136,7 @@ export const V2: XcmCreator = {
 	},
 
 	// Same across all versions
-	hereDest({ parents }: { parents: number }): XcmDestBeneficiary {
+	hereDest({ parents }: { parents: number }): XcmVersionedMultiLocation {
 		return {
 			V2: {
 				parents,
@@ -145,7 +145,7 @@ export const V2: XcmCreator = {
 		};
 	},
 
-	interiorDest(_opts: { destId: string; parents: number }): XcmDestBeneficiary {
+	interiorDest(_opts: { destId: string; parents: number }): XcmVersionedMultiLocation {
 		throw new BaseError('XcmVersion not supported.', BaseErrorsEnum.InvalidXcmVersion);
 	},
 

--- a/src/createXcmTypes/xcm/v2.ts
+++ b/src/createXcmTypes/xcm/v2.ts
@@ -14,7 +14,6 @@ import {
 	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 	XcmMultiLocation,
-	XcmV2DestBeneficiary,
 	XcmV2MultiLocation,
 	XcmVersionedAssetId,
 } from '../types.js';
@@ -66,7 +65,7 @@ export const V2: XcmCreator = {
 			parents,
 			interior: { X1 },
 		};
-		return { V2: beneficiary } as XcmV2DestBeneficiary;
+		return { V2: beneficiary };
 	},
 
 	fungibleAsset({ amount, multiLocation }: { amount: string; multiLocation: AnyJson }): FungibleAssetType {

--- a/src/createXcmTypes/xcm/v3.ts
+++ b/src/createXcmTypes/xcm/v3.ts
@@ -16,7 +16,6 @@ import {
 	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 	XcmMultiLocation,
-	XcmV3DestBeneficiary,
 	XcmV3MultiLocation,
 	XcmVersionedAssetId,
 } from '../types.js';
@@ -67,7 +66,7 @@ export const V3: XcmCreator = {
 			parents,
 			interior: { X1 },
 		};
-		return { V3: beneficiary } as XcmV3DestBeneficiary;
+		return { V3: beneficiary };
 	},
 
 	// Same as V2

--- a/src/createXcmTypes/xcm/v3.ts
+++ b/src/createXcmTypes/xcm/v3.ts
@@ -117,7 +117,14 @@ export const V3: XcmCreator = {
 
 	// Same as V2
 	parachainDest({ destId, parents }: { destId: string; parents: number }): XcmDestBeneficiary {
-		const X1 = { Parachain: destId };
+		const chainId = Number(destId);
+		if (isNaN(chainId)) {
+			throw new BaseError(
+				'destChainId expected to be string representation of an integer',
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
+		const X1 = { Parachain: chainId };
 		return {
 			V3: {
 				parents,

--- a/src/createXcmTypes/xcm/v3.ts
+++ b/src/createXcmTypes/xcm/v3.ts
@@ -11,9 +11,9 @@ import {
 	InteriorValue,
 	XcAssetsMultiAsset,
 	XcAssetsMultiLocation,
+	XcmBeneficiary,
 	XcmCreator,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmMultiAssets,
 	XcmMultiLocation,
 	XcmV3MultiLocation,
@@ -44,7 +44,7 @@ export const V3: XcmCreator = {
 		accountId: string;
 		destChainId: string;
 		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	}): XcmBeneficiary {
 		const beneficiary = createParachainDestBeneficiaryInner({
 			accountId,
 			destChainId,
@@ -54,13 +54,7 @@ export const V3: XcmCreator = {
 	},
 
 	// Same as V2
-	xTokensDestBeneficiary({
-		accountId,
-		parents = 1,
-	}: {
-		accountId: string;
-		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	xTokensDestBeneficiary({ accountId, parents = 1 }: { accountId: string; parents: number }): XcmBeneficiary {
 		const X1 = { AccountId32: { id: accountId } };
 		const beneficiary = {
 			parents,

--- a/src/createXcmTypes/xcm/v4.ts
+++ b/src/createXcmTypes/xcm/v4.ts
@@ -14,10 +14,10 @@ import {
 	XcmDestBeneficiary,
 	XcmDestBeneficiaryXcAssets,
 	XcmJunction,
+	XcmJunctionDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
 	XcmV4DestBeneficiary,
-	XcmV4JunctionDestBeneficiary,
 	XcmV4MultiLocation,
 	XcmVersionedAssetId,
 } from '../types.js';
@@ -154,9 +154,9 @@ export const V4: XcmCreator = {
 
 		let interior: InteriorKey | undefined = undefined;
 		if (multiLocation && multiLocation.interior.X1) {
-			interior = { X1: [multiLocation.interior.X1 as XcmV4JunctionDestBeneficiary] };
+			interior = { X1: [multiLocation.interior.X1 as XcmJunctionDestBeneficiary] };
 		} else {
-			interior = { X2: multiLocation.interior.X2 as XcmV4JunctionDestBeneficiary[] };
+			interior = { X2: multiLocation.interior.X2 as XcmJunctionDestBeneficiary[] };
 		}
 
 		if (!interior) {

--- a/src/createXcmTypes/xcm/v4.ts
+++ b/src/createXcmTypes/xcm/v4.ts
@@ -10,9 +10,9 @@ import {
 	InteriorKey,
 	XcAssetsMultiAsset,
 	XcAssetsMultiLocation,
+	XcmBeneficiary,
 	XcmCreator,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmJunction,
 	XcmJunctionDestBeneficiary,
 	XcmMultiAssets,
@@ -47,7 +47,7 @@ export const V4: XcmCreator = {
 		accountId: string;
 		destChainId: string;
 		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	}): XcmBeneficiary {
 		const beneficiary = createParachainDestBeneficiaryInner({
 			accountId,
 			destChainId,
@@ -56,13 +56,7 @@ export const V4: XcmCreator = {
 		return { V4: beneficiary };
 	},
 
-	xTokensDestBeneficiary({
-		accountId,
-		parents = 1,
-	}: {
-		accountId: string;
-		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	xTokensDestBeneficiary({ accountId, parents = 1 }: { accountId: string; parents: number }): XcmBeneficiary {
 		const X1 = [{ AccountId32: { id: accountId } }] as [{ AccountId32: { id: string } }];
 		const beneficiary = {
 			parents,

--- a/src/createXcmTypes/xcm/v4.ts
+++ b/src/createXcmTypes/xcm/v4.ts
@@ -123,7 +123,14 @@ export const V4: XcmCreator = {
 	},
 
 	parachainDest({ destId, parents }: { destId: string; parents: number }): XcmDestBeneficiary {
-		const X1 = [{ Parachain: destId }];
+		const chainId = Number(destId);
+		if (isNaN(chainId)) {
+			throw new BaseError(
+				'destChainId expected to be string representation of an integer',
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
+		const X1 = [{ Parachain: chainId }];
 		return {
 			V4: {
 				parents,

--- a/src/createXcmTypes/xcm/v4.ts
+++ b/src/createXcmTypes/xcm/v4.ts
@@ -17,7 +17,6 @@ import {
 	XcmJunctionDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
-	XcmV4DestBeneficiary,
 	XcmV4MultiLocation,
 	XcmVersionedAssetId,
 } from '../types.js';
@@ -64,12 +63,12 @@ export const V4: XcmCreator = {
 		accountId: string;
 		parents: number;
 	}): XcmDestBeneficiaryXcAssets {
-		const X1 = [{ AccountId32: { id: accountId } }]; // Now in array
+		const X1 = [{ AccountId32: { id: accountId } }] as [{ AccountId32: { id: string } }];
 		const beneficiary = {
 			parents,
 			interior: { X1 },
 		};
-		return { V4: beneficiary } as XcmV4DestBeneficiary;
+		return { V4: beneficiary };
 	},
 
 	fungibleAsset({ amount, multiLocation }: { amount: string; multiLocation: AnyJson }): FungibleAssetType {

--- a/src/createXcmTypes/xcm/v5.ts
+++ b/src/createXcmTypes/xcm/v5.ts
@@ -8,9 +8,9 @@ import {
 	InteriorKey,
 	XcAssetsMultiAsset,
 	XcAssetsMultiLocation,
+	XcmBeneficiary,
 	XcmCreator,
 	XcmDestBeneficiary,
-	XcmDestBeneficiaryXcAssets,
 	XcmJunctionDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
@@ -39,7 +39,7 @@ export const V5: XcmCreator = {
 		accountId: string;
 		destChainId: string;
 		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	}): XcmBeneficiary {
 		const beneficiary = createParachainDestBeneficiaryInner({
 			accountId,
 			destChainId,
@@ -49,13 +49,7 @@ export const V5: XcmCreator = {
 	},
 
 	// Same as V4
-	xTokensDestBeneficiary({
-		accountId,
-		parents = 1,
-	}: {
-		accountId: string;
-		parents: number;
-	}): XcmDestBeneficiaryXcAssets {
+	xTokensDestBeneficiary({ accountId, parents = 1 }: { accountId: string; parents: number }): XcmBeneficiary {
 		const X1 = [{ AccountId32: { id: accountId } }] as [{ AccountId32: { id: string } }];
 		const beneficiary = {
 			parents,

--- a/src/createXcmTypes/xcm/v5.ts
+++ b/src/createXcmTypes/xcm/v5.ts
@@ -11,9 +11,9 @@ import {
 	XcmCreator,
 	XcmDestBeneficiary,
 	XcmDestBeneficiaryXcAssets,
+	XcmJunctionDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
-	XcmV4JunctionDestBeneficiary,
 	XcmV5DestBeneficiary,
 	XcmV5MultiLocation,
 	XcmVersionedAssetId,
@@ -133,9 +133,9 @@ export const V5: XcmCreator = {
 
 		let interior: InteriorKey | undefined = undefined;
 		if (multiLocation && multiLocation.interior.X1) {
-			interior = { X1: [multiLocation.interior.X1 as XcmV4JunctionDestBeneficiary] };
+			interior = { X1: [multiLocation.interior.X1 as XcmJunctionDestBeneficiary] };
 		} else {
-			interior = { X2: multiLocation.interior.X2 as XcmV4JunctionDestBeneficiary[] };
+			interior = { X2: multiLocation.interior.X2 as XcmJunctionDestBeneficiary[] };
 		}
 
 		if (!interior) {

--- a/src/createXcmTypes/xcm/v5.ts
+++ b/src/createXcmTypes/xcm/v5.ts
@@ -101,7 +101,14 @@ export const V5: XcmCreator = {
 
 	// Same as V4
 	parachainDest({ destId, parents }: { destId: string; parents: number }): XcmDestBeneficiary {
-		const X1 = [{ Parachain: destId }];
+		const chainId = Number(destId);
+		if (isNaN(chainId)) {
+			throw new BaseError(
+				'destChainId expected to be string representation of an integer',
+				BaseErrorsEnum.InvalidInput,
+			);
+		}
+		const X1 = [{ Parachain: chainId }];
 		return {
 			V5: {
 				parents,

--- a/src/createXcmTypes/xcm/v5.ts
+++ b/src/createXcmTypes/xcm/v5.ts
@@ -14,7 +14,6 @@ import {
 	XcmJunctionDestBeneficiary,
 	XcmMultiAssets,
 	XcmMultiLocation,
-	XcmV5DestBeneficiary,
 	XcmV5MultiLocation,
 	XcmVersionedAssetId,
 } from '../types.js';
@@ -57,12 +56,12 @@ export const V5: XcmCreator = {
 		accountId: string;
 		parents: number;
 	}): XcmDestBeneficiaryXcAssets {
-		const X1 = [{ AccountId32: { id: accountId } }]; // Now in array
+		const X1 = [{ AccountId32: { id: accountId } }] as [{ AccountId32: { id: string } }];
 		const beneficiary = {
 			parents,
 			interior: { X1 },
 		};
-		return { V5: beneficiary } as XcmV5DestBeneficiary;
+		return { V5: beneficiary };
 	},
 
 	// Same as V4


### PR DESCRIPTION
There are already `XcmBeneficiary` and `XcmDestBeneficiary` which are competing types that also compete with `MultiLocation`. Thus we can remove them to match `polkadot-sdk` where the beneficiaries are simply versioned multi locations.

This may unravel along the way.
Looks like potential fixes in `parseMultiLocationString`