### PR TITLE
feat: Add runtime validation for XcmMultiLocation

### DIFF
--- a/src/createXcmTypes/xcm/common.ts
+++ b/src/createXcmTypes/xcm/common.ts
@@ -1,6 +1,7 @@
 import { AnyJson } from '@polkadot/types-codec/types';
 import { isEthereumAddress } from '@polkadot/util-crypto';
 
+import { SUPPORTED_XCM_VERSIONS } from '../../consts.js';
 import { BaseError, BaseErrorsEnum } from '../../errors/BaseError.js';
 import { sanitizeKeys } from '../../util/sanitizeKeys.js';
 import { XcmJunction, XcmMultiLocation } from '../types.js';
@@ -50,6 +51,7 @@ export function parseMultiLocation(input: AnyJson, xcmVersion: number): XcmMulti
 	let multiLocation: XcmMultiLocation;
 	try {
 		multiLocation = JSON.parse(location) as XcmMultiLocation;
+		validateXcmMultiLocation(multiLocation);
 	} catch {
 		throw new BaseError(`Unable to parse ${multiLocationStr} as a valid location`, BaseErrorsEnum.InvalidInput);
 	}
@@ -63,4 +65,44 @@ export function parseMultiLocation(input: AnyJson, xcmVersion: number): XcmMulti
 	// We can do that instead in resolveMultiLocation
 
 	return sanitizeKeys(multiLocation);
+}
+
+/**
+ * Return true if the input is a XcmMultiLocation or a MultiLocation variant.
+ *
+ * This is not exhaustive and is a bit messy.
+ * The output may not actually be a XcmMultiLocation but
+ * a MultiLocationVariant<J> instead. This dates back to
+ * some historical string parsing.
+ *
+ * Ideally this is eventually removed altogether with the
+ * removal of passing stringified multilocations around
+ * to be interpretted.
+ */
+function validateXcmMultiLocation(obj: AnyJson): obj is XcmMultiLocation {
+	const requiredKeys = ['parents', 'interior'];
+	// We continue to support parsing of older version so we can't rely purely on SUPPORTED_XCM_VERSIONS
+	const maxVersion = Math.max(...SUPPORTED_XCM_VERSIONS);
+	const versions = Array.from({ length: maxVersion }, (_, i) => i);
+	const versionLabels = versions.flatMap((v) => [`V${v}`, `v${v}`]);
+
+	if (typeof obj === 'object' && obj !== null) {
+		const lowerCaseKeys = Object.keys(obj).map((k) => k.toLowerCase());
+		const objRecord = obj as { [key: string]: AnyJson };
+
+		// Check if XcmMultiVersion: wrapped in V{xcmVersion}
+		const versionKeys = versionLabels.filter((key) => key in objRecord);
+		if (versionKeys.length === 1) {
+			const matchedKey = versionKeys[0];
+			return validateXcmMultiLocation(objRecord[matchedKey]);
+		} else if (versionKeys.length > 1) {
+			throw new BaseError(`Unable to parse ${JSON.stringify(obj)} as a valid location`, BaseErrorsEnum.InvalidInput);
+		}
+
+		// Check if MultiLocationVariant
+		if (requiredKeys.every((key) => lowerCaseKeys.includes(key))) {
+			return true;
+		}
+	}
+	throw new BaseError(`Unable to parse ${JSON.stringify(obj)} as a valid location`, BaseErrorsEnum.InvalidInput);
 }


### PR DESCRIPTION
Allow throwing error on invalid input while parsing multilocations.

Motivation: I'm trying to debug some issues cause from attempting to use assetIds as MultiLocations, leading to unexpected behavior. This will correctly catch these.

Alternatively we could use something like `zod` but I was trying to keep this lightweight. If we need any future runtime validation, that is the route that we should go.