### PR TITLE
test: Skip flaking integration test.

### DIFF
--- a/src/integrationTests/AssetsTransferApi.spec.ts
+++ b/src/integrationTests/AssetsTransferApi.spec.ts
@@ -2336,7 +2336,10 @@ describe('AssetTransferApi Integration Tests', () => {
 
 			expect(parseInt(destinationFeesInfo[0][1].xcmFee)).toBeGreaterThan(0);
 		}, 10000);
-		it('Correctly throws an error when the provided runtime does not support the xcmPaymentApi', async () => {
+		it.skip('Correctly throws an error when the provided runtime does not support the xcmPaymentApi', async () => {
+			// TODO: Either rewrite or remove this test.
+			// This test is too flaky and constantly failing.
+			// This would likely be better as a unit test (if not already covered in unit testing)
 			const dryRunResult = await systemAssetsApiV1016000.dryRunCall(sendersAddress, mockSubmittableExt, 'submittable');
 			expect(dryRunResult?.isOk).toBe(true);
 


### PR DESCRIPTION
It is constantly failing in CI and making us number to test failures which comes with risk of other issues slipping through.