### PR TITLE
refactor: transferAssetsUsingTypeAndThenCleanup

### DIFF
--- a/e2e-tests/astar.spec.ts
+++ b/e2e-tests/astar.spec.ts
@@ -178,7 +178,7 @@ describe('Polkadot Asset Hub <-> Astar', () => {
 				amount.sub(usdtXcmFee),
 				"Bob's final USDT balance is incorrect on Astar",
 			);
-		}, 60000);
+		}, 90000);
 	});
 	describe('Polkadot Asset Hub -> Astar', () => {
 		test.skip('USDT', async () => {

--- a/src/createXcmCalls/polkadotXcm/transferAssetsUsingTypeAndThen.ts
+++ b/src/createXcmCalls/polkadotXcm/transferAssetsUsingTypeAndThen.ts
@@ -3,14 +3,7 @@ import type { ISubmittableResult } from '@polkadot/types/types';
 
 import { ASSET_HUB_CHAIN_ID } from '../../consts.js';
 import { getTypeCreator } from '../../createXcmTypes/index.js';
-import {
-	FungibleAsset,
-	FungibleMultiAsset,
-	WildAsset,
-	XcmJunction,
-	XcmMultiLocation,
-	XcmVersionedAssetId,
-} from '../../createXcmTypes/types.js';
+import { FungibleAssetType, XcmJunction, XcmVersionedAssetId } from '../../createXcmTypes/types.js';
 import { assetIdIsLocation } from '../../createXcmTypes/util/assetIdIsLocation.js';
 import { createXcmOnDestBeneficiary } from '../../createXcmTypes/util/createXcmOnDestBeneficiary.js';
 import { createXcmOnDestination } from '../../createXcmTypes/util/createXcmOnDestination.js';
@@ -65,7 +58,7 @@ export const transferAssetsUsingTypeAndThen = async (
 	let feeAssetTransferType: AssetTransferType;
 
 	if (direction === Direction.ParaToEthereum) {
-		let erc20Location: WildAsset | undefined = undefined;
+		let erc20Location: FungibleAssetType | undefined = undefined;
 		let erc20Key: string | undefined = undefined;
 
 		// get erc20 Asset Location from assetIds
@@ -81,7 +74,7 @@ export const transferAssetsUsingTypeAndThen = async (
 			if (!assetIdLocationStr.toLowerCase().includes('ethereum')) {
 				continue;
 			}
-			let assetLocation = JSON.parse(assetIdLocationStr) as XcmMultiLocation;
+			let assetLocation = xcmCreator.resolveMultiLocation(assetIdLocationStr);
 
 			if ('v1' in assetLocation) {
 				assetLocation = xcmCreator.resolveMultiLocation(JSON.stringify(assetLocation.v1));
@@ -90,24 +83,13 @@ export const transferAssetsUsingTypeAndThen = async (
 			// parse registry xc assets erc20 v1 location
 			if ('X2' in assetLocation.interior && Array.isArray(assetLocation.interior.X2)) {
 				if ('AccountKey20' in assetLocation.interior.X2[1]) {
-					erc20Location =
-						xcmVersion === 3
-							? {
-									id: {
-										Concrete: {
-											parents: assetLocation.parents,
-											interior: assetLocation.interior,
-										} as XcmMultiLocation,
-									},
-									fun: 'Fungible',
-								}
-							: {
-									id: {
-										parents: assetLocation.parents,
-										interior: assetLocation.interior,
-									} as XcmMultiLocation,
-									fun: 'Fungible',
-								};
+					erc20Location = xcmCreator.fungibleAsset({
+						multiLocation: {
+							parents: assetLocation.parents,
+							interior: assetLocation.interior,
+						},
+						amount: 'Fungible',
+					});
 					const erc20KeyX2 = assetLocation.interior?.X2 as [XcmJunction, XcmJunction] | undefined;
 					if (erc20KeyX2 && 'AccountKey20' in erc20KeyX2[1]) {
 						erc20Key = (erc20KeyX2[1].AccountKey20 as { network?: string; key: string }).key;
@@ -123,42 +105,19 @@ export const transferAssetsUsingTypeAndThen = async (
 			);
 		}
 
-		const reanchoredERC20AccountLocation: FungibleMultiAsset | FungibleAsset =
-			xcmVersion === 3
-				? {
-						id: {
-							Concrete: {
-								parents: 0,
-								interior: {
-									X1: {
-										AccountKey20: {
-											key: erc20Key,
-										},
-									},
-								},
-							} as XcmMultiLocation,
+		const reanchoredERC20AccountLocation = xcmCreator.fungibleAsset({
+			multiLocation: {
+				parents: 0,
+				interior: {
+					X1: {
+						AccountKey20: {
+							key: erc20Key,
 						},
-						fun: {
-							Fungible: '1',
-						},
-					}
-				: {
-						id: {
-							parents: 0,
-							interior: {
-								X1: [
-									{
-										AccountKey20: {
-											key: erc20Key,
-										},
-									},
-								],
-							},
-						} as XcmMultiLocation,
-						fun: {
-							Fungible: '1',
-						},
-					};
+					},
+				},
+			},
+			amount: '1',
+		});
 
 		if (!sendersAddr || !erc20Location) {
 			throw new BaseError(

--- a/src/createXcmCalls/polkadotXcm/transferAssetsUsingTypeAndThen.ts
+++ b/src/createXcmCalls/polkadotXcm/transferAssetsUsingTypeAndThen.ts
@@ -1,6 +1,7 @@
 import type { SubmittableExtrinsic } from '@polkadot/api/submittable/types';
 import type { ISubmittableResult } from '@polkadot/types/types';
 
+import { ASSET_HUB_CHAIN_ID } from '../../consts.js';
 import { getTypeCreator } from '../../createXcmTypes/index.js';
 import {
 	FungibleAsset,
@@ -177,7 +178,7 @@ export const transferAssetsUsingTypeAndThen = async (
 		assetTransferType = {
 			DestinationReserve: 'null',
 		};
-		destChainId = '1000'; // Set AssetHub as first hop after constructing custom XCM
+		destChainId = ASSET_HUB_CHAIN_ID;
 	} else {
 		assetTransferType = resolveAssetTransferType(
 			assetTransferTypeStr,

--- a/src/createXcmTypes/types.ts
+++ b/src/createXcmTypes/types.ts
@@ -96,19 +96,6 @@ export type XcAssetsMultiLocation = {
 	[V in XcmVersionKey]: XcAssetsMultiLocationForVersion<V>;
 }[XcmVersionKey];
 
-// Wild Asset
-interface WildAssetV3 {
-	id: {
-		Concrete: XcmMultiLocation;
-	};
-	fun: string;
-}
-interface WildAssetV4 {
-	id: XcmMultiLocation;
-	fun: string;
-}
-export type WildAsset = WildAssetV3 | WildAssetV4;
-
 // XcmMultiAssets
 type XcmMultiAssetsVariant<V extends XcmVersionKey> = VersionedXcmType<V, AssetTypeForVersion<V>[]>;
 export type XcmMultiAssets = {


### PR DESCRIPTION
I noticed room for improvement while debugging unrelated issues.

Effectively lean more heavily on `xcmCreator` instead of casting and implementing xcmVersion specific logic elsewhere.