### PR TITLE
refactor: parseLocationStrToLocation to require xcmCreator

### DIFF
--- a/src/AssetTransferApi.spec.ts
+++ b/src/AssetTransferApi.spec.ts
@@ -3,6 +3,7 @@ import type { Weight, WeightV2 } from '@polkadot/types/interfaces';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { AssetTransferApi } from './AssetTransferApi';
+import { DEFAULT_XCM_VERSION } from './consts';
 import {
 	limitedReserveTransferAssets,
 	limitedTeleportAssets,
@@ -1815,8 +1816,9 @@ describe('AssetTransferAPI', () => {
 	describe('checkAssetLpTokenPairExists', () => {
 		it('Should correctly return true when an assetConversion lp pool token location pair contains a match to a given paysWithFee asset location', async () => {
 			const paysWithFeeOrigin = `{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`;
+			const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 
-			expect(await systemAssetsApi['checkAssetLpTokenPairExists'](paysWithFeeOrigin)).toEqual([
+			expect(await systemAssetsApi['checkAssetLpTokenPairExists']({ paysWithFeeOrigin, xcmCreator })).toEqual([
 				true,
 				{
 					parents: '0',
@@ -1828,8 +1830,9 @@ describe('AssetTransferAPI', () => {
 		});
 		it('Should correctly return false when an assetConversion lp pool token location pair does not contain a match to a given paysWithFee asset location', async () => {
 			const paysWithFeeOrigin = `{"parents":"0","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"2000"}]}}`;
+			const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 
-			expect(await systemAssetsApi['checkAssetLpTokenPairExists'](paysWithFeeOrigin)).toEqual([
+			expect(await systemAssetsApi['checkAssetLpTokenPairExists']({ paysWithFeeOrigin, xcmCreator })).toEqual([
 				false,
 				{
 					parents: '0',

--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -212,6 +212,11 @@ export class AssetTransferApi {
 			xcmPalletOverride,
 		} = opts;
 
+		const { api, specName, safeXcmVersion, originChainId, registry } = this;
+		const declaredXcmVersion = xcmVersion === undefined ? safeXcmVersion : xcmVersion;
+		checkXcmVersion(declaredXcmVersion); // Throws an error when the xcmVersion is not supported.
+		const xcmCreator = getXcmCreator(declaredXcmVersion);
+
 		if (!this.registryConfig.registryInitialized) {
 			await this.initializeRegistry();
 		}
@@ -227,7 +232,6 @@ export class AssetTransferApi {
 		 */
 		checkBaseInputTypes(destChainId, destAddr, assetIds, amounts);
 
-		const { api, specName, safeXcmVersion, originChainId, registry } = this;
 		const isLiquidTokenTransfer = transferLiquidToken === true;
 		const chainOriginDestInfo = {
 			isOriginRelayChain: api.query.paras ? true : false,
@@ -236,8 +240,8 @@ export class AssetTransferApi {
 			isDestRelayChain: destChainId === RELAY_CHAIN_IDS[0],
 			isDestSystemParachain: isSystemChain(destChainId),
 			isDestParachain: isParachain(destChainId),
-			isDestBridge: chainDestIsBridge(destChainId),
-			isDestEthereum: chainDestIsEthereum(destChainId),
+			isDestBridge: chainDestIsBridge({ destLocation: destChainId, xcmCreator }),
+			isDestEthereum: chainDestIsEthereum({ destLocation: destChainId, xcmCreator }),
 		};
 
 		/**
@@ -252,9 +256,6 @@ export class AssetTransferApi {
 		const isForeignAssetsTransfer = await this.checkContainsForeignAssets(api, assetIds);
 		const isPrimaryParachainNativeAsset = isParachainPrimaryNativeAsset(registry, specName, xcmDirection, assetIds[0]);
 		const xcmPallet = establishXcmPallet(api, xcmDirection, xcmPalletOverride);
-		const declaredXcmVersion = xcmVersion === undefined ? safeXcmVersion : xcmVersion;
-		checkXcmVersion(declaredXcmVersion); // Throws an error when the xcmVersion is not supported.
-		const xcmCreator = getXcmCreator(declaredXcmVersion);
 
 		/**
 		 * Create a local asset transfer
@@ -305,13 +306,14 @@ export class AssetTransferApi {
 			xcmFeeAsset,
 		};
 
-		await checkXcmTxInputs(
-			{ ...baseArgs, xcmPallet },
-			{
+		await checkXcmTxInputs({
+			baseArgs: { ...baseArgs, xcmPallet },
+			opts: {
 				...baseOpts,
 				isPrimaryParachainNativeAsset,
 			},
-		);
+			xcmCreator,
+		});
 
 		const assetType = this.fetchAssetType(xcmDirection, isForeignAssetsTransfer);
 		const assetCallType = this.fetchCallType({
@@ -332,6 +334,7 @@ export class AssetTransferApi {
 			baseArgs,
 			baseOpts,
 			paysWithFeeDest,
+			xcmCreator,
 		});
 
 		return this.constructFormat<T>({
@@ -388,13 +391,14 @@ export class AssetTransferApi {
 		const { api, specName, originChainId, registry, safeXcmVersion } = this;
 		const { format, sendersAddr, transferLiquidToken: isLiquidToken, xcmVersion } = opts;
 		const declaredXcmVersion = xcmVersion === undefined ? safeXcmVersion : xcmVersion;
+		const xcmCreator = getXcmCreator(declaredXcmVersion);
 		const isLiquidTokenTransfer = isLiquidToken ? true : false;
 		const assetIdsContainLocations = this.checkContainsAssetLocations(assetIds);
 		const beneficiaryAddress = sanitizeAddress(beneficiary);
 
 		checkXcmVersion(declaredXcmVersion);
 		checkBaseInputOptions(opts, specName);
-		checkClaimAssetsInputs(assetIds, amounts);
+		checkClaimAssetsInputs({ assets: assetIds, amounts, xcmCreator });
 
 		const ext = await claimAssets(
 			api,
@@ -411,7 +415,6 @@ export class AssetTransferApi {
 			},
 		);
 
-		const xcmCreator = getXcmCreator(declaredXcmVersion);
 		return await this.constructFormat({
 			tx: ext,
 			direction: 'local',
@@ -697,7 +700,11 @@ export class AssetTransferApi {
 		const fmt = format ? format : 'payload';
 		const result: TxResult<T> = {
 			origin,
-			dest: this.getDestinationSpecName(dest, this.registry),
+			dest: this.getDestinationSpecName({
+				destId: dest,
+				registry: this.registry,
+				xcmCreator,
+			}),
 			direction,
 			xcmVersion: xcmCreator.xcmVersion,
 			method,
@@ -717,9 +724,13 @@ export class AssetTransferApi {
 			// We can type cast here since the api will ensure if the format is a paylaod that the
 			// sendersAddr must be present.
 			const addr = sendersAddr as string;
-			result.tx = (await this.createPayload(tx, {
-				paysWithFeeOrigin,
-				sendersAddr: addr,
+			result.tx = (await this.createPayload({
+				tx,
+				opts: {
+					paysWithFeeOrigin,
+					sendersAddr: addr,
+				},
+				xcmCreator,
 			})) as ConstructedFormat<T>;
 		}
 
@@ -943,10 +954,15 @@ export class AssetTransferApi {
 	 * @param tx SubmittableExtrinsic<'promise', ISubmittableResult>
 	 * @param paysWithFeeOrigin string
 	 */
-	private createPayload = async (
-		tx: SubmittableExtrinsic<'promise', ISubmittableResult>,
-		opts: { paysWithFeeOrigin?: string; sendersAddr: string },
-	): Promise<GenericExtrinsicPayload> => {
+	private createPayload = async ({
+		tx,
+		opts,
+		xcmCreator,
+	}: {
+		tx: SubmittableExtrinsic<'promise', ISubmittableResult>;
+		opts: { paysWithFeeOrigin?: string; sendersAddr: string };
+		xcmCreator: XcmCreator;
+	}): Promise<GenericExtrinsicPayload> => {
 		const { paysWithFeeOrigin, sendersAddr } = opts;
 		let assetId: AnyJson = {};
 
@@ -955,7 +971,7 @@ export class AssetTransferApi {
 		if (paysWithFeeOrigin && isOriginSystemParachain) {
 			let paysWithFeeOriginAssetLocation: string;
 
-			if (!assetIdIsLocation(paysWithFeeOrigin)) {
+			if (!assetIdIsLocation({ assetId: paysWithFeeOrigin, xcmCreator })) {
 				const paysWithFeeOriginLocation = getPaysWithFeeOriginAssetLocationFromRegistry(this, paysWithFeeOrigin);
 
 				if (!paysWithFeeOriginLocation) {
@@ -969,7 +985,10 @@ export class AssetTransferApi {
 				paysWithFeeOriginAssetLocation = paysWithFeeOrigin;
 			}
 
-			const [isValidLpToken] = await this.checkAssetLpTokenPairExists(paysWithFeeOriginAssetLocation);
+			const [isValidLpToken] = await this.checkAssetLpTokenPairExists({
+				paysWithFeeOrigin: paysWithFeeOriginAssetLocation,
+				xcmCreator,
+			});
 
 			if (!isValidLpToken) {
 				throw new BaseError(
@@ -1032,13 +1051,21 @@ export class AssetTransferApi {
 	 * @param registry Registry
 	 * @returns string
 	 */
-	private getDestinationSpecName(destId: string, registry: Registry): string {
+	private getDestinationSpecName({
+		destId,
+		registry,
+		xcmCreator,
+	}: {
+		destId: string;
+		registry: Registry;
+		xcmCreator: XcmCreator;
+	}): string {
 		if (destId === '0') {
 			return registry.relayChain;
 		}
 
-		if (chainDestIsBridge(destId)) {
-			return getGlobalConsensusSystemName(destId);
+		if (chainDestIsBridge({ destLocation: destId, xcmCreator })) {
+			return getGlobalConsensusSystemName({ destLocation: destId, xcmCreator });
 		}
 
 		const lookup = registry.lookupParachainInfo(destId);
@@ -1106,7 +1133,13 @@ export class AssetTransferApi {
 	 * @param paysWithFeeOrigin XcmMultiLocation
 	 * @returns Promise<boolean>
 	 */
-	private checkAssetLpTokenPairExists = async (paysWithFeeOrigin: string): Promise<[boolean, XcmMultiLocation]> => {
+	private checkAssetLpTokenPairExists = async ({
+		paysWithFeeOrigin,
+		xcmCreator,
+	}: {
+		paysWithFeeOrigin: string;
+		xcmCreator: XcmCreator;
+	}): Promise<[boolean, XcmMultiLocation]> => {
 		let feeAsset: XcmMultiLocation;
 
 		try {
@@ -1128,14 +1161,14 @@ export class AssetTransferApi {
 
 					if (Array.isArray(lpTokenLocations[0])) {
 						// convert json into locations
-						const firstLpToken = parseLocationStrToLocation(
-							JSON.stringify(lpTokenLocations[0][0]).replace(/(\d),/g, '$1'),
-							this.safeXcmVersion,
-						);
-						const secondLpToken = parseLocationStrToLocation(
-							JSON.stringify(lpTokenLocations[0][1]).replace(/(\d),/g, '$1'),
-							this.safeXcmVersion,
-						);
+						const firstLpToken = parseLocationStrToLocation({
+							locationStr: JSON.stringify(lpTokenLocations[0][0]).replace(/(\d),/g, '$1'),
+							xcmCreator,
+						});
+						const secondLpToken = parseLocationStrToLocation({
+							locationStr: JSON.stringify(lpTokenLocations[0][1]).replace(/(\d),/g, '$1'),
+							xcmCreator,
+						});
 
 						// check locations match paysWithFeeOrigin feeAsset
 						if (deepEqual(sanitizeKeys(firstLpToken), feeAsset) || deepEqual(sanitizeKeys(secondLpToken), feeAsset)) {
@@ -1381,6 +1414,7 @@ export class AssetTransferApi {
 		baseArgs,
 		baseOpts,
 		paysWithFeeDest,
+		xcmCreator,
 	}: {
 		assetIds: string[];
 		xcmPallet: XcmPalletName;
@@ -1388,6 +1422,7 @@ export class AssetTransferApi {
 		assetCallType: AssetCallType;
 		baseArgs: XcmBaseArgs | XTokensBaseArgs;
 		baseOpts: CreateXcmCallOpts;
+		xcmCreator: XcmCreator;
 		paysWithFeeDest?: string;
 	}): Promise<ResolvedCallInfo> {
 		const { api } = baseArgs;
@@ -1403,7 +1438,7 @@ export class AssetTransferApi {
 			// This ensures paraToRelay always uses `transferMultiAsset`.
 			if (xcmDirection === Direction.ParaToRelay || (!paysWithFeeDest && assetIds.length < 2)) {
 				txMethod = 'transferMultiasset';
-			} else if (paysWithFeeDest && assetIdIsLocation(paysWithFeeDest)) {
+			} else if (paysWithFeeDest && assetIdIsLocation({ assetId: paysWithFeeDest, xcmCreator })) {
 				txMethod = 'transferMultiassetWithFee';
 			} else {
 				txMethod = 'transferMultiassets';

--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -334,7 +334,6 @@ export class AssetTransferApi {
 			baseArgs,
 			baseOpts,
 			paysWithFeeDest,
-			xcmCreator,
 		});
 
 		return this.constructFormat<T>({
@@ -1414,7 +1413,6 @@ export class AssetTransferApi {
 		baseArgs,
 		baseOpts,
 		paysWithFeeDest,
-		xcmCreator,
 	}: {
 		assetIds: string[];
 		xcmPallet: XcmPalletName;
@@ -1422,10 +1420,10 @@ export class AssetTransferApi {
 		assetCallType: AssetCallType;
 		baseArgs: XcmBaseArgs | XTokensBaseArgs;
 		baseOpts: CreateXcmCallOpts;
-		xcmCreator: XcmCreator;
 		paysWithFeeDest?: string;
 	}): Promise<ResolvedCallInfo> {
-		const { api } = baseArgs;
+		const { api, xcmVersion } = baseArgs;
+		const xcmCreator = getXcmCreator(xcmVersion);
 		let txMethod: Methods | undefined = undefined;
 
 		const isXtokensPallet = xcmPallet === XcmPalletName.xTokens || xcmPallet === XcmPalletName.xtokens;

--- a/src/createXcmCalls/polkadotXcm/transferAssetsUsingTypeAndThen.ts
+++ b/src/createXcmCalls/polkadotXcm/transferAssetsUsingTypeAndThen.ts
@@ -84,7 +84,7 @@ export const transferAssetsUsingTypeAndThen = async (
 			let assetLocation = JSON.parse(assetIdLocationStr) as XcmMultiLocation;
 
 			if ('v1' in assetLocation) {
-				assetLocation = parseLocationStrToLocation(JSON.stringify(assetLocation.v1), xcmVersion);
+				assetLocation = parseLocationStrToLocation({ locationStr: JSON.stringify(assetLocation.v1), xcmCreator });
 			}
 
 			// parse registry xc assets erc20 v1 location
@@ -201,7 +201,7 @@ export const transferAssetsUsingTypeAndThen = async (
 	});
 
 	let remoteFeesId: XcmVersionedAssetId;
-	if (paysWithFeeDest && !assetIdIsLocation(paysWithFeeDest)) {
+	if (paysWithFeeDest && !assetIdIsLocation({ assetId: paysWithFeeDest, xcmCreator })) {
 		const remoteFeesAssetLocation = await getAssetId({ api, registry, asset: paysWithFeeDest, specName, xcmCreator });
 		remoteFeesId = createXcmVersionedAssetId(remoteFeesAssetLocation, xcmCreator);
 	} else {

--- a/src/createXcmTypes/handlers/ParaToEthereum.ts
+++ b/src/createXcmTypes/handlers/ParaToEthereum.ts
@@ -111,7 +111,7 @@ const createParaToEthereumMultiAssets = async ({
 
 	if (isPrimaryParachainNativeAsset) {
 		const multiLocation = xcmCreator.resolveMultiLocation(
-			getParachainNativeAssetLocation(registry, assets[0], destChainId),
+			getParachainNativeAssetLocation({ registry, nativeAssetSymbol: assets[0], destChainId, xcmCreator }),
 		);
 
 		const multiAsset = xcmCreator.fungibleAsset({

--- a/src/createXcmTypes/handlers/ParaToPara.ts
+++ b/src/createXcmTypes/handlers/ParaToPara.ts
@@ -148,7 +148,7 @@ const createParaToParaMultiAssets = async ({
 
 	if (isPrimaryParachainNativeAsset) {
 		const multiLocation = xcmCreator.resolveMultiLocation(
-			getParachainNativeAssetLocation(registry, assets[0], destChainId),
+			getParachainNativeAssetLocation({ registry, nativeAssetSymbol: assets[0], destChainId, xcmCreator }),
 		);
 
 		const multiAsset = xcmCreator.fungibleAsset({

--- a/src/createXcmTypes/handlers/ParaToSystem.ts
+++ b/src/createXcmTypes/handlers/ParaToSystem.ts
@@ -146,7 +146,7 @@ const createParaToSystemMultiAssets = async ({
 
 	if (isPrimaryParachainNativeAsset) {
 		const multiLocation = xcmCreator.resolveMultiLocation(
-			getParachainNativeAssetLocation(registry, assets[0], destChainId),
+			getParachainNativeAssetLocation({ registry, nativeAssetSymbol: assets[0], destChainId, xcmCreator }),
 		);
 
 		const multiAsset = xcmCreator.fungibleAsset({

--- a/src/createXcmTypes/handlers/SystemToBridge.ts
+++ b/src/createXcmTypes/handlers/SystemToBridge.ts
@@ -111,7 +111,13 @@ const createSystemToBridgeAssets = async ({
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
-		const palletId = fetchPalletInstanceId(api, assetId, isLiquidTokenTransfer, isForeignAssetsTransfer);
+		const palletId = fetchPalletInstanceId({
+			api,
+			assetId,
+			isLiquidToken: isLiquidTokenTransfer,
+			isForeignAsset: isForeignAssetsTransfer,
+			xcmCreator,
+		});
 
 		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(registry, assetId);

--- a/src/createXcmTypes/handlers/SystemToPara.ts
+++ b/src/createXcmTypes/handlers/SystemToPara.ts
@@ -123,7 +123,13 @@ export const createSystemToParaMultiAssets = async ({
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
-		const palletId = fetchPalletInstanceId(api, assetId, isLiquidTokenTransfer, isForeignAssetsTransfer);
+		const palletId = fetchPalletInstanceId({
+			api,
+			assetId,
+			isLiquidToken: isLiquidTokenTransfer,
+			isForeignAsset: isForeignAssetsTransfer,
+			xcmCreator,
+		});
 
 		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(registry, assetId);
@@ -134,7 +140,7 @@ export const createSystemToParaMultiAssets = async ({
 
 		let multiLocation: XcmMultiLocation;
 
-		if (isForeignAssetsTransfer && assetIdIsLocation(assetId)) {
+		if (isForeignAssetsTransfer && assetIdIsLocation({ assetId, xcmCreator })) {
 			multiLocation = xcmCreator.resolveMultiLocation(assetId);
 		} else {
 			const parents = isRelayNative ? 1 : 0;

--- a/src/createXcmTypes/handlers/SystemToSystem.ts
+++ b/src/createXcmTypes/handlers/SystemToSystem.ts
@@ -121,7 +121,13 @@ const createSystemToSystemMultiAssets = async ({
 		let assetId: string = assets[i];
 		const amount = amounts[i];
 
-		const palletId = fetchPalletInstanceId(api, assetId, isLiquidTokenTransfer, isForeignAssetsTransfer);
+		const palletId = fetchPalletInstanceId({
+			api,
+			assetId,
+			isLiquidToken: isLiquidTokenTransfer,
+			isForeignAsset: isForeignAssetsTransfer,
+			xcmCreator,
+		});
 
 		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(registry, assetId);

--- a/src/createXcmTypes/util/assetIdIsLocation.spec.ts
+++ b/src/createXcmTypes/util/assetIdIsLocation.spec.ts
@@ -1,24 +1,27 @@
+import { DEFAULT_XCM_VERSION } from '../../consts';
+import { getXcmCreator } from '../xcm';
 import { assetIdIsLocation } from './assetIdIsLocation';
 
 describe('assetIdIsLocation', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	it('Should correctly return true for a valid location assetId string', () => {
 		const assetId = `{"parents":"1","interior":{"X2":[{"Parchain":"2004"},{"PalletInstance":"10"}]}}`;
 
-		expect(assetIdIsLocation(assetId)).toBe(true);
+		expect(assetIdIsLocation({ assetId, xcmCreator })).toBe(true);
 	});
 	it('Should correctly return false for an invalid location assetId string', () => {
 		const assetId = `{"parents":"1"}`;
 
-		expect(assetIdIsLocation(assetId)).toBe(false);
+		expect(assetIdIsLocation({ assetId, xcmCreator })).toBe(false);
 	});
 	it('Should correctly return false for an inter assetId string', () => {
 		const assetId = `1984`;
 
-		expect(assetIdIsLocation(assetId)).toBe(false);
+		expect(assetIdIsLocation({ assetId, xcmCreator })).toBe(false);
 	});
 	it('Should correctly return false for a symbol assetId string', () => {
 		const assetId = `usdt`;
 
-		expect(assetIdIsLocation(assetId)).toBe(false);
+		expect(assetIdIsLocation({ assetId, xcmCreator })).toBe(false);
 	});
 });

--- a/src/createXcmTypes/util/assetIdIsLocation.ts
+++ b/src/createXcmTypes/util/assetIdIsLocation.ts
@@ -1,12 +1,12 @@
-import { DEFAULT_XCM_VERSION } from '../../consts.js';
+import { XcmCreator } from '../types.js';
 import { parseLocationStrToLocation } from './parseLocationStrToLocation.js';
 
-export const assetIdIsLocation = (assetId: string): boolean => {
+export const assetIdIsLocation = ({ assetId, xcmCreator }: { assetId: string; xcmCreator: XcmCreator }): boolean => {
 	if (!assetId.toLowerCase().includes('parents') || !assetId.toLowerCase().includes('interior')) {
 		return false;
 	}
 
-	const location = parseLocationStrToLocation(assetId, DEFAULT_XCM_VERSION);
+	const location = parseLocationStrToLocation({ locationStr: assetId, xcmCreator });
 
 	return Object.keys(location).length === 2;
 };

--- a/src/createXcmTypes/util/chainDestIsBridge.spec.ts
+++ b/src/createXcmTypes/util/chainDestIsBridge.spec.ts
@@ -1,17 +1,20 @@
+import { DEFAULT_XCM_VERSION } from '../../consts';
+import { getXcmCreator } from '../xcm';
 import { chainDestIsBridge } from './chainDestIsBridge';
 
 describe('chainDestIsBridge', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	it('Should correctly return true for a GlobalConsensus destination location', () => {
 		const destLocation = `{"parents":"2","interior":{"X1":{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}}}}`;
 
-		const result = chainDestIsBridge(destLocation);
+		const result = chainDestIsBridge({ destLocation, xcmCreator });
 
 		expect(result).toEqual(true);
 	});
 	it('Should correctly return false for a destination location that does not contain a GlobalConsensus junction', () => {
 		const destLocation = `{"parents":"2","interior":{"X1":{"Parachain":"2030"}}}`;
 
-		const result = chainDestIsBridge(destLocation);
+		const result = chainDestIsBridge({ destLocation, xcmCreator });
 
 		expect(result).toEqual(false);
 	});

--- a/src/createXcmTypes/util/chainDestIsBridge.ts
+++ b/src/createXcmTypes/util/chainDestIsBridge.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_XCM_VERSION } from '../../consts.js';
+import { XcmCreator } from '../types.js';
 import { parseLocationStrToLocation } from './parseLocationStrToLocation.js';
 
 /**
@@ -6,8 +6,14 @@ import { parseLocationStrToLocation } from './parseLocationStrToLocation.js';
  * @param destLocation
  * @returns boolean
  */
-export const chainDestIsBridge = (destLocation: string): boolean => {
-	const location = parseLocationStrToLocation(destLocation, DEFAULT_XCM_VERSION);
+export const chainDestIsBridge = ({
+	destLocation,
+	xcmCreator,
+}: {
+	destLocation: string;
+	xcmCreator: XcmCreator;
+}): boolean => {
+	const location = parseLocationStrToLocation({ locationStr: destLocation, xcmCreator });
 	let destIsBridge = false;
 
 	if (location.interior) {

--- a/src/createXcmTypes/util/chainDestIsEthereum.spec.ts
+++ b/src/createXcmTypes/util/chainDestIsEthereum.spec.ts
@@ -1,16 +1,19 @@
+import { DEFAULT_XCM_VERSION } from '../../consts';
+import { getXcmCreator } from '../xcm';
 import { chainDestIsEthereum } from './chainDestIsEthereum';
 
 describe('chainDestIsEthereum', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	it('Should correctly return true for a GlobalConsensus destination location', () => {
 		const destLocation = `{"parents":"2","interior":{"X1":{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}}}}`;
-		const result = chainDestIsEthereum(destLocation);
+		const result = chainDestIsEthereum({ destLocation, xcmCreator });
 
 		expect(result).toEqual(true);
 	});
 	it('Should correctly return false for a destination location that does not contain a GlobalConsensus junction', () => {
 		const destLocation = `{"parents":"2","interior":{"X1":{"Parachain":"2030"}}}`;
 
-		const result = chainDestIsEthereum(destLocation);
+		const result = chainDestIsEthereum({ destLocation, xcmCreator });
 
 		expect(result).toEqual(false);
 	});

--- a/src/createXcmTypes/util/chainDestIsEthereum.ts
+++ b/src/createXcmTypes/util/chainDestIsEthereum.ts
@@ -1,12 +1,18 @@
-import { DEFAULT_XCM_VERSION } from '../../consts.js';
+import { XcmCreator } from '../types.js';
 import { parseLocationStrToLocation } from './parseLocationStrToLocation.js';
 
-export const chainDestIsEthereum = (destLocation: string): boolean => {
+export const chainDestIsEthereum = ({
+	destLocation,
+	xcmCreator,
+}: {
+	destLocation: string;
+	xcmCreator: XcmCreator;
+}): boolean => {
 	if (!destLocation.toLowerCase().includes('parents') || !destLocation.toLowerCase().includes('interior')) {
 		return false;
 	}
 
-	const location = parseLocationStrToLocation(destLocation, DEFAULT_XCM_VERSION);
+	const location = parseLocationStrToLocation({ locationStr: destLocation, xcmCreator });
 
 	const destIsEthereum = location.interior.X1
 		? JSON.stringify(location.interior.X1).toLowerCase().includes('ethereum')

--- a/src/createXcmTypes/util/createAssetLocations.ts
+++ b/src/createXcmTypes/util/createAssetLocations.ts
@@ -61,7 +61,13 @@ export const createAssetLocations = async ({
 			if (isRelayNative) {
 				interior = { Here: '' };
 			} else {
-				const palletId = fetchPalletInstanceId(api, assetId, isLiquidTokenTransfer, assetIdsContainLocations);
+				const palletId = fetchPalletInstanceId({
+					api,
+					assetId,
+					isLiquidToken: isLiquidTokenTransfer,
+					isForeignAsset: assetIdsContainLocations,
+					xcmCreator,
+				});
 				interior = {
 					X2: [{ PalletInstance: palletId }, { GeneralIndex: assetId }],
 				};

--- a/src/createXcmTypes/util/createXcmVersionedAssetId.ts
+++ b/src/createXcmTypes/util/createXcmVersionedAssetId.ts
@@ -13,10 +13,10 @@ export const createXcmVersionedAssetId = (
 		throw new BaseError('XcmVersion must be greater than 2', BaseErrorsEnum.InvalidXcmVersion);
 	}
 
-	let location = parseLocationStrToLocation(destFeesAssetId, xcmCreator.xcmVersion);
+	let location = parseLocationStrToLocation({ locationStr: destFeesAssetId, xcmCreator });
 
 	if (typeof location === 'object' && 'v1' in location) {
-		location = parseLocationStrToLocation(JSON.stringify(location.v1), xcmCreator.xcmVersion);
+		location = parseLocationStrToLocation({ locationStr: JSON.stringify(location.v1), xcmCreator });
 	}
 
 	return xcmCreator.versionedAssetId(location);

--- a/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.spec.ts
@@ -1,35 +1,65 @@
+import { DEFAULT_XCM_VERSION } from '../../consts';
 import { mockBifrostParachainApi } from '../../testHelpers/mockBifrostParachainApi';
 import { mockSystemApi } from '../../testHelpers/mockSystemApi';
+import { getXcmCreator } from '../xcm';
 import { fetchPalletInstanceId } from './fetchPalletInstanceId';
 
 describe('fetchPalletInstanceId', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	it('Should return the correct string when the api has the assets pallet', () => {
-		const res = fetchPalletInstanceId(mockSystemApi, '1984', false, false);
+		const res = fetchPalletInstanceId({
+			api: mockSystemApi,
+			assetId: '1984',
+			isLiquidToken: false,
+			isForeignAsset: false,
+			xcmCreator,
+		});
 
 		expect(res).toEqual(50);
 	});
 	it('Should correctly grab the poolAssets pallet instance', () => {
-		const res = fetchPalletInstanceId(mockSystemApi, '0', true, false);
+		const res = fetchPalletInstanceId({
+			api: mockSystemApi,
+			assetId: '0',
+			isLiquidToken: true,
+			isForeignAsset: false,
+			xcmCreator,
+		});
 
 		expect(res).toEqual(55);
 	});
 	it('Should correctly grab the foreignAssets pallet instance', () => {
-		const res = fetchPalletInstanceId(
-			mockSystemApi,
-			`{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}`,
-			false,
-			true,
-		);
+		const res = fetchPalletInstanceId({
+			api: mockSystemApi,
+			assetId: `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}`,
+			isLiquidToken: false,
+			isForeignAsset: true,
+			xcmCreator,
+		});
 
 		expect(res).toEqual(53);
 	});
 	it('Should correctly error when both foreign assets and pool assets are true', () => {
-		const err = () => fetchPalletInstanceId(mockSystemApi, '0', true, true);
+		const err = () =>
+			fetchPalletInstanceId({
+				api: mockSystemApi,
+				assetId: '0',
+				isLiquidToken: true,
+				isForeignAsset: true,
+				xcmCreator,
+			});
 
 		expect(err).toThrow("Can't find the appropriate pallet when both liquid tokens and foreign assets");
 	});
 	it('Should correctly error when the assets pallet is not found', () => {
-		const err = () => fetchPalletInstanceId(mockBifrostParachainApi, '0', false, false);
+		const err = () =>
+			fetchPalletInstanceId({
+				api: mockBifrostParachainApi,
+				assetId: '0',
+				isLiquidToken: false,
+				isForeignAsset: false,
+				xcmCreator,
+			});
 
 		expect(err).toThrow("No pallet available, can't find a valid PalletInstance.");
 	});

--- a/src/createXcmTypes/util/fetchPalletInstanceId.ts
+++ b/src/createXcmTypes/util/fetchPalletInstanceId.ts
@@ -1,6 +1,7 @@
 import type { ApiPromise } from '@polkadot/api';
 
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
+import { XcmCreator } from '../types.js';
 import { assetIdIsLocation } from './assetIdIsLocation.js';
 
 /**
@@ -9,12 +10,19 @@ import { assetIdIsLocation } from './assetIdIsLocation.js';
  * @param api ApiPromise.
  * @param isLiquidToken Boolean to determine whether or not to fetch the PoolAssets id.
  */
-export const fetchPalletInstanceId = (
-	api: ApiPromise,
-	assetId: string,
-	isLiquidToken: boolean,
-	isForeignAsset: boolean,
-): number => {
+export const fetchPalletInstanceId = ({
+	api,
+	assetId,
+	isLiquidToken,
+	isForeignAsset,
+	xcmCreator,
+}: {
+	api: ApiPromise;
+	assetId: string;
+	isLiquidToken: boolean;
+	isForeignAsset: boolean;
+	xcmCreator: XcmCreator;
+}): number => {
 	if (isLiquidToken && isForeignAsset) {
 		throw new BaseError(
 			"Can't find the appropriate pallet when both liquid tokens and foreign assets",
@@ -25,7 +33,7 @@ export const fetchPalletInstanceId = (
 	const palletName =
 		isLiquidToken && api.query.poolAssets
 			? 'PoolAssets'
-			: isForeignAsset && api.query.foreignAssets && assetIdIsLocation(assetId)
+			: isForeignAsset && api.query.foreignAssets && assetIdIsLocation({ assetId, xcmCreator })
 				? 'ForeignAssets'
 				: api.query.assets
 					? 'Assets'

--- a/src/createXcmTypes/util/getAssetId.ts
+++ b/src/createXcmTypes/util/getAssetId.ts
@@ -203,15 +203,15 @@ export const getAssetId = async ({
 					if (typeof info.symbol === 'string' && info.symbol.toLowerCase() === asset.toLowerCase()) {
 						assetId = info.xcmV1MultiLocation;
 						registry.setAssetInCache(asset, assetId);
-					} else if (assetIdIsLocation(asset)) {
+					} else if (assetIdIsLocation({ assetId: asset, xcmCreator })) {
 						const v1AssetLocation = JSON.parse(info.xcmV1MultiLocation) as XcmMultiLocation;
 
 						if ('v1' in v1AssetLocation) {
-							const registryAssetLocation = parseLocationStrToLocation(
-								JSON.stringify(v1AssetLocation.v1),
-								xcmCreator.xcmVersion,
-							);
-							const assetLocation = parseLocationStrToLocation(asset, xcmCreator.xcmVersion);
+							const registryAssetLocation = parseLocationStrToLocation({
+								locationStr: JSON.stringify(v1AssetLocation.v1),
+								xcmCreator,
+							});
+							const assetLocation = parseLocationStrToLocation({ locationStr: asset, xcmCreator });
 
 							if (JSON.stringify(registryAssetLocation).toLowerCase() === JSON.stringify(assetLocation).toLowerCase()) {
 								assetId = info.xcmV1MultiLocation;

--- a/src/createXcmTypes/util/getGlobalConsensusSystemName.spec.ts
+++ b/src/createXcmTypes/util/getGlobalConsensusSystemName.spec.ts
@@ -1,25 +1,28 @@
+import { DEFAULT_XCM_VERSION } from '../../consts';
+import { getXcmCreator } from '../xcm';
 import { getGlobalConsensusSystemName } from './getGlobalConsensusSystemName';
 
 describe('getGlobalConsensusSystemName', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	describe('X1', () => {
 		it('Should correctly return the consensus system name for Polkadot', () => {
 			const destLocation = `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Polkadot"}}}`;
 
-			const result = getGlobalConsensusSystemName(destLocation);
+			const result = getGlobalConsensusSystemName({ destLocation, xcmCreator });
 
 			expect(result).toEqual('polkadot');
 		});
 		it('Should correctly return the consensus system name for Kusama', () => {
 			const destLocation = `{"parents":"2","interior":{"X1":{"GlobalConsensus":"Kusama"}}}`;
 
-			const result = getGlobalConsensusSystemName(destLocation);
+			const result = getGlobalConsensusSystemName({ destLocation, xcmCreator });
 
 			expect(result).toEqual('kusama');
 		});
 		it('Should correctly return the consensus system name for Ethereum', () => {
 			const destLocation = `{"parents":"2","interior":{"X1":{"GlobalConsensus":{"Ethereum":{"chainId":"11155111"}}}}}`;
 
-			const result = getGlobalConsensusSystemName(destLocation);
+			const result = getGlobalConsensusSystemName({ destLocation, xcmCreator });
 
 			expect(result).toEqual('ethereum');
 		});
@@ -28,14 +31,14 @@ describe('getGlobalConsensusSystemName', () => {
 		it('Should correctly return the consensus system name for Polkadot AssetHub', () => {
 			const destLocation = `{"parents":"2","interior":{"X2":[{"GlobalConsensus":"Polkadot"},{"Parachain":"1000"}]}}`;
 
-			const result = getGlobalConsensusSystemName(destLocation);
+			const result = getGlobalConsensusSystemName({ destLocation, xcmCreator });
 
 			expect(result).toEqual('polkadot');
 		});
 		it('Should correctly return the consensus system name for Kusama AssetHub', () => {
 			const destLocation = `{"parents":"2","interior":{"X2":[{"GlobalConsensus":"Kusama"},{"Parachain":"1000"}]}}`;
 
-			const result = getGlobalConsensusSystemName(destLocation);
+			const result = getGlobalConsensusSystemName({ destLocation, xcmCreator });
 
 			expect(result).toEqual('kusama');
 		});
@@ -43,7 +46,7 @@ describe('getGlobalConsensusSystemName', () => {
 	it('Should correctly throw an error when no valid consensus system name is found', () => {
 		const destLocation = `{"parents":"2","interior":{"X1":{"GlobalConsensus":{"Cosmos":{"chainId":"0"}}}}}`;
 
-		const err = () => getGlobalConsensusSystemName(destLocation);
+		const err = () => getGlobalConsensusSystemName({ destLocation, xcmCreator });
 
 		expect(err).toThrow(
 			`No known consensus system found for location {"parents":"2","interior":{"X1":{"GlobalConsensus":{"Cosmos":{"chainId":"0"}}}}}`,

--- a/src/createXcmTypes/util/getGlobalConsensusSystemName.ts
+++ b/src/createXcmTypes/util/getGlobalConsensusSystemName.ts
@@ -1,9 +1,16 @@
-import { DEFAULT_XCM_VERSION, KNOWN_GLOBAL_CONSENSUS_SYSTEM_NAMES } from '../../consts.js';
+import { KNOWN_GLOBAL_CONSENSUS_SYSTEM_NAMES } from '../../consts.js';
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
+import { XcmCreator } from '../types.js';
 import { parseLocationStrToLocation } from './parseLocationStrToLocation.js';
 
-export const getGlobalConsensusSystemName = (destLocation: string): string => {
-	const location = parseLocationStrToLocation(destLocation, DEFAULT_XCM_VERSION);
+export const getGlobalConsensusSystemName = ({
+	destLocation,
+	xcmCreator,
+}: {
+	destLocation: string;
+	xcmCreator: XcmCreator;
+}): string => {
+	const location = parseLocationStrToLocation({ locationStr: destLocation, xcmCreator });
 
 	for (const systemName of KNOWN_GLOBAL_CONSENSUS_SYSTEM_NAMES) {
 		if (

--- a/src/createXcmTypes/util/getParachainNativeAssetLocation.spec.ts
+++ b/src/createXcmTypes/util/getParachainNativeAssetLocation.spec.ts
@@ -1,46 +1,75 @@
+import { DEFAULT_XCM_VERSION } from '../../consts';
 import { Registry } from '../../registry';
+import { getXcmCreator } from '../xcm';
 import { getParachainNativeAssetLocation } from './getParachainNativeAssetLocation';
 
 describe('getParachainNativeAssetLocation', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	it('Correctly returns the native asset location for Moonbeam', () => {
 		const registry = new Registry('moonbeam', {});
 
-		const res = getParachainNativeAssetLocation(registry, 'GLMR', '2034');
+		const res = getParachainNativeAssetLocation({
+			registry,
+			nativeAssetSymbol: 'GLMR',
+			destChainId: '2034',
+			xcmCreator,
+		});
 
 		expect(JSON.stringify(res)).toEqual('{"parents":0,"interior":{"X1":{"PalletInstance":"10"}}}');
 	});
 	it('Correctly returns the native asset location for Moonriver', () => {
 		const registry = new Registry('moonriver', {});
 
-		const res = getParachainNativeAssetLocation(registry, 'MOVR', '2001');
+		const res = getParachainNativeAssetLocation({
+			registry,
+			nativeAssetSymbol: 'MOVR',
+			destChainId: '2001',
+			xcmCreator,
+		});
 
 		expect(JSON.stringify(res)).toEqual('{"parents":0,"interior":{"X1":{"PalletInstance":"10"}}}');
 	});
 	it('Correctly returns the native asset location for Phala', () => {
 		const registry = new Registry('phala', {});
 
-		const res = getParachainNativeAssetLocation(registry, 'PHA', '2034');
+		const res = getParachainNativeAssetLocation({
+			registry,
+			nativeAssetSymbol: 'PHA',
+			destChainId: '2034',
+			xcmCreator,
+		});
 
 		expect(JSON.stringify(res)).toEqual('{"parents":0,"interior":{"X1":{"Parachain":"2035"}}}');
 	});
 	it('Correctly returns the native asset location for Hydration', () => {
 		const registry = new Registry('hydradx', {});
 
-		const res = getParachainNativeAssetLocation(registry, 'HDX', '2004');
+		const res = getParachainNativeAssetLocation({
+			registry,
+			nativeAssetSymbol: 'HDX',
+			destChainId: '2004',
+			xcmCreator,
+		});
 
 		expect(JSON.stringify(res)).toEqual('{"parents":0,"interior":{"X1":{"GeneralIndex":"0"}}}');
 	});
 	it('Correctly returns the native asset location for Hydration when destination is AssetHub', () => {
 		const registry = new Registry('hydradx', {});
 
-		const res = getParachainNativeAssetLocation(registry, 'HDX', '1000');
+		const res = getParachainNativeAssetLocation({
+			registry,
+			nativeAssetSymbol: 'HDX',
+			destChainId: '1000',
+			xcmCreator,
+		});
 
 		expect(JSON.stringify(res)).toEqual('{"parents":0,"interior":{"X1":{"GeneralIndex":"0"}}}');
 	});
 	it('correctly throws an error when no valid location is found for the given native asset', () => {
 		const registry = new Registry('moonbeam', {});
 
-		const err = () => getParachainNativeAssetLocation(registry, 'GLMR', '3369');
+		const err = () =>
+			getParachainNativeAssetLocation({ registry, nativeAssetSymbol: 'GLMR', destChainId: '3369', xcmCreator });
 
 		expect(err).toThrow('No location found for asset GLMR');
 	});

--- a/src/createXcmTypes/util/getParachainNativeAssetLocation.ts
+++ b/src/createXcmTypes/util/getParachainNativeAssetLocation.ts
@@ -1,16 +1,21 @@
-import { DEFAULT_XCM_VERSION } from '../../consts.js';
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
 import { Registry } from '../../registry/index.js';
 import { SanitizedXcAssetsData } from '../../registry/types.js';
 import { sanitizeKeys } from '../../util/sanitizeKeys.js';
-import { XcmJunction, XcmMultiLocation } from '../types.js';
+import { XcmCreator, XcmJunction, XcmMultiLocation } from '../types.js';
 import { parseLocationStrToLocation } from './parseLocationStrToLocation.js';
 
-export const getParachainNativeAssetLocation = (
-	registry: Registry,
-	nativeAssetSymbol: string,
-	destChainId?: string,
-): XcmMultiLocation => {
+export const getParachainNativeAssetLocation = ({
+	registry,
+	nativeAssetSymbol,
+	destChainId,
+	xcmCreator,
+}: {
+	registry: Registry;
+	nativeAssetSymbol: string;
+	destChainId?: string;
+	xcmCreator: XcmCreator;
+}): XcmMultiLocation => {
 	if (!destChainId) {
 		throw new BaseError('No destination chainId provided', BaseErrorsEnum.InternalError);
 	}
@@ -22,7 +27,7 @@ export const getParachainNativeAssetLocation = (
 			const paraXcAssets = registry.getRelaysRegistry[relayRegistryKey].xcAssetsData;
 
 			if (paraXcAssets) {
-				location = getNativeAssetLocation(nativeAssetSymbol, paraXcAssets);
+				location = getNativeAssetLocation({ nativeAssetSymbol, paraXcAssets, xcmCreator });
 
 				if (location) {
 					return location;
@@ -33,7 +38,7 @@ export const getParachainNativeAssetLocation = (
 		const paraXcAssets = registry.getRelaysRegistry[destChainId].xcAssetsData;
 
 		if (paraXcAssets) {
-			location = getNativeAssetLocation(nativeAssetSymbol, paraXcAssets);
+			location = getNativeAssetLocation({ nativeAssetSymbol, paraXcAssets, xcmCreator });
 			if (location) {
 				return location;
 			}
@@ -43,17 +48,22 @@ export const getParachainNativeAssetLocation = (
 	throw new BaseError(`No location found for asset ${nativeAssetSymbol}`, BaseErrorsEnum.InvalidAsset);
 };
 
-const getNativeAssetLocation = (
-	nativeAssetSymbol: string,
-	paraXcAssets: SanitizedXcAssetsData[],
-): XcmMultiLocation | undefined => {
+const getNativeAssetLocation = ({
+	nativeAssetSymbol,
+	paraXcAssets,
+	xcmCreator,
+}: {
+	nativeAssetSymbol: string;
+	paraXcAssets: SanitizedXcAssetsData[];
+	xcmCreator: XcmCreator;
+}): XcmMultiLocation | undefined => {
 	let location: XcmMultiLocation | undefined = undefined;
 
 	for (const asset of paraXcAssets) {
 		if (typeof asset.symbol === 'string' && asset.symbol.toLowerCase() === nativeAssetSymbol.toLowerCase()) {
 			// get the location from v1
 			const v1LocationStr = asset.xcmV1MultiLocation;
-			location = parseLocationStrToLocation(v1LocationStr, DEFAULT_XCM_VERSION);
+			location = parseLocationStrToLocation({ locationStr: v1LocationStr, xcmCreator });
 
 			// handle case where result is an xcmV1Multilocation from the registry
 			if (typeof location === 'object' && 'v1' in location) {

--- a/src/createXcmTypes/util/parseLocationStrToLocation.spec.ts
+++ b/src/createXcmTypes/util/parseLocationStrToLocation.spec.ts
@@ -1,7 +1,9 @@
 import { DEFAULT_XCM_VERSION } from '../../consts';
+import { getXcmCreator } from '../xcm';
 import { parseLocationStrToLocation } from './parseLocationStrToLocation';
 
 describe('parseLocationStrToLocation', () => {
+	const xcmCreator = getXcmCreator(DEFAULT_XCM_VERSION);
 	it('Should correctly return a valid UnionXcmMultilocation', () => {
 		const locationStr = '{"parents":"2","interior":{"X2":[{"GlobalConsensus":"Polkadot"},{"Parachain":"1000"}]}}';
 		const expected = {
@@ -37,14 +39,14 @@ describe('parseLocationStrToLocation', () => {
 				],
 			},
 		};
-		const result = parseLocationStrToLocation(locationStr, DEFAULT_XCM_VERSION);
+		const result = parseLocationStrToLocation({ locationStr, xcmCreator });
 
 		expect(result).toEqual(expected);
 	});
 	it('Should correctly error when an unparseable location string is provided', () => {
 		const locationStr = '{"parents":"2","interior":{"X2":[{GlobalConsensus":"Polkadot"},{"Parachain":"1000"}]}}';
 
-		const err = () => parseLocationStrToLocation(locationStr, DEFAULT_XCM_VERSION);
+		const err = () => parseLocationStrToLocation({ locationStr, xcmCreator });
 
 		expect(err).toThrow(
 			'Unable to parse {"parents":"2","interior":{"X2":[{GlobalConsensus":"Polkadot"},{"Parachain":"1000"}]}} as a valid location',

--- a/src/createXcmTypes/util/parseLocationStrToLocation.spec.ts
+++ b/src/createXcmTypes/util/parseLocationStrToLocation.spec.ts
@@ -17,7 +17,7 @@ describe('parseLocationStrToLocation', () => {
 				],
 			},
 		};
-		const result = parseLocationStrToLocation(locationStr, DEFAULT_XCM_VERSION);
+		const result = parseLocationStrToLocation({ locationStr, xcmCreator });
 
 		expect(result).toEqual(expected);
 	});

--- a/src/createXcmTypes/util/parseLocationStrToLocation.ts
+++ b/src/createXcmTypes/util/parseLocationStrToLocation.ts
@@ -1,11 +1,7 @@
-import { DEFAULT_XCM_VERSION } from '../../consts.js';
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
 import { XcmJunction, XcmJunctionForVersion, XcmMultiLocation, XcmVersionKey } from '../types.js';
 
-export const parseLocationStrToLocation = (
-	locationStr: string,
-	xcmVersion: number = DEFAULT_XCM_VERSION,
-): XcmMultiLocation => {
+export const parseLocationStrToLocation = (locationStr: string, xcmVersion: number): XcmMultiLocation => {
 	let location = '';
 	const isX1V4Location = locationStr.includes(`X1":[`) && locationStr.includes(`]`);
 

--- a/src/createXcmTypes/util/parseLocationStrToLocation.ts
+++ b/src/createXcmTypes/util/parseLocationStrToLocation.ts
@@ -1,7 +1,14 @@
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
-import { XcmJunction, XcmJunctionForVersion, XcmMultiLocation, XcmVersionKey } from '../types.js';
+import { XcmCreator, XcmJunction, XcmJunctionForVersion, XcmMultiLocation, XcmVersionKey } from '../types.js';
 
-export const parseLocationStrToLocation = (locationStr: string, xcmVersion: number): XcmMultiLocation => {
+export const parseLocationStrToLocation = ({
+	locationStr,
+	xcmCreator,
+}: {
+	locationStr: string;
+	xcmCreator: XcmCreator;
+}): XcmMultiLocation => {
+	const xcmVersion = xcmCreator.xcmVersion;
 	let location = '';
 	const isX1V4Location = locationStr.includes(`X1":[`) && locationStr.includes(`]`);
 

--- a/src/createXcmTypes/xcm/v2.ts
+++ b/src/createXcmTypes/xcm/v2.ts
@@ -95,7 +95,7 @@ export const V2: XcmCreator = {
 			);
 		}
 
-		let result = parseLocationStrToLocation(multiLocationStr, this.xcmVersion);
+		let result = parseLocationStrToLocation({ locationStr: multiLocationStr, xcmCreator: this });
 
 		// handle case where result is an xcmV1Multilocation from the registry
 		if (typeof result === 'object' && 'v1' in result) {

--- a/src/createXcmTypes/xcm/v3.ts
+++ b/src/createXcmTypes/xcm/v3.ts
@@ -84,7 +84,7 @@ export const V3: XcmCreator = {
 	resolveMultiLocation(multiLocation: AnyJson): XcmMultiLocation {
 		const multiLocationStr = typeof multiLocation === 'string' ? multiLocation : JSON.stringify(multiLocation);
 
-		let result = parseLocationStrToLocation(multiLocationStr, this.xcmVersion);
+		let result = parseLocationStrToLocation({ locationStr: multiLocationStr, xcmCreator: this });
 
 		// handle case where result is an xcmV1Multilocation from the registry
 		if (typeof result === 'object' && 'v1' in result) {
@@ -149,7 +149,7 @@ export const V3: XcmCreator = {
 	},
 
 	interiorDest({ destId, parents }: { destId: string; parents: number }): XcmVersionedMultiLocation {
-		const multiLocation = parseLocationStrToLocation(destId, this.xcmVersion) as XcmV3MultiLocation;
+		const multiLocation = parseLocationStrToLocation({ locationStr: destId, xcmCreator: this }) as XcmV3MultiLocation;
 		if (!multiLocation.interior) {
 			throw new BaseError('Unable to create XCM Destination location', BaseErrorsEnum.InternalError);
 		}

--- a/src/createXcmTypes/xcm/v4.ts
+++ b/src/createXcmTypes/xcm/v4.ts
@@ -83,7 +83,7 @@ export const V4: XcmCreator = {
 	resolveMultiLocation(multiLocation: AnyJson): XcmMultiLocation {
 		const multiLocationStr = typeof multiLocation === 'string' ? multiLocation : JSON.stringify(multiLocation);
 
-		let result = parseLocationStrToLocation(multiLocationStr, this.xcmVersion);
+		let result = parseLocationStrToLocation({ locationStr: multiLocationStr, xcmCreator: this });
 
 		// handle case where result is an xcmV1Multilocation from the registry
 		if (typeof result === 'object' && 'v1' in result) {
@@ -155,7 +155,7 @@ export const V4: XcmCreator = {
 	},
 
 	interiorDest({ destId, parents }: { destId: string; parents: number }): XcmVersionedMultiLocation {
-		const multiLocation = parseLocationStrToLocation(destId, this.xcmVersion) as XcmV4MultiLocation;
+		const multiLocation = parseLocationStrToLocation({ locationStr: destId, xcmCreator: this }) as XcmV4MultiLocation;
 
 		return {
 			V4: {

--- a/src/createXcmTypes/xcm/v5.ts
+++ b/src/createXcmTypes/xcm/v5.ts
@@ -135,7 +135,7 @@ export const V5: XcmCreator = {
 
 	// Same as V4
 	interiorDest({ destId, parents }: { destId: string; parents: number }): XcmVersionedMultiLocation {
-		const multiLocation = parseLocationStrToLocation(destId, this.xcmVersion) as XcmV5MultiLocation;
+		const multiLocation = parseLocationStrToLocation({ locationStr: destId, xcmCreator: this }) as XcmV5MultiLocation;
 
 		if (!multiLocation.interior) {
 			throw new BaseError('Unable to create XCM Destination location', BaseErrorsEnum.InternalError);

--- a/src/errors/checkXcmTxInputs.spec.ts
+++ b/src/errors/checkXcmTxInputs.spec.ts
@@ -1,5 +1,6 @@
 import { AssetTransferApi } from '../AssetTransferApi';
 import { XcmPalletName } from '../createXcmCalls/util/establishXcmPallet';
+import { getXcmCreator } from '../createXcmTypes/xcm';
 import { Registry } from '../registry';
 import { adjustedMockMoonriverParachainApi } from '../testHelpers/adjustedMockMoonriverParachainApi';
 import { adjustedMockSystemApi } from '../testHelpers/adjustedMockSystemApiV1004000';
@@ -32,6 +33,7 @@ import {
 const parachainAssetsApi = new AssetTransferApi(adjustedMockMoonriverParachainApi, 'moonriver', 2, {
 	registryType: 'NPM',
 });
+const xcmCreator = getXcmCreator(2);
 const runTests = async (tests: Test[]) => {
 	for (const test of tests) {
 		const [specName, testInputs, direction, errorMessage] = test;
@@ -39,17 +41,17 @@ const runTests = async (tests: Test[]) => {
 		const currentRegistry = registry.currentRelayRegistry;
 
 		await expect(async () => {
-			await checkAssetIdInput(
-				parachainAssetsApi.api,
-				testInputs,
-				currentRegistry,
+			await checkAssetIdInput({
+				api: parachainAssetsApi.api,
+				assetIds: testInputs,
+				relayChainInfo: currentRegistry,
 				specName,
-				direction,
+				xcmDirection: direction,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).rejects.toThrow(errorMessage);
 	}
 };
@@ -210,17 +212,17 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: mockSystemApi,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -253,17 +255,17 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: mockSystemApi,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -277,17 +279,17 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
-				await checkAssetIdInput(
-					parachainAssetsApi.api,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: parachainAssetsApi.api,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -320,17 +322,17 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: mockSystemApi,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -350,17 +352,17 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
-				await checkAssetIdInput(
-					mockSystemApi,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: mockSystemApi,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -379,17 +381,17 @@ describe('checkAssetIds', () => {
 			const registry = new Registry(specName, {});
 			const currentRegistry = registry.currentRelayRegistry;
 			await expect(async () => {
-				await checkAssetIdInput(
-					parachainAssetsApi.api,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: parachainAssetsApi.api,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -415,17 +417,17 @@ describe('checkAssetIds', () => {
 			const currentRegistry = registry.currentRelayRegistry;
 
 			await expect(async () => {
-				await checkAssetIdInput(
-					parachainAssetsApi.api,
-					testInputs,
-					currentRegistry,
+				await checkAssetIdInput({
+					api: parachainAssetsApi.api,
+					assetIds: testInputs,
+					relayChainInfo: currentRegistry,
 					specName,
-					direction,
+					xcmDirection: direction,
 					registry,
-					2,
-					false,
-					false,
-				);
+					xcmCreator,
+					isForeignAssetsTransfer: false,
+					isLiquidTokenTransfer: false,
+				});
 			}).rejects.toThrow(errorMessage);
 		}
 	});
@@ -434,17 +436,17 @@ describe('checkAssetIds', () => {
 		const currentRegistry = registry.currentRelayRegistry;
 
 		await expect(async () => {
-			await checkAssetIdInput(
-				parachainAssetsApi.api,
-				['0x1234'],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToSystem,
+			await checkAssetIdInput({
+				api: parachainAssetsApi.api,
+				assetIds: ['0x1234'],
+				relayChainInfo: currentRegistry,
+				specName: 'moonriver',
+				xcmDirection: Direction.ParaToSystem,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).rejects.toThrow('(ParaToSystem) assetId 0x1234, is not a valid erc20 token.');
 	});
 	it('Should error when an invalid token is passed into a liquidTokenTransfer', async () => {
@@ -453,17 +455,17 @@ describe('checkAssetIds', () => {
 		const isLiquidTokenTransfer = true;
 
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['TEST'],
-				currentRegistry,
-				'westmint',
-				Direction.SystemToPara,
+			await checkAssetIdInput({
+				api: adjustedMockSystemApi,
+				assetIds: ['TEST'],
+				relayChainInfo: currentRegistry,
+				specName: 'westmint',
+				xcmDirection: Direction.SystemToPara,
 				registry,
-				2,
-				false,
+				xcmCreator,
+				isForeignAssetsTransfer: false,
 				isLiquidTokenTransfer,
-			);
+			});
 		}).rejects.toThrow('Liquid Tokens must be valid Integers');
 	});
 	it('Should error when a token does not exist in the registry or node', async () => {
@@ -472,17 +474,17 @@ describe('checkAssetIds', () => {
 		const isLiquidTokenTransfer = true;
 
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['999111'],
-				currentRegistry,
-				'westmint',
-				Direction.SystemToPara,
+			await checkAssetIdInput({
+				api: adjustedMockSystemApi,
+				assetIds: ['999111'],
+				relayChainInfo: currentRegistry,
+				specName: 'westmint',
+				xcmDirection: Direction.SystemToPara,
 				registry,
-				2,
-				false,
+				xcmCreator,
+				isForeignAssetsTransfer: false,
 				isLiquidTokenTransfer,
-			);
+			});
 		}).rejects.toThrow(
 			'No liquid token asset was detected. When setting the option "transferLiquidToken" to true a valid liquid token assetId must be present.',
 		);
@@ -494,17 +496,17 @@ describe('checkAssetIds', () => {
 
 		// eslint-disable-next-line @typescript-eslint/await-thenable
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['0'],
-				currentRegistry,
-				'westmint',
-				Direction.SystemToPara,
+			await checkAssetIdInput({
+				api: adjustedMockSystemApi,
+				assetIds: ['0'],
+				relayChainInfo: currentRegistry,
+				specName: 'westmint',
+				xcmDirection: Direction.SystemToPara,
 				registry,
-				2,
-				false,
+				xcmCreator,
+				isForeignAssetsTransfer: false,
 				isLiquidTokenTransfer,
-			);
+			});
 		}).not.toThrow();
 	});
 	it('Should not throw an error for ParaToRelay when its a valid', async () => {
@@ -512,59 +514,59 @@ describe('checkAssetIds', () => {
 		const currentRegistry = registry.currentRelayRegistry;
 		// eslint-disable-next-line @typescript-eslint/await-thenable
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['KSM'],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
+			await checkAssetIdInput({
+				api: adjustedMockMoonriverParachainApi,
+				assetIds: ['KSM'],
+				relayChainInfo: currentRegistry,
+				specName: 'moonriver',
+				xcmDirection: Direction.ParaToRelay,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).not.toThrow();
 		// eslint-disable-next-line @typescript-eslint/await-thenable
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['42259045809535163221576417993425387648'],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
+			await checkAssetIdInput({
+				api: adjustedMockMoonriverParachainApi,
+				assetIds: ['42259045809535163221576417993425387648'],
+				relayChainInfo: currentRegistry,
+				specName: 'moonriver',
+				xcmDirection: Direction.ParaToRelay,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).not.toThrow();
 		// eslint-disable-next-line @typescript-eslint/await-thenable
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				[''],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
+			await checkAssetIdInput({
+				api: adjustedMockMoonriverParachainApi,
+				assetIds: [''],
+				relayChainInfo: currentRegistry,
+				specName: 'moonriver',
+				xcmDirection: Direction.ParaToRelay,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).not.toThrow();
 		// eslint-disable-next-line @typescript-eslint/await-thenable
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				[],
-				currentRegistry,
-				'moonriver',
-				Direction.ParaToRelay,
+			await checkAssetIdInput({
+				api: adjustedMockMoonriverParachainApi,
+				assetIds: [],
+				relayChainInfo: currentRegistry,
+				specName: 'moonriver',
+				xcmDirection: Direction.ParaToRelay,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).not.toThrow();
 	});
 	it('Should error when an invalid assetId is inputted for ParaToRelay', async () => {
@@ -572,17 +574,17 @@ describe('checkAssetIds', () => {
 		const currentRegistry = registry.currentRelayRegistry;
 
 		await expect(async () => {
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['TEST'],
-				currentRegistry,
-				'crust-collator',
-				Direction.ParaToRelay,
+			await checkAssetIdInput({
+				api: adjustedMockMoonriverParachainApi,
+				assetIds: ['TEST'],
+				relayChainInfo: currentRegistry,
+				specName: 'crust-collator',
+				xcmDirection: Direction.ParaToRelay,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 		}).rejects.toThrow("The current input for assetId's does not meet our specifications for ParaToRelay transfers.");
 	});
 });
@@ -713,7 +715,7 @@ describe('checkAssetIdsAreOfSameAssetIdType', () => {
 	it('Should correctly error when an integer assetId and multilocation assetId are passed in together', () => {
 		const assetIds = ['1984', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+		const err = () => checkAssetIdsAreOfSameAssetIdType({ assetIds, xcmCreator });
 
 		expect(err).toThrow(
 			`Found both native asset with assetID 1984 and foreign asset with assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Native assets and foreign assets can't be transferred within the same call.`,
@@ -723,7 +725,7 @@ describe('checkAssetIdsAreOfSameAssetIdType', () => {
 	it('Should correctly error when a symbol assetId and multilocation assetId are passed in together', () => {
 		const assetIds = ['ksm', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+		const err = () => checkAssetIdsAreOfSameAssetIdType({ assetIds, xcmCreator });
 
 		expect(err).toThrow(
 			'Found both symbol ksm and multilocation assetId {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Asset Ids must be symbol and integer or multilocation exclusively.',
@@ -733,7 +735,7 @@ describe('checkAssetIdsAreOfSameAssetIdType', () => {
 	it('Should correctly error when the default relay asset value and multilocation assetId are passed in together', () => {
 		const assetIds = ['', '{"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}'];
 
-		const err = () => checkAssetIdsAreOfSameAssetIdType(assetIds);
+		const err = () => checkAssetIdsAreOfSameAssetIdType({ assetIds, xcmCreator });
 
 		expect(err).toThrow(
 			`Found both default relay native asset and foreign asset with assetId: {"parents": "1", "interior": {"X2": [{"Parachain": "2125"}, {"GeneralIndex": "0"}]}}. Relay native asset and foreign assets can't be transferred within the same call.`,
@@ -937,7 +939,14 @@ describe('checkParaAssets', () => {
 		let didNotError = true;
 
 		try {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+			await checkParaAssets({
+				api: adjustedMockMoonriverParachainApi,
+				assetId,
+				specName,
+				registry,
+				xcmDirection: Direction.ParaToSystem,
+				xcmCreator,
+			});
 		} catch (err) {
 			didNotError = false;
 		}
@@ -951,7 +960,14 @@ describe('checkParaAssets', () => {
 		let didNotError = true;
 
 		try {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+			await checkParaAssets({
+				api: adjustedMockMoonriverParachainApi,
+				assetId,
+				specName,
+				registry,
+				xcmDirection: Direction.ParaToSystem,
+				xcmCreator,
+			});
 		} catch (err) {
 			didNotError = false;
 		}
@@ -964,7 +980,14 @@ describe('checkParaAssets', () => {
 		const registry = new Registry(specName, {});
 
 		await expect(async () => {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+			await checkParaAssets({
+				api: adjustedMockMoonriverParachainApi,
+				assetId,
+				specName,
+				registry,
+				xcmDirection: Direction.ParaToSystem,
+				xcmCreator,
+			});
 		}).rejects.toThrow('(ParaToSystem) symbol assetId xcUSDfake not found for parachain moonriver');
 	});
 	it('Should correctly error when an invalid integer assetId is provided', async () => {
@@ -973,7 +996,14 @@ describe('checkParaAssets', () => {
 		const registry = new Registry(specName, {});
 
 		await expect(async () => {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+			await checkParaAssets({
+				api: adjustedMockMoonriverParachainApi,
+				assetId,
+				specName,
+				registry,
+				xcmDirection: Direction.ParaToSystem,
+				xcmCreator,
+			});
 		}).rejects.toThrow('(ParaToSystem) integer assetId 2096586909097964981698161 not found in moonriver');
 	});
 	it('Should correctly error when a valid assetId is not found in the xcAsset registry', async () => {
@@ -982,7 +1012,14 @@ describe('checkParaAssets', () => {
 		const registry = new Registry(specName, {});
 
 		await expect(async () => {
-			await checkParaAssets(adjustedMockMoonriverParachainApi, assetId, specName, registry, Direction.ParaToSystem);
+			await checkParaAssets({
+				api: adjustedMockMoonriverParachainApi,
+				assetId,
+				specName,
+				registry,
+				xcmDirection: Direction.ParaToSystem,
+				xcmCreator,
+			});
 		}).rejects.toThrow('unable to identify xcAsset with ID 999999999999999999999999999999999999999');
 	});
 
@@ -999,17 +1036,17 @@ describe('checkParaAssets', () => {
 				},
 			};
 
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['1984'],
-				chainInfo,
-				'statemine',
-				Direction.SystemToPara,
+			await checkAssetIdInput({
+				api: adjustedMockSystemApi,
+				assetIds: ['1984'],
+				relayChainInfo: chainInfo,
+				specName: 'statemine',
+				xcmDirection: Direction.SystemToPara,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 
 			expect(registry.cacheLookupAsset('1984')).toEqual('USDt');
 		});
@@ -1025,17 +1062,17 @@ describe('checkParaAssets', () => {
 				},
 			};
 
-			await checkAssetIdInput(
-				adjustedMockMoonriverParachainApi,
-				['xcUSDT'],
-				chainInfo,
-				'moonriver',
-				Direction.ParaToSystem,
+			await checkAssetIdInput({
+				api: adjustedMockMoonriverParachainApi,
+				assetIds: ['xcUSDT'],
+				relayChainInfo: chainInfo,
+				specName: 'moonriver',
+				xcmDirection: Direction.ParaToSystem,
 				registry,
-				2,
-				false,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: false,
+			});
 
 			expect(registry.cacheLookupAsset('xcUSDT')).toEqual('311091173110107856861649819128533077277');
 		});
@@ -1064,17 +1101,17 @@ describe('checkParaAssets', () => {
 				},
 			};
 
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}'],
-				chainInfo,
-				'statemine',
-				Direction.SystemToPara,
+			await checkAssetIdInput({
+				api: adjustedMockSystemApi,
+				assetIds: ['{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}'],
+				relayChainInfo: chainInfo,
+				specName: 'statemine',
+				xcmDirection: Direction.SystemToPara,
 				registry,
-				2,
-				true,
-				false,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: true,
+				isLiquidTokenTransfer: false,
+			});
 
 			expect(registry.cacheLookupForeignAsset('GDZ')).toEqual({
 				multiLocation: '{"parents":"1","interior":{"X2":[{"Parachain":"1103"},{"GeneralIndex":"0"}]}}',
@@ -1107,17 +1144,17 @@ describe('checkParaAssets', () => {
 				},
 			};
 
-			await checkAssetIdInput(
-				adjustedMockSystemApi,
-				['0'],
-				chainInfo,
-				'statemine',
-				Direction.SystemToPara,
+			await checkAssetIdInput({
+				api: adjustedMockSystemApi,
+				assetIds: ['0'],
+				relayChainInfo: chainInfo,
+				specName: 'statemine',
+				xcmDirection: Direction.SystemToPara,
 				registry,
-				2,
-				false,
-				true,
-			);
+				xcmCreator,
+				isForeignAssetsTransfer: false,
+				isLiquidTokenTransfer: true,
+			});
 
 			expect(registry.cacheLookupPoolAsset('0')).toEqual({
 				lpToken: '0',


### PR DESCRIPTION
This will make it easier to replace with `xcmCreator.resolveMultiLocation`
as we will have xcmCreator available everywhere it is needed.

This also should remove potential mismatches of XCM versions
caused by defaulting to a different version than what was desired.

A follow up MR will then replace `parseLocationStrToLocation ` with `xcmCreator.resolveMultiLocation`