### PR TITLE
fix: Check assets individually in `claimAssets(...)`

### DIFF
--- a/src/AssetTransferApi.ts
+++ b/src/AssetTransferApi.ts
@@ -391,27 +391,23 @@ export class AssetTransferApi {
 		const declaredXcmVersion = xcmVersion === undefined ? safeXcmVersion : xcmVersion;
 		const xcmCreator = getXcmCreator(declaredXcmVersion);
 		const isLiquidTokenTransfer = isLiquidToken ? true : false;
-		const assetIdsContainLocations = this.checkContainsAssetLocations(assetIds);
 		const beneficiaryAddress = sanitizeAddress(beneficiary);
 
 		checkXcmVersion(declaredXcmVersion);
 		checkBaseInputOptions(opts, specName);
 		checkClaimAssetsInputs({ assets: assetIds, amounts, xcmCreator });
 
-		const ext = await claimAssets(
+		const ext = await claimAssets({
 			api,
 			registry,
 			specName,
 			assetIds,
 			amounts,
 			beneficiaryAddress,
-			declaredXcmVersion,
+			xcmVersion: declaredXcmVersion,
 			originChainId,
-			{
-				isForeignAssetsTransfer: assetIdsContainLocations,
-				isLiquidTokenTransfer,
-			},
-		);
+			isLiquidTokenTransfer,
+		});
 
 		return await this.constructFormat({
 			tx: ext,
@@ -1076,24 +1072,6 @@ export class AssetTransferApi {
 		}
 
 		return lookup[0].specName;
-	}
-
-	/**
-	 * Returns if `assetIds` contains asset location values
-	 *
-	 * @param assetIds string[]
-	 * @returns boolean
-	 */
-	private checkContainsAssetLocations(assetIds: string[]): boolean {
-		if (assetIds.length === 0) {
-			return false;
-		}
-
-		if (!assetIds[0].toLowerCase().includes('parents')) {
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/src/createXcmCalls/polkadotXcm/claimAssets.spec.ts
+++ b/src/createXcmCalls/polkadotXcm/claimAssets.spec.ts
@@ -13,70 +13,61 @@ describe('claimAssets', () => {
 		const xcmVersion = 4;
 		const beneficiaryAddress = '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b';
 
-		const ext = await claimAssets(
-			adjustedMockSystemApiV1016000,
+		const ext = await claimAssets({
+			api: adjustedMockSystemApiV1016000,
 			registry,
 			specName,
 			assetIds,
 			amounts,
 			beneficiaryAddress,
 			xcmVersion,
-			'1000',
-			{
-				isForeignAssetsTransfer: true,
-				isLiquidTokenTransfer: false,
-			},
-		);
+			originChainId: '1000',
+			isLiquidTokenTransfer: false,
+		});
 
 		expect(ext.toHex()).toEqual(
 			'0xd8041f0c04040102043205011f0002093d000400010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 		);
 	});
 	it('Should correctly construct an XCM V3 claimAssets call', async () => {
-		const assets = [`{"parents":"1","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`];
+		const assetIds = [`{"parents":"1","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`];
 		const amounts = ['1000000'];
 		const xcmVersion = 3;
 		const beneficiaryAddress = '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b';
 
-		const ext = await claimAssets(
-			adjustedMockSystemApiV1016000,
+		const ext = await claimAssets({
+			api: adjustedMockSystemApiV1016000,
 			registry,
 			specName,
-			assets,
+			assetIds,
 			amounts,
 			beneficiaryAddress,
 			xcmVersion,
-			'1000',
-			{
-				isForeignAssetsTransfer: true,
-				isLiquidTokenTransfer: false,
-			},
-		);
+			originChainId: '1000',
+			isLiquidTokenTransfer: false,
+		});
 
 		expect(ext.toHex()).toEqual(
 			'0xdc041f0c0304000102043205011f0002093d000300010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
 		);
 	});
 	it('Should correctly construct an XCM V2 claimAssets call', async () => {
-		const assets = [`{"parents":"1","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`];
+		const assetIds = [`{"parents":"1","interior":{"X2":[{"PalletInstance":"50"},{"GeneralIndex":"1984"}]}}`];
 		const amounts = ['1000000'];
 		const xcmVersion = 2;
 		const beneficiaryAddress = '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b';
 
-		const ext = await claimAssets(
-			adjustedMockSystemApiV1016000,
+		const ext = await claimAssets({
+			api: adjustedMockSystemApiV1016000,
 			registry,
 			specName,
-			assets,
+			assetIds,
 			amounts,
 			beneficiaryAddress,
 			xcmVersion,
-			'1000',
-			{
-				isForeignAssetsTransfer: true,
-				isLiquidTokenTransfer: false,
-			},
-		);
+			originChainId: '1000',
+			isLiquidTokenTransfer: false,
+		});
 
 		expect(ext.toHex()).toEqual(
 			'0xdc041f0c0104000102043205011f0002093d000100010100f5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b',
@@ -89,20 +80,17 @@ describe('claimAssets', () => {
 		const beneficiaryAddress = '0xf5d5714c084c112843aca74f8c498da06cc5a2d63153b825189baa51043b1f0b';
 
 		await expect(async () => {
-			await claimAssets(
-				adjustedMockSystemApi,
+			await claimAssets({
+				api: adjustedMockSystemApi,
 				registry,
 				specName,
 				assetIds,
 				amounts,
 				beneficiaryAddress,
 				xcmVersion,
-				'1000',
-				{
-					isForeignAssetsTransfer: true,
-					isLiquidTokenTransfer: false,
-				},
-			);
+				originChainId: '1000',
+				isLiquidTokenTransfer: false,
+			});
 		}).rejects.toThrow('Did not find claimAssets call from pallet polkadotXcm in the current runtime.');
 	});
 });

--- a/src/createXcmCalls/polkadotXcm/claimAssets.ts
+++ b/src/createXcmCalls/polkadotXcm/claimAssets.ts
@@ -7,7 +7,6 @@ import { createBeneficiary } from '../../createXcmTypes/util/createBeneficiary.j
 import { getXcmCreator } from '../../createXcmTypes/xcm/index.js';
 import { BaseError, BaseErrorsEnum } from '../../errors/index.js';
 import { Registry } from '../../registry/index.js';
-import { CreateXcmCallOpts } from '../types.js';
 import { establishXcmPallet } from '../util/establishXcmPallet.js';
 
 /**
@@ -19,18 +18,27 @@ import { establishXcmPallet } from '../util/establishXcmPallet.js';
  * @param xcmVersion number
  * @param beneficiaryAddress string
  */
-export const claimAssets = async (
-	api: ApiPromise,
-	registry: Registry,
-	specName: string,
-	assetIds: string[],
-	amounts: string[],
-	beneficiaryAddress: string,
-	xcmVersion: number,
-	originChainId: string,
-	opts: CreateXcmCallOpts,
-): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> => {
-	const { isForeignAssetsTransfer: assetIdsContainLocations, isLiquidTokenTransfer } = opts;
+export const claimAssets = async ({
+	api,
+	registry,
+	specName,
+	assetIds,
+	amounts,
+	beneficiaryAddress,
+	xcmVersion,
+	originChainId,
+	isLiquidTokenTransfer,
+}: {
+	api: ApiPromise;
+	registry: Registry;
+	specName: string;
+	assetIds: string[];
+	amounts: string[];
+	beneficiaryAddress: string;
+	xcmVersion: number;
+	originChainId: string;
+	isLiquidTokenTransfer: boolean;
+}): Promise<SubmittableExtrinsic<'promise', ISubmittableResult>> => {
 	const xcmCreator = getXcmCreator(xcmVersion);
 	const beneficiary = createBeneficiary(beneficiaryAddress, xcmCreator);
 
@@ -41,7 +49,6 @@ export const claimAssets = async (
 		amounts,
 		registry,
 		originChainId,
-		assetIdsContainLocations,
 		isLiquidTokenTransfer,
 		xcmCreator,
 	});

--- a/src/createXcmTypes/util/createAssetLocations.ts
+++ b/src/createXcmTypes/util/createAssetLocations.ts
@@ -16,7 +16,6 @@ export const createAssetLocations = async ({
 	amounts,
 	registry,
 	originChainId,
-	assetIdsContainLocations,
 	isLiquidTokenTransfer,
 	xcmCreator,
 }: {
@@ -26,7 +25,6 @@ export const createAssetLocations = async ({
 	amounts: string[];
 	registry: Registry;
 	originChainId: string;
-	assetIdsContainLocations: boolean;
 	isLiquidTokenTransfer: boolean;
 	xcmCreator: XcmCreator;
 }): Promise<XcmMultiAssets> => {
@@ -42,18 +40,20 @@ export const createAssetLocations = async ({
 		const isValidInt = validateNumber(assetId);
 		const isRelayNative = isRelayNativeAsset(registry, assetId);
 
-		if (!assetIdsContainLocations && !isRelayNative && !isValidInt) {
+		const isLocation = assetId.toLowerCase().includes('parents');
+
+		if (!isLocation && !isRelayNative && !isValidInt) {
 			assetId = await getAssetId({
 				api,
 				registry,
 				asset: assetId,
 				specName,
 				xcmCreator,
-				isForeignAssetsTransfer: assetIdsContainLocations,
+				isForeignAssetsTransfer: isLocation,
 			});
 		}
 
-		if (assetIdsContainLocations) {
+		if (isLocation) {
 			multiLocation = xcmCreator.resolveMultiLocation(assetId);
 		} else {
 			const parents = isRelayNative && !isRelayChain ? 1 : 0;
@@ -65,7 +65,7 @@ export const createAssetLocations = async ({
 					api,
 					assetId,
 					isLiquidToken: isLiquidTokenTransfer,
-					isForeignAsset: assetIdsContainLocations,
+					isForeignAsset: isLocation,
 					xcmCreator,
 				});
 				interior = {


### PR DESCRIPTION
This is in place of treating all assets as the same if a single one contains a multilocation.

Also used this as an opportunity to move `claimAssets()` to object params as well as remove `CreateXcmCallOpts` parameter from `claimAssets()` as it was out of place.