### PR TITLE
feat: Verify originChainId matches the chain id looked up from specName

### DIFF
--- a/src/testHelpers/adjustedMockBifrostParachainApi.ts
+++ b/src/testHelpers/adjustedMockBifrostParachainApi.ts
@@ -63,6 +63,9 @@ export const adjustedMockBifrostParachainApi = {
 		polkadotXcm: {
 			safeXcmVersion: getSystemSafeXcmVersion,
 		},
+		parachainInfo: {
+			parachainId: () => Promise.resolve('2001'),
+		},
 	},
 	tx: Object.assign(
 		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {

--- a/src/testHelpers/adjustedMockHydrationParachainApi.ts
+++ b/src/testHelpers/adjustedMockHydrationParachainApi.ts
@@ -63,6 +63,9 @@ export const adjustedmockHydrationParachainApi = {
 		polkadotXcm: {
 			safeXcmVersion: getSystemSafeXcmVersion,
 		},
+		parachainInfo: {
+			parachainId: () => Promise.resolve('2034'),
+		},
 	},
 	tx: Object.assign(
 		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {

--- a/src/testHelpers/adjustedMockMoonriverParachainApi.ts
+++ b/src/testHelpers/adjustedMockMoonriverParachainApi.ts
@@ -567,6 +567,9 @@ export const adjustedMockMoonriverParachainApi = {
 			}),
 			metadata: metadata,
 		},
+		parachainInfo: {
+			parachainId: () => Promise.resolve('2023'),
+		},
 	},
 	tx: Object.assign(
 		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {

--- a/src/testHelpers/adjustedMockSystemApiV1004000.ts
+++ b/src/testHelpers/adjustedMockSystemApiV1004000.ts
@@ -557,6 +557,9 @@ export const adjustedMockSystemApi = {
 				},
 			}),
 		},
+		parachainInfo: {
+			parachainId: () => Promise.resolve('1000'),
+		},
 	},
 	tx: Object.assign(
 		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {

--- a/src/testHelpers/adjustedMockSystemApiV1016000.ts
+++ b/src/testHelpers/adjustedMockSystemApiV1016000.ts
@@ -635,6 +635,9 @@ export const adjustedMockSystemApiV1016000 = {
 				},
 			}),
 		},
+		parachainInfo: {
+			parachainId: () => Promise.resolve('1000'),
+		},
 	},
 	tx: Object.assign(
 		(_extrinsic: Call | Extrinsic | Uint8Array | string) => {


### PR DESCRIPTION
Resolves #625 

Verify that the `originChainId` matches the parachain id of the supplied API, if not, throw an error. This is meant to catch human error where the wrong spec name is supplied which can lead to hard to debug issues.

## Testing

Testing of these changes is covered via the existing [integration tests](https://github.com/paritytech/asset-transfer-api/actions/runs/16882167519/job/47820514240?pr=647#step:7:1) and [examples](https://github.com/paritytech/asset-transfer-api/actions/runs/16882167519/job/47820514229?pr=647#step:7:27) which call `createTransferTransaction`. The unit tests are less useful here as the API responses have been mocked. 