### PR TITLE
docs: Update README with a deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+⚠️**Deprecated**⚠️: `asset-transfer-api` has been deprecated and is no longer actively maintained.
+
+Please use [✨ParaSpell✨](https://paraspell.github.io/docs/) instead.
+
+Additional information can be found in [this GitHub issue](https://github.com/paritytech/asset-transfer-api/issues/652).
+
 <br /><br />
 
 <div align="center">


### PR DESCRIPTION
Related to https://github.com/paritytech/asset-transfer-api/issues/652.

Staging as a draft for now so this is ready if/when `asset-transfer-api` is deprecated.

[Quick link to rendered README](https://github.com/paritytech/asset-transfer-api/tree/docs/deprecation)